### PR TITLE
fix: forecasted reminder transfers had reverse pretty_total logic

### DIFF
--- a/backend/accounts/api/views/forecast.py
+++ b/backend/accounts/api/views/forecast.py
@@ -92,12 +92,12 @@ def get_forecast(
         targetobject_out = TargetObject(value=0)
         fillobject_out = FillObject(
             target=targetobject_out,
-            above="rgb(236 , 253, 245)",
-            below="rgb(248, 121, 121)",
+            above="rgb(76, 175, 80)",
+            below="rgb(255, 52, 7)",
         )
         datasets_out = DatasetObject(
-            borderColor="#06966A",
-            backgroundColor="#06966A",
+            borderColor="#212121",
+            backgroundColor="#212121",
             tension=0.1,
             data=data,
             fill=fillobject_out,

--- a/backend/transactions/api/dependencies/get_reminder_transaction_list.py
+++ b/backend/transactions/api/dependencies/get_reminder_transaction_list.py
@@ -72,6 +72,9 @@ def get_reminder_transaction_list(
             pretty_account = (
                 source_account_name + " => " + destination_account_name
             )
+            print(
+                f"reminder_account_id:{reminder.reminder_source_account.id} | account:{account}"
+            )
             if reminder.reminder_source_account.id == account:
                 pretty_total = -abs(reminder.amount)
             else:

--- a/backend/transactions/api/dependencies/get_transactions_by_account.py
+++ b/backend/transactions/api/dependencies/get_transactions_by_account.py
@@ -79,7 +79,7 @@ def get_transactions_by_account(
     # Get reminder transactions
     if not cleared_only:
         reminder_transactions_list = get_reminder_transaction_list(
-            end_date, account, forecast
+            end_date, account_id, forecast
         )
 
     # Combine pending and reminder transactions


### PR DESCRIPTION
### Description

Forecasted reminder transactions of type transfer were incorrectly reporting the pretty_total, throwing off the forecast.

Fixes # (issue)

---

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

---

### Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
