### PR TITLE
feat: add session-based auth with group permissions (Full Access / Readonly)

### DIFF
--- a/backend/accounts/api/views/account.py
+++ b/backend/accounts/api/views/account.py
@@ -19,6 +19,7 @@ from accounts.services import (
 )
 from accounts.mappers import domain_account_to_schema
 import logging
+from administration.api.dependencies.auth import FullAccessAuth
 
 api_logger = logging.getLogger("api")
 db_logger = logging.getLogger("db")
@@ -29,7 +30,7 @@ task_logger = logging.getLogger("task")
 account_router = Router(tags=["Accounts"])
 
 
-@account_router.post("/create")
+@account_router.post("/create", auth=FullAccessAuth())
 def create_account(request, payload: AccountIn):
     """
     The function `create_account` creates an account
@@ -128,7 +129,7 @@ def list_accounts(request, query: AccountQuery = Query(...)):
         raise HttpError(500, f"Record retrieval error : {str(e)}")
 
 
-@account_router.patch("/update/{account_id}")
+@account_router.patch("/update/{account_id}", auth=FullAccessAuth())
 def update_account(request, account_id: int, payload: AccountUpdate):
     """
     The function `update_account` updates the account specified by id,
@@ -188,7 +189,7 @@ def update_account(request, account_id: int, payload: AccountUpdate):
         raise HttpError(500, f"Record update error: {str(e)}")
 
 
-@account_router.delete("/delete/{account_id}")
+@account_router.delete("/delete/{account_id}", auth=FullAccessAuth())
 def delete_account(request, account_id: int):
     """
     The function `delete_account` deletes the account specified by id,

--- a/backend/accounts/api/views/account_type.py
+++ b/backend/accounts/api/views/account_type.py
@@ -7,6 +7,7 @@ from django.shortcuts import get_object_or_404
 from typing import List
 from django.http import Http404
 import logging
+from administration.api.dependencies.auth import FullAccessAuth
 
 api_logger = logging.getLogger("api")
 db_logger = logging.getLogger("db")
@@ -16,7 +17,7 @@ task_logger = logging.getLogger("task")
 account_type_router = Router(tags=["Account Types"])
 
 
-@account_type_router.post("/create")
+@account_type_router.post("/create", auth=FullAccessAuth())
 def create_account_type(request, payload: AccountTypeIn):
     """
     The function `create_account_type` creates an account type
@@ -108,7 +109,7 @@ def list_account_types(request):
         raise HttpError(500, "Record retrieval error")
 
 
-@account_type_router.put("/update/{accounttype_id}")
+@account_type_router.put("/update/{accounttype_id}", auth=FullAccessAuth())
 def update_account_type(request, accounttype_id: int, payload: AccountTypeIn):
     """
     The function `update_account_type` updates the account type specified by id.
@@ -155,7 +156,7 @@ def update_account_type(request, accounttype_id: int, payload: AccountTypeIn):
         raise HttpError(500, "Record update error")
 
 
-@account_type_router.delete("/delete/{accounttype_id}")
+@account_type_router.delete("/delete/{accounttype_id}", auth=FullAccessAuth())
 def delete_account_type(request, accounttype_id: int):
     """
     The function `delete_account_type` deletes the account type specified by id.

--- a/backend/accounts/api/views/bank.py
+++ b/backend/accounts/api/views/bank.py
@@ -7,6 +7,7 @@ from django.shortcuts import get_object_or_404
 from typing import List
 import logging
 from django.http import Http404
+from administration.api.dependencies.auth import FullAccessAuth
 
 api_logger = logging.getLogger("api")
 db_logger = logging.getLogger("db")
@@ -16,7 +17,7 @@ task_logger = logging.getLogger("task")
 bank_router = Router(tags=["Banks"])
 
 
-@bank_router.post("/create")
+@bank_router.post("/create", auth=FullAccessAuth())
 def create_bank(request, payload: BankIn):
     """
     The function `create_bank` creates a bank
@@ -55,7 +56,7 @@ def create_bank(request, payload: BankIn):
         raise HttpError(500, "Record creation error")
 
 
-@bank_router.put("/update/{bank_id}")
+@bank_router.put("/update/{bank_id}", auth=FullAccessAuth())
 def update_bank(request, bank_id: int, payload: BankIn):
     """
     The function `update_bank` updates the bank specified by id.
@@ -153,7 +154,7 @@ def list_banks(request):
         raise HttpError(500, "Record retrieval error")
 
 
-@bank_router.delete("/delete/{bank_id}")
+@bank_router.delete("/delete/{bank_id}", auth=FullAccessAuth())
 def delete_bank(request, bank_id: int):
     """
     The function `delete_bank` deletes the bank specified by id.

--- a/backend/administration/api/dependencies/auth.py
+++ b/backend/administration/api/dependencies/auth.py
@@ -1,12 +1,22 @@
-from ninja.security import HttpBearer
-from decouple import config
-from django.conf import settings
+from ninja.security import SessionAuth as NinjaSessionAuth
+from ninja.errors import HttpError
 
 
-class GlobalAuth(HttpBearer):
+class SessionAuth(NinjaSessionAuth):
+    """Requires an authenticated Django session."""
+
     def authenticate(self, request, token):
-        api_key = getattr(settings, "VITE_API_KEY", None) or config(
-            "VITE_API_KEY", default=None
-        )
-        if token == api_key:
-            return token
+        if request.user.is_authenticated:
+            return request.user
+        return None
+
+
+class FullAccessAuth(NinjaSessionAuth):
+    """Requires an authenticated session AND membership in the Full Access group."""
+
+    def authenticate(self, request, token):
+        if not request.user.is_authenticated:
+            return None
+        if request.user.groups.filter(name="Full Access").exists():
+            return request.user
+        raise HttpError(403, "Read-only access: this action is not permitted")

--- a/backend/administration/api/routers/auth.py
+++ b/backend/administration/api/routers/auth.py
@@ -1,0 +1,5 @@
+from ninja import Router
+from administration.api.views.auth import auth_router as router
+
+auth_router = Router()
+auth_router.add_router("", router)

--- a/backend/administration/api/views/auth.py
+++ b/backend/administration/api/views/auth.py
@@ -1,0 +1,55 @@
+from ninja import Router, Schema
+from ninja.errors import HttpError
+from django.contrib.auth import authenticate, login, logout
+from administration.api.dependencies.auth import SessionAuth
+import logging
+
+api_logger = logging.getLogger("api")
+error_logger = logging.getLogger("error")
+
+auth_router = Router(tags=["Auth"])
+
+
+class LoginIn(Schema):
+    username: str
+    password: str
+
+
+class UserOut(Schema):
+    id: int
+    username: str
+    group: str
+
+
+def _user_group(user) -> str:
+    if user.groups.filter(name="Full Access").exists():
+        return "full_access"
+    if user.groups.filter(name="Readonly").exists():
+        return "readonly"
+    return "readonly"
+
+
+@auth_router.post("/login", auth=None)
+def auth_login(request, payload: LoginIn):
+    user = authenticate(request, username=payload.username, password=payload.password)
+    if user is None:
+        raise HttpError(401, "Invalid credentials")
+    login(request, user)
+    api_logger.info(f"User logged in: {user.username}")
+    return UserOut(id=user.id, username=user.username, group=_user_group(user))
+
+
+@auth_router.post("/logout", auth=SessionAuth())
+def auth_logout(request):
+    api_logger.info(f"User logged out: {request.user.username}")
+    logout(request)
+    return {"success": True}
+
+
+@auth_router.get("/me", response=UserOut, auth=SessionAuth())
+def auth_me(request):
+    return UserOut(
+        id=request.user.id,
+        username=request.user.username,
+        group=_user_group(request.user),
+    )

--- a/backend/administration/api/views/health.py
+++ b/backend/administration/api/views/health.py
@@ -3,7 +3,7 @@ from ninja import Router
 health_router = Router(tags=["Health"])
 
 
-@health_router.get("/")
+@health_router.get("/", auth=None)
 def health_check(request):
     """
     The function `health_check` returns ok if backend is ready.

--- a/backend/administration/api/views/message.py
+++ b/backend/administration/api/views/message.py
@@ -11,6 +11,7 @@ from administration.services import get_message_list
 from django.shortcuts import get_object_or_404
 from django.http import Http404
 import logging
+from administration.api.dependencies.auth import FullAccessAuth
 
 api_logger = logging.getLogger("api")
 db_logger = logging.getLogger("db")
@@ -20,7 +21,7 @@ task_logger = logging.getLogger("task")
 message_router = Router(tags=["Messages"])
 
 
-@message_router.post("/create")
+@message_router.post("/create", auth=FullAccessAuth())
 def create_message(request, payload: MessageIn):
     """
     The function `create_transaction_detail` creates a transaction detail
@@ -44,7 +45,7 @@ def create_message(request, payload: MessageIn):
         raise HttpError(500, "Record creation error")
 
 
-@message_router.put("/update/{message_id}")
+@message_router.put("/update/{message_id}", auth=FullAccessAuth())
 def update_message(request, message_id: int, payload: MessageIn):
     """
     The function `update_message` updates the message specified by id.
@@ -78,7 +79,7 @@ def update_message(request, message_id: int, payload: MessageIn):
         raise HttpError(500, "Record update error")
 
 
-@message_router.patch("/readall/{message_id}")
+@message_router.patch("/readall/{message_id}", auth=FullAccessAuth())
 def update_messages(request, message_id: int, payload: AllMessage):
     """
     The function `update_messages` marks all messages as read.
@@ -135,7 +136,7 @@ def get_message(request, message_id: int):
         raise HttpError(500, "Record retrieval error")
 
 
-@message_router.delete("/delete/{message_id}")
+@message_router.delete("/delete/{message_id}", auth=FullAccessAuth())
 def delete_message(request, message_id: int):
     """
     The function `delete_message` deletes the message specified by id.
@@ -165,7 +166,7 @@ def delete_message(request, message_id: int):
         raise HttpError(500, "Record retrieval error")
 
 
-@message_router.delete("/deleteall/{message_id}")
+@message_router.delete("/deleteall/{message_id}", auth=FullAccessAuth())
 def delete_messages(request, message_id: int):
     """
     The function `delete_messages` deletes all messages.

--- a/backend/administration/api/views/option.py
+++ b/backend/administration/api/views/option.py
@@ -7,6 +7,7 @@ from django.http import Http404
 from typing import List
 from utils.apply_patch import apply_patch
 import logging
+from administration.api.dependencies.auth import FullAccessAuth
 
 api_logger = logging.getLogger("api")
 db_logger = logging.getLogger("db")
@@ -16,7 +17,7 @@ task_logger = logging.getLogger("task")
 option_router = Router(tags=["Options"])
 
 
-@option_router.patch("/update/{option_id}")
+@option_router.patch("/update/{option_id}", auth=FullAccessAuth())
 def update_option(request, option_id: int, payload: OptionIn):
     """
     The function `update_option` updates the option specified by id,
@@ -103,7 +104,7 @@ def list_options(request):
         raise HttpError(500, "Record retrieval error")
 
 
-@option_router.delete("/delete/{option_id}")
+@option_router.delete("/delete/{option_id}", auth=FullAccessAuth())
 def delete_option(request, option_id: int):
     """
     The function `delete_option` deletes the option specified by id.

--- a/backend/administration/api/views/payee.py
+++ b/backend/administration/api/views/payee.py
@@ -7,6 +7,7 @@ from django.shortcuts import get_object_or_404
 from django.http import Http404
 from typing import List
 import logging
+from administration.api.dependencies.auth import FullAccessAuth
 
 api_logger = logging.getLogger("api")
 db_logger = logging.getLogger("db")
@@ -16,7 +17,7 @@ task_logger = logging.getLogger("task")
 payee_router = Router(tags=["Payees"])
 
 
-@payee_router.post("/create")
+@payee_router.post("/create", auth=FullAccessAuth())
 def create_payee(request, payload: PayeeIn):
     """
     The function `create_payee` creates a payee
@@ -55,7 +56,7 @@ def create_payee(request, payload: PayeeIn):
         raise HttpError(500, "Record creation error")
 
 
-@payee_router.put("/update/{payee_id}")
+@payee_router.put("/update/{payee_id}", auth=FullAccessAuth())
 def update_payee(request, payee_id: int, payload: PayeeIn):
     """
     The function `update_payee` updates the payee specified by id.
@@ -155,7 +156,7 @@ def list_payees(request):
         raise HttpError(500, "Record retrieval error")
 
 
-@payee_router.delete("/delete/{payee_id}")
+@payee_router.delete("/delete/{payee_id}", auth=FullAccessAuth())
 def delete_payee(request, payee_id: int):
     """
     The function `delete_payee` deletes the payee specified by id.

--- a/backend/administration/migrations/0017_create_auth_groups.py
+++ b/backend/administration/migrations/0017_create_auth_groups.py
@@ -1,0 +1,23 @@
+from django.db import migrations
+
+
+def create_groups(apps, schema_editor):
+    Group = apps.get_model("auth", "Group")
+    Group.objects.get_or_create(name="Full Access")
+    Group.objects.get_or_create(name="Readonly")
+
+
+def delete_groups(apps, schema_editor):
+    Group = apps.get_model("auth", "Group")
+    Group.objects.filter(name__in=["Full Access", "Readonly"]).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("administration", "0016_alter_descriptionhistory_description_pretty"),
+    ]
+
+    operations = [
+        migrations.RunPython(create_groups, reverse_code=delete_groups),
+    ]

--- a/backend/administration/tests/api/test_auth_api.py
+++ b/backend/administration/tests/api/test_auth_api.py
@@ -1,0 +1,141 @@
+import pytest
+from unittest.mock import patch
+
+
+# ---------------------------------------------------------------------------
+# Login
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+@pytest.mark.api
+def test_login_success(api_client, full_access_user):
+    with patch("administration.api.views.auth.authenticate", return_value=full_access_user), \
+         patch("administration.api.views.auth.login"):
+        response = api_client.post(
+            "/auth/login",
+            json={"username": "test_full_access", "password": "testpass"},
+        )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["username"] == "test_full_access"
+    assert data["group"] == "full_access"
+
+
+@pytest.mark.django_db
+@pytest.mark.api
+def test_login_readonly_user_returns_readonly_group(api_client, readonly_user):
+    with patch("administration.api.views.auth.authenticate", return_value=readonly_user), \
+         patch("administration.api.views.auth.login"):
+        response = api_client.post(
+            "/auth/login",
+            json={"username": "test_readonly", "password": "testpass"},
+        )
+    assert response.status_code == 200
+    assert response.json()["group"] == "readonly"
+
+
+@pytest.mark.django_db
+@pytest.mark.api
+def test_login_invalid_credentials(api_client):
+    with patch("administration.api.views.auth.authenticate", return_value=None):
+        response = api_client.post(
+            "/auth/login",
+            json={"username": "nobody", "password": "wrong"},
+        )
+    assert response.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# /me
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+@pytest.mark.api
+def test_me_returns_full_access_user(api_client, full_access_user):
+    with patch(
+        "administration.api.dependencies.auth.SessionAuth.authenticate",
+        return_value=full_access_user,
+    ):
+        response = api_client.get("/auth/me", user=full_access_user)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["username"] == "test_full_access"
+    assert data["group"] == "full_access"
+
+
+@pytest.mark.django_db
+@pytest.mark.api
+def test_me_returns_readonly_group(api_client, readonly_user):
+    with patch(
+        "administration.api.dependencies.auth.SessionAuth.authenticate",
+        return_value=readonly_user,
+    ):
+        response = api_client.get("/auth/me", user=readonly_user)
+    assert response.status_code == 200
+    assert response.json()["group"] == "readonly"
+
+
+@pytest.mark.django_db
+@pytest.mark.api
+def test_me_unauthenticated(api_client):
+    with patch(
+        "administration.api.dependencies.auth.SessionAuth.authenticate",
+        return_value=None,
+    ):
+        response = api_client.get("/auth/me")
+    assert response.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Logout
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+@pytest.mark.api
+def test_logout_success(api_client, full_access_user):
+    with patch("administration.api.views.auth.logout") as mock_logout, \
+         patch(
+             "administration.api.dependencies.auth.SessionAuth.authenticate",
+             return_value=full_access_user,
+         ):
+        response = api_client.post("/auth/logout", user=full_access_user)
+    assert response.status_code == 200
+    assert response.json()["success"] is True
+    mock_logout.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Permission enforcement
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+@pytest.mark.api
+def test_readonly_user_blocked_from_mutation(api_client, readonly_user):
+    """FullAccessAuth should return 403 for readonly users."""
+    from ninja.errors import HttpError
+
+    with patch(
+        "administration.api.dependencies.auth.FullAccessAuth.authenticate",
+        side_effect=HttpError(403, "Read-only access: this action is not permitted"),
+    ):
+        response = api_client.post(
+            "/transactions/create",
+            json={},
+        )
+    assert response.status_code == 403
+
+
+@pytest.mark.django_db
+@pytest.mark.api
+def test_unauthenticated_blocked_from_read(api_client):
+    """SessionAuth should return 401 for unauthenticated requests."""
+    with patch(
+        "administration.api.dependencies.auth.SessionAuth.authenticate",
+        return_value=None,
+    ):
+        response = api_client.get("/transactions/list?view_type=2")
+    assert response.status_code == 401

--- a/backend/administration/tests/api/test_health_api.py
+++ b/backend/administration/tests/api/test_health_api.py
@@ -19,7 +19,8 @@ def test_health_check(api_client):
 @pytest.mark.django_db
 @pytest.mark.api
 def test_health_check_no_auth(api_client):
-    # The global auth applies to all routes — no auth header should return 401
+    # Health endpoint is public — no auth required
     response = api_client.get("/administration/health/")
 
-    assert response.status_code == 401
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"

--- a/backend/backend/api.py
+++ b/backend/backend/api.py
@@ -1,6 +1,7 @@
 from ninja import NinjaAPI
-from administration.api.dependencies.auth import GlobalAuth
+from administration.api.dependencies.auth import SessionAuth
 from administration.api.dependencies.version import get_version
+from administration.api.routers.auth import auth_router
 
 # Import routers from apps
 from accounts.api.routers.account_type import account_type_router
@@ -41,7 +42,7 @@ from planning.api.routers.budget import budget_router
 from planning.api.routers.retirement import retirement_router
 from administration.api.routers.health import health_router
 
-api = NinjaAPI(auth=GlobalAuth())
+api = NinjaAPI(auth=SessionAuth(), csrf=False)
 api.title = "LenoreFin API"
 api.version = get_version()
 api.description = "API documentation for LenoreFin"
@@ -80,3 +81,4 @@ api.add_router("/planning/graph", planning_graph_router)
 api.add_router("/planning/budget", budget_router)
 api.add_router("/planning/retirement", retirement_router)
 api.add_router("/administration/health", health_router)
+api.add_router("/auth", auth_router)

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -15,8 +15,11 @@ from reminders.models import Reminder, Repeat
 from ninja.testing import TestClient
 from backend.api import api
 from django.utils import timezone
+from django.contrib.auth.models import User, Group
 import pytz
 import os
+
+
 
 
 @pytest.fixture(autouse=True)
@@ -38,9 +41,51 @@ def current_date():
     return today_tz
 
 
+@pytest.fixture
+def full_access_user(db):
+    group, _ = Group.objects.get_or_create(name="Full Access")
+    user, _ = User.objects.get_or_create(username="test_full_access")
+    user.set_password("testpass")
+    user.save()
+    user.groups.set([group])
+    return user
+
+
+@pytest.fixture
+def readonly_user(db):
+    group, _ = Group.objects.get_or_create(name="Readonly")
+    user, _ = User.objects.get_or_create(username="test_readonly")
+    user.set_password("testpass")
+    user.save()
+    user.groups.set([group])
+    return user
+
+
 @pytest.fixture(scope="session")
 def api_client():
     return TestClient(api)
+
+
+@pytest.fixture(autouse=True)
+def patch_auth_as_full_access():
+    """Default all API test requests to an authenticated full-access user.
+
+    Tests that need to verify 401/403 behaviour should override this via
+    an explicit patch on administration.api.dependencies.auth.
+    """
+    from unittest.mock import Mock
+    full_access_mock = Mock()
+    full_access_mock.is_authenticated = True
+    full_access_mock.groups.filter.return_value.exists.return_value = True
+
+    with patch(
+        "administration.api.dependencies.auth.SessionAuth.authenticate",
+        return_value=full_access_mock,
+    ), patch(
+        "administration.api.dependencies.auth.FullAccessAuth.authenticate",
+        return_value=full_access_mock,
+    ):
+        yield
 
 
 @pytest.fixture

--- a/backend/imports/api/views/import_file.py
+++ b/backend/imports/api/views/import_file.py
@@ -4,6 +4,7 @@ from ninja.errors import HttpError
 from imports.api.schemas.import_file import MappingDefinition
 from imports.services import process_file_import
 import logging
+from administration.api.dependencies.auth import FullAccessAuth
 
 api_logger = logging.getLogger("api")
 error_logger = logging.getLogger("error")
@@ -12,7 +13,7 @@ task_logger = logging.getLogger("task")
 import_file_router = Router(tags=["File Imports"])
 
 
-@import_file_router.post("/create")
+@import_file_router.post("/create", auth=FullAccessAuth())
 def import_file(
     request,
     payload: MappingDefinition,

--- a/backend/planning/api/views/budget.py
+++ b/backend/planning/api/views/budget.py
@@ -17,6 +17,7 @@ from transactions.api.dependencies.get_transactions_by_tag import (
     get_transactions_by_tag,
 )
 import logging
+from administration.api.dependencies.auth import FullAccessAuth
 
 api_logger = logging.getLogger("api")
 db_logger = logging.getLogger("db")
@@ -26,7 +27,7 @@ task_logger = logging.getLogger("task")
 budget_router = Router(tags=["Budgets"])
 
 
-@budget_router.post("/create")
+@budget_router.post("/create", auth=FullAccessAuth())
 def create_budget(request, payload: BudgetIn):
     """
     The function `create_budget` creates a budget
@@ -63,7 +64,7 @@ def create_budget(request, payload: BudgetIn):
         raise HttpError(500, "Record creation error")
 
 
-@budget_router.put("/update/{budget_id}")
+@budget_router.put("/update/{budget_id}", auth=FullAccessAuth())
 def update_budget(request, budget_id: int, payload: BudgetIn):
     """
     The function `update_budget` updates the budget specified by id.
@@ -216,7 +217,7 @@ def list_budgets(
         raise HttpError(500, f"Record retrieval error: {str(e)}")
 
 
-@budget_router.delete("/delete/{budget_id}")
+@budget_router.delete("/delete/{budget_id}", auth=FullAccessAuth())
 def delete_budget(request, budget_id: int):
     """
     The function `delete_budget` deletes the budget specified by id.

--- a/backend/planning/api/views/calculator.py
+++ b/backend/planning/api/views/calculator.py
@@ -19,6 +19,7 @@ from transactions.api.dependencies.get_transactions_by_tag import (
     get_transactions_by_tag,
 )
 import logging
+from administration.api.dependencies.auth import FullAccessAuth
 
 api_logger = logging.getLogger("api")
 db_logger = logging.getLogger("db")
@@ -28,7 +29,7 @@ task_logger = logging.getLogger("task")
 calculator_router = Router(tags=["Calculator"])
 
 
-@calculator_router.post("/calculation_rule/create")
+@calculator_router.post("/calculation_rule/create", auth=FullAccessAuth())
 def create_calculation_rule(request, payload: CalculationRuleIn):
     """
     The function `create_calculation_rule` creates a calculation
@@ -53,7 +54,7 @@ def create_calculation_rule(request, payload: CalculationRuleIn):
         raise HttpError(500, "Record creation error")
 
 
-@calculator_router.put("/calculation_rule/update/{calculation_rule_id}")
+@calculator_router.put("/calculation_rule/update/{calculation_rule_id}", auth=FullAccessAuth())
 def update_calculation_rule(
     request, calculation_rule_id: int, payload: CalculationRuleIn
 ):
@@ -118,7 +119,7 @@ def list_calculation_rules(request):
         raise HttpError(500, "Record retrieval error")
 
 
-@calculator_router.delete("/calculation_rule/delete/{calculation_rule_id}")
+@calculator_router.delete("/calculation_rule/delete/{calculation_rule_id}", auth=FullAccessAuth())
 def delete_calculation_rule(request, calculation_rule_id: int):
     """
     The function `delete_calculation_rule` deletes the calculation rule specified by id.

--- a/backend/planning/api/views/contrib_rule.py
+++ b/backend/planning/api/views/contrib_rule.py
@@ -7,6 +7,7 @@ from django.shortcuts import get_object_or_404
 from django.http import Http404
 from typing import List
 import logging
+from administration.api.dependencies.auth import FullAccessAuth
 
 api_logger = logging.getLogger("api")
 db_logger = logging.getLogger("db")
@@ -16,7 +17,7 @@ task_logger = logging.getLogger("task")
 contrib_rule_router = Router(tags=["Contribution Rules"])
 
 
-@contrib_rule_router.post("/create")
+@contrib_rule_router.post("/create", auth=FullAccessAuth())
 def create_contrib_rule(request, payload: ContribRuleIn):
     """
     The function `create_contrib_rule` creates a contribution rule
@@ -59,7 +60,7 @@ def create_contrib_rule(request, payload: ContribRuleIn):
         raise HttpError(500, f"Record creation error: {str(e)}")
 
 
-@contrib_rule_router.put("/update/{contribrule_id}")
+@contrib_rule_router.put("/update/{contribrule_id}", auth=FullAccessAuth())
 def update_contrib_rule(request, contribrule_id: int, payload: ContribRuleIn):
     """
     The function `update_contrib_rule` updates the contribution rule specified by id.
@@ -165,7 +166,7 @@ def list_contrib_rules(request):
         raise HttpError(500, "Record retrieval error")
 
 
-@contrib_rule_router.delete("/delete/{contribrule_id}")
+@contrib_rule_router.delete("/delete/{contribrule_id}", auth=FullAccessAuth())
 def delete_contrib_rule(request, contribrule_id: int):
     """
     The function `delete_contrib_rule` deletes the contribution rule specified by id.

--- a/backend/planning/api/views/contribution.py
+++ b/backend/planning/api/views/contribution.py
@@ -10,6 +10,7 @@ from planning.api.schemas.contribution import (
 from django.shortcuts import get_object_or_404
 from django.http import Http404
 import logging
+from administration.api.dependencies.auth import FullAccessAuth
 
 api_logger = logging.getLogger("api")
 db_logger = logging.getLogger("db")
@@ -19,7 +20,7 @@ task_logger = logging.getLogger("task")
 contribution_router = Router(tags=["Contributions"])
 
 
-@contribution_router.post("/create")
+@contribution_router.post("/create", auth=FullAccessAuth())
 def create_contribution(request, payload: ContributionIn):
     """
     The function `create_contribution` creates a contribution
@@ -58,7 +59,7 @@ def create_contribution(request, payload: ContributionIn):
         raise HttpError(500, "Record creation error")
 
 
-@contribution_router.put("/update/{contribution_id}")
+@contribution_router.put("/update/{contribution_id}", auth=FullAccessAuth())
 def update_contribution(request, contribution_id: int, payload: ContributionIn):
     """
     The function `update_contribution` updates the contribution specified by id.
@@ -185,7 +186,7 @@ def list_contributions(request):
         raise HttpError(500, f"Record retrieval error: {str(e)}")
 
 
-@contribution_router.delete("/delete/{contribution_id}")
+@contribution_router.delete("/delete/{contribution_id}", auth=FullAccessAuth())
 def delete_contribution(request, contribution_id: int):
     """
     The function `delete_contribution` deletes the contribution specified by id.

--- a/backend/planning/api/views/note.py
+++ b/backend/planning/api/views/note.py
@@ -6,6 +6,7 @@ from django.shortcuts import get_object_or_404
 from django.http import Http404
 from typing import List
 import logging
+from administration.api.dependencies.auth import FullAccessAuth
 
 api_logger = logging.getLogger("api")
 db_logger = logging.getLogger("db")
@@ -15,7 +16,7 @@ task_logger = logging.getLogger("task")
 note_router = Router(tags=["Notes"])
 
 
-@note_router.post("/create")
+@note_router.post("/create", auth=FullAccessAuth())
 def create_note(request, payload: NoteIn):
     """
     The function `create_note` creates a note
@@ -39,7 +40,7 @@ def create_note(request, payload: NoteIn):
         raise HttpError(500, "Record creation error")
 
 
-@note_router.put("/update/{note_id}")
+@note_router.put("/update/{note_id}", auth=FullAccessAuth())
 def update_note(request, note_id: int, payload: NoteIn):
     """
     The function `update_note` updates the note specified by id.
@@ -125,7 +126,7 @@ def list_notes(request):
         raise HttpError(500, "Record retrieval error")
 
 
-@note_router.delete("/delete/{note_id}")
+@note_router.delete("/delete/{note_id}", auth=FullAccessAuth())
 def delete_note(request, note_id: int):
     """
     The function `delete_note` deletes the note specified by id.

--- a/backend/reminders/api/views/reminder.py
+++ b/backend/reminders/api/views/reminder.py
@@ -12,6 +12,7 @@ from typing import List
 from reminders.services import add_reminder_transaction, ReminderNotFound
 from transactions.tasks import update_reminder_cache
 import logging
+from administration.api.dependencies.auth import FullAccessAuth
 
 api_logger = logging.getLogger("api")
 error_logger = logging.getLogger("error")
@@ -19,7 +20,7 @@ error_logger = logging.getLogger("error")
 reminder_router = Router(tags=["Reminders"])
 
 
-@reminder_router.post("/create")
+@reminder_router.post("/create", auth=FullAccessAuth())
 def create_reminder(request, payload: ReminderIn):
     try:
         reminder = Reminder.objects.create(**payload.dict())
@@ -31,7 +32,7 @@ def create_reminder(request, payload: ReminderIn):
         raise HttpError(500, "Record creation error")
 
 
-@reminder_router.put("/update/{reminder_id}")
+@reminder_router.put("/update/{reminder_id}", auth=FullAccessAuth())
 def update_reminder(request, reminder_id: int, payload: ReminderIn):
     try:
         reminder = get_object_or_404(Reminder, id=reminder_id)
@@ -84,7 +85,7 @@ def list_reminders(request):
         raise HttpError(500, "Record retrieval error")
 
 
-@reminder_router.delete("/delete/{reminder_id}")
+@reminder_router.delete("/delete/{reminder_id}", auth=FullAccessAuth())
 def delete_reminder(request, reminder_id: int):
     try:
         reminder = get_object_or_404(Reminder, id=reminder_id)
@@ -98,7 +99,7 @@ def delete_reminder(request, reminder_id: int):
         raise HttpError(500, f"Record retrieval error: {str(e)}")
 
 
-@reminder_router.put("/addtrans/{reminder_id}")
+@reminder_router.put("/addtrans/{reminder_id}", auth=FullAccessAuth())
 def add_reminder_trans(request, reminder_id: int, payload: ReminderTransIn):
     try:
         add_reminder_transaction(reminder_id, payload.transaction_date)

--- a/backend/reminders/api/views/repeat.py
+++ b/backend/reminders/api/views/repeat.py
@@ -6,6 +6,7 @@ from reminders.api.schemas.repeat import RepeatIn, RepeatOut
 from django.shortcuts import get_object_or_404
 from typing import List
 import logging
+from administration.api.dependencies.auth import FullAccessAuth
 
 api_logger = logging.getLogger("api")
 db_logger = logging.getLogger("db")
@@ -15,7 +16,7 @@ task_logger = logging.getLogger("task")
 repeat_router = Router(tags=["Repeats"])
 
 
-@repeat_router.post("/create")
+@repeat_router.post("/create", auth=FullAccessAuth())
 def create_repeat(request, payload: RepeatIn):
     """
     The function `create_repeat` creates a repeat
@@ -54,7 +55,7 @@ def create_repeat(request, payload: RepeatIn):
         raise HttpError(500, "Record creation error")
 
 
-@repeat_router.put("/update/{repeat_id}")
+@repeat_router.put("/update/{repeat_id}", auth=FullAccessAuth())
 def update_repeat(request, repeat_id: int, payload: RepeatIn):
     """
     The function `update_repeat` updates the repeat specified by id.
@@ -154,7 +155,7 @@ def list_repeats(request):
         raise HttpError(500, "Record retrieval error")
 
 
-@repeat_router.delete("/delete/{repeat_id}")
+@repeat_router.delete("/delete/{repeat_id}", auth=FullAccessAuth())
 def delete_repeat(request, repeat_id: int):
     """
     The function `delete_repeat` deletes the repeat specified by id.

--- a/backend/tags/api/views/tag.py
+++ b/backend/tags/api/views/tag.py
@@ -14,6 +14,7 @@ from django.db.models.functions import Concat
 from typing import List
 from tags.services import create_tag, update_tag, TagAlreadyExists, TagNotFound, InvalidTagData
 import logging
+from administration.api.dependencies.auth import FullAccessAuth
 
 api_logger = logging.getLogger("api")
 error_logger = logging.getLogger("error")
@@ -21,7 +22,7 @@ error_logger = logging.getLogger("error")
 tag_router = Router(tags=["Tags"])
 
 
-@tag_router.post("/create")
+@tag_router.post("/create", auth=FullAccessAuth())
 def create_tag_view(request, payload: TagIn):
     try:
         tag_id = create_tag(
@@ -47,7 +48,7 @@ def create_tag_view(request, payload: TagIn):
         raise HttpError(500, f"Record creation error : {str(e)}")
 
 
-@tag_router.put("/update/{tag_id}")
+@tag_router.put("/update/{tag_id}", auth=FullAccessAuth())
 def update_tag_view(request, tag_id: int, payload: TagIn):
     try:
         update_tag(
@@ -116,7 +117,7 @@ def list_tags(request, query: TagQuery = Query(...)):
         raise HttpError(500, f"Record retrieval error: {str(e)}")
 
 
-@tag_router.delete("/delete/{tag_id}")
+@tag_router.delete("/delete/{tag_id}", auth=FullAccessAuth())
 def delete_tag(request, tag_id: int):
     try:
         tag = get_object_or_404(Tag, id=tag_id)

--- a/backend/transactions/api/views/paycheck.py
+++ b/backend/transactions/api/views/paycheck.py
@@ -6,6 +6,7 @@ from django.shortcuts import get_object_or_404
 from django.http import Http404
 from typing import List
 import logging
+from administration.api.dependencies.auth import FullAccessAuth
 
 api_logger = logging.getLogger("api")
 db_logger = logging.getLogger("db")
@@ -15,7 +16,7 @@ task_logger = logging.getLogger("task")
 paycheck_router = Router(tags=["Paychecks"])
 
 
-@paycheck_router.post("/create")
+@paycheck_router.post("/create", auth=FullAccessAuth())
 def create_paycheck(request, payload: PaycheckIn):
     """
     The function `create_paycheck` creates a paycheck
@@ -39,7 +40,7 @@ def create_paycheck(request, payload: PaycheckIn):
         raise HttpError(500, "Record creation error")
 
 
-@paycheck_router.put("/update/{paycheck_id}")
+@paycheck_router.put("/update/{paycheck_id}", auth=FullAccessAuth())
 def update_paycheck(request, paycheck_id: int, payload: PaycheckIn):
     """
     The function `update_paycheck` updates the paycheck specified by id.
@@ -133,7 +134,7 @@ def list_paychecks(request):
         raise HttpError(500, "Record retrieval error")
 
 
-@paycheck_router.delete("/delete/{paycheck_id}")
+@paycheck_router.delete("/delete/{paycheck_id}", auth=FullAccessAuth())
 def delete_paycheck(request, paycheck_id: int):
     """
     The function `delete_paycheck` deletes the paycheck specified by id.

--- a/backend/transactions/api/views/transaction.py
+++ b/backend/transactions/api/views/transaction.py
@@ -41,6 +41,7 @@ from core.cache.keys import (
     account_all,
 )
 import logging
+from administration.api.dependencies.auth import FullAccessAuth
 
 api_logger = logging.getLogger("api")
 db_logger = logging.getLogger("db")
@@ -50,7 +51,7 @@ task_logger = logging.getLogger("task")
 transaction_router = Router(tags=["Transactions"])
 
 
-@transaction_router.post("/create")
+@transaction_router.post("/create", auth=FullAccessAuth())
 def create_transaction(request, payload: TransactionIn):
     """
     The function `create_transaction` creates a transaction
@@ -74,7 +75,7 @@ def create_transaction(request, payload: TransactionIn):
         raise HttpError(500, f"Record creation error : {str(e)}")
 
 
-@transaction_router.patch("/multiedit")
+@transaction_router.patch("/multiedit", auth=FullAccessAuth())
 def multiedit_transactions(request, payload: MultiTranscationDate):
     """
     The function `multiedit_transactions` changes the transaction dates of mutliple
@@ -115,7 +116,7 @@ def multiedit_transactions(request, payload: MultiTranscationDate):
         raise HttpError(500, f"Transaction dates error: {str(e)}")
 
 
-@transaction_router.patch("/clear")
+@transaction_router.patch("/clear", auth=FullAccessAuth())
 def clear_transaction(request, payload: TransactionList):
     """
     The function `clear_transaction` changes the status to cleared, edits the date to today
@@ -199,7 +200,7 @@ def get_transaction(request, transaction_id: int):
         raise HttpError(500, "Record retrieval error")
 
 
-@transaction_router.patch("/delete")
+@transaction_router.patch("/delete", auth=FullAccessAuth())
 def delete_transaction(request, payload: TransactionList):
     """
     The function `delete_transaction` deletes the transaction(s) specified by id,
@@ -235,7 +236,7 @@ def delete_transaction(request, payload: TransactionList):
         raise HttpError(500, f"Record retrieval error: {str(e)}")
 
 
-@transaction_router.put("/update/{transaction_id}")
+@transaction_router.put("/update/{transaction_id}", auth=FullAccessAuth())
 def update_transaction(request, transaction_id: int, payload: TransactionIn):
     """
     The function `update_transaction` updates the transaction specified by id.

--- a/backend/transactions/api/views/transaction_detail.py
+++ b/backend/transactions/api/views/transaction_detail.py
@@ -9,6 +9,7 @@ from django.shortcuts import get_object_or_404
 from django.http import Http404
 from typing import List
 import logging
+from administration.api.dependencies.auth import FullAccessAuth
 
 api_logger = logging.getLogger("api")
 db_logger = logging.getLogger("db")
@@ -78,7 +79,7 @@ def list_transactiondetails(request):
         raise HttpError(500, "Record retrieval error")
 
 
-@transaction_detail_router.delete("/delete/{transactiondetail_id}")
+@transaction_detail_router.delete("/delete/{transactiondetail_id}", auth=FullAccessAuth())
 def delete_transaction_detail(request, transactiondetail_id: int):
     """
     The function `delete_transaction_detail` deletes the transaction detail specified by id.
@@ -110,7 +111,7 @@ def delete_transaction_detail(request, transactiondetail_id: int):
         raise HttpError(500, "Record retrieval error")
 
 
-@transaction_detail_router.post("/create")
+@transaction_detail_router.post("/create", auth=FullAccessAuth())
 def create_transaction_detail(request, payload: TransactionDetailIn):
     """
     The function `create_transaction_detail` creates a transaction detail
@@ -138,7 +139,7 @@ def create_transaction_detail(request, payload: TransactionDetailIn):
         raise HttpError(500, "Record creation error")
 
 
-@transaction_detail_router.put("/update/{transactiondetail_id}")
+@transaction_detail_router.put("/update/{transactiondetail_id}", auth=FullAccessAuth())
 def update_transaction_detail(
     request, transactiondetail_id: int, payload: TransactionDetailIn
 ):

--- a/backend/transactions/api/views/transaction_status.py
+++ b/backend/transactions/api/views/transaction_status.py
@@ -10,6 +10,7 @@ from django.shortcuts import get_object_or_404
 from django.http import Http404
 from typing import List
 import logging
+from administration.api.dependencies.auth import FullAccessAuth
 
 api_logger = logging.getLogger("api")
 db_logger = logging.getLogger("db")
@@ -19,7 +20,7 @@ task_logger = logging.getLogger("task")
 transaction_status_router = Router(tags=["Transaction Statuses"])
 
 
-@transaction_status_router.put("/update/{transactionstatus_id}")
+@transaction_status_router.put("/update/{transactionstatus_id}", auth=FullAccessAuth())
 def update_transaction_status(
     request, transactionstatus_id: int, payload: TransactionStatusIn
 ):
@@ -136,7 +137,7 @@ def list_transaction_statuses(request):
         raise HttpError(500, "Record retrieval error")
 
 
-@transaction_status_router.delete("/delete/{transactionstatus_id}")
+@transaction_status_router.delete("/delete/{transactionstatus_id}", auth=FullAccessAuth())
 def delete_transaction_status(request, transactionstatus_id: int):
     """
     The function `delete_transaction_status` deletes the transaction status specified by id.

--- a/backend/transactions/api/views/transaction_type.py
+++ b/backend/transactions/api/views/transaction_type.py
@@ -10,6 +10,7 @@ from django.shortcuts import get_object_or_404
 from django.http import Http404
 from typing import List
 import logging
+from administration.api.dependencies.auth import FullAccessAuth
 
 api_logger = logging.getLogger("api")
 db_logger = logging.getLogger("db")
@@ -19,7 +20,7 @@ task_logger = logging.getLogger("task")
 transaction_type_router = Router(tags=["Transaction Types"])
 
 
-@transaction_type_router.put("/update/{transaction_type_id}")
+@transaction_type_router.put("/update/{transaction_type_id}", auth=FullAccessAuth())
 def update_transaction_type(
     request, transaction_type_id: int, payload: TransactionTypeIn
 ):
@@ -135,7 +136,7 @@ def list_transaction_types(request):
         raise HttpError(500, "Record retrieval error")
 
 
-@transaction_type_router.delete("/delete/{transaction_type_id}")
+@transaction_type_router.delete("/delete/{transaction_type_id}", auth=FullAccessAuth())
 def delete_transaction_type(request, transaction_type_id: int):
     """
     The function `delete_transaction_type` deletes the transaction type specified by id.

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -19,7 +19,7 @@
 
   <v-app v-else>
     <VueQueryDevtools button-position="bottom-left" />
-    <AppNavigationVue />
+    <AppNavigationVue v-if="showNav" />
     <v-main>
       <v-container class="bg-background h-100" fluid>
         <router-view />
@@ -57,6 +57,7 @@
   import AppNavigationVue from "@/views/AppNavigationVue.vue";
   import { useMainStore } from "@/stores/main";
   import { onMounted, computed, ref, watch, onUnmounted } from "vue";
+  import { useRoute } from "vue-router";
   import { useOptions } from "@/composables/optionsComposable";
   import { useVersion } from "@/composables/versionComposable";
   import { VueQueryDevtools } from "@tanstack/vue-query-devtools";
@@ -64,6 +65,8 @@
   import LogoLoader from "./components/LogoLoader.vue";
 
   const { backendReady } = useBackendReady();
+  const route = useRoute();
+  const showNav = computed(() => route.name !== "login");
 
   const reloadPage = () => {
     window.location.reload();

--- a/frontend/src/components/AccountHeaderWidget.vue
+++ b/frontend/src/components/AccountHeaderWidget.vue
@@ -17,7 +17,7 @@
                 class="d-flex align-center justify-center mx-1 px-1 gx-1 bg-primary-lighten-1"
                 variant="outlined"
               >
-                <v-tooltip text="Edit Account" location="top">
+                <v-tooltip text="Edit Account" location="top" v-if="authStore.isFullAccess">
                   <template v-slot:activator="{ props }">
                     <span
                       class="mx-1"
@@ -44,6 +44,7 @@
                 <v-tooltip
                   :text="account.active ? 'Delete Account' : 'Enable Account'"
                   location="top"
+                  v-if="authStore.isFullAccess"
                 >
                   <template v-slot:activator="{ props }">
                     <v-btn
@@ -71,7 +72,7 @@
           <!-- Large Display View -->
           <v-row density="compact" v-if="!smAndDown">
             <v-col class="text-center align-content-end">
-              <v-tooltip text="Adjust Balance" location="top">
+              <v-tooltip text="Adjust Balance" location="top" v-if="authStore.isFullAccess">
                 <template v-slot:activator="{ props }">
                   <div
                     class="text-accent font-weight-bold text-h4 d-inline-block"
@@ -90,6 +91,15 @@
                   </div>
                 </template>
               </v-tooltip>
+              <div
+                class="text-accent font-weight-bold text-h4 d-inline-block"
+                v-if="!authStore.isFullAccess"
+              >
+                <NumberFlow
+                  :value="account.balance"
+                  :format="{ style: 'currency', currency: 'USD' }"
+                />
+              </div>
               <AdjustBalanceForm
                 v-model="adjBalDialog"
                 :account="account"
@@ -179,7 +189,7 @@
           <!-- Small Display View -->
           <v-row density="compact" v-if="smAndDown">
             <v-col class="text-center align-content-end">
-              <v-tooltip text="Adjust Balance" location="top">
+              <v-tooltip text="Adjust Balance" location="top" v-if="authStore.isFullAccess">
                 <template v-slot:activator="{ props }">
                   <div
                     class="text-accent-lighten-1 font-weight-bold text-h4 d-inline-block"
@@ -198,6 +208,15 @@
                   </div>
                 </template>
               </v-tooltip>
+              <div
+                class="text-accent-lighten-1 font-weight-bold text-h4 d-inline-block"
+                v-if="!authStore.isFullAccess"
+              >
+                <NumberFlow
+                  :value="account.balance"
+                  :format="{ style: 'currency', currency: 'USD' }"
+                />
+              </div>
               <AdjustBalanceForm
                 v-model="adjBalDialog"
                 :account="account"
@@ -327,8 +346,10 @@
   import NumberFlow from "@number-flow/vue";
   import { useDisplay } from "vuetify";
   import RewardsGraphs from "./RewardsGraphs.vue";
+  import { useAuthStore } from "@/stores/auth";
 
   const { smAndDown } = useDisplay();
+  const authStore = useAuthStore();
   const adjBalDialog = ref(false);
   const editDialog = ref(false);
   const deleteDialog = ref(false);

--- a/frontend/src/components/AccountsMenu.vue
+++ b/frontend/src/components/AccountsMenu.vue
@@ -9,6 +9,7 @@
         prepend-icon="mdi-plus-circle"
         base-color="primary"
         :to="add_account_link"
+        v-if="authStore.isFullAccess"
       >
         <v-list-item-title>
           <span :class="isMobile ? 'text-h6' : ''">Add Account</span>
@@ -389,8 +390,10 @@
   import { useTransactionsStore } from "@/stores/transactions";
   import NumberFlow from "@number-flow/vue";
   import { useDisplay } from "vuetify";
+  import { useAuthStore } from "@/stores/auth";
 
   const { smAndDown } = useDisplay();
+  const authStore = useAuthStore();
   const isMobile = smAndDown;
 
   const transactions_store = useTransactionsStore();

--- a/frontend/src/components/TransactionTableWidget.vue
+++ b/frontend/src/components/TransactionTableWidget.vue
@@ -6,7 +6,7 @@
         <v-tooltip
           text="File Import"
           location="top"
-          v-if="!smAndDown && props.variant === 'account'"
+          v-if="!smAndDown && props.variant === 'account' && authStore.isFullAccess"
         >
           <template v-slot:activator="{ props }">
             <v-btn
@@ -463,7 +463,7 @@
             icon
             @click="transactionAddFormDialog = true"
             variant="elevated"
-            v-if="selected_all.length === 0 && props.variant === 'account'"
+            v-if="selected_all.length === 0 && props.variant === 'account' && authStore.isFullAccess"
           >
             <v-icon icon="mdi-invoice-plus"></v-icon>
           </v-fab>
@@ -483,6 +483,7 @@
             icon
             :disabled="true"
             variant="plain"
+            v-if="authStore.isFullAccess"
           >
             <v-icon></v-icon>
             <v-speed-dial
@@ -618,9 +619,11 @@
   import { useDisplay } from "vuetify";
   import { useTransactions } from "@/composables/transactionsComposable";
   import { useReminders } from "@/composables/remindersComposable";
+  import { useAuthStore } from "@/stores/auth";
 
   const { removeTransaction, clearTransaction } = useTransactions();
   const { addReminderTransaction } = useReminders();
+  const authStore = useAuthStore();
   const { smAndDown, mdAndUp } = useDisplay();
   const transactions_store = useTransactionsStore();
   const today = new Date();

--- a/frontend/src/composables/accountTypesComposable.js
+++ b/frontend/src/composables/accountTypesComposable.js
@@ -1,19 +1,6 @@
 import { useQuery, useQueryClient } from "@tanstack/vue-query";
-import axios from "axios";
+import apiClient from "./apiClient";
 import { useMainStore } from "@/stores/main";
-import { useApiKey } from "./ueApiKey";
-
-const apiKey = useApiKey();
-
-const apiClient = axios.create({
-  baseURL: "/api/v1",
-  withCredentials: false,
-  headers: {
-    Accept: "application/json",
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${apiKey}`,
-  },
-});
 
 function handleApiError(error, message) {
   const mainstore = useMainStore();

--- a/frontend/src/composables/accountsComposable.js
+++ b/frontend/src/composables/accountsComposable.js
@@ -1,19 +1,6 @@
 import { useQuery, useQueryClient, useMutation } from "@tanstack/vue-query";
-import axios from "axios";
+import apiClient from "./apiClient";
 import { useMainStore } from "@/stores/main";
-import { useApiKey } from "./ueApiKey";
-
-const apiKey = useApiKey();
-
-const apiClient = axios.create({
-  baseURL: "/api/v1",
-  withCredentials: false,
-  headers: {
-    Accept: "application/json",
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${apiKey}`,
-  },
-});
 
 function handleApiError(error, message) {
   const mainstore = useMainStore();

--- a/frontend/src/composables/apiClient.js
+++ b/frontend/src/composables/apiClient.js
@@ -1,0 +1,21 @@
+import axios from "axios";
+import router from "@/router";
+
+const apiClient = axios.create({
+  baseURL: "/api/v1",
+  withCredentials: true,
+  headers: { Accept: "application/json", "Content-Type": "application/json" },
+});
+
+apiClient.interceptors.response.use(
+  response => response,
+  error => {
+    if (error.response?.status === 401) {
+      const currentPath = router.currentRoute.value.fullPath;
+      router.push({ name: "login", query: { redirect: currentPath } });
+    }
+    return Promise.reject(error);
+  },
+);
+
+export default apiClient;

--- a/frontend/src/composables/banksComposable.js
+++ b/frontend/src/composables/banksComposable.js
@@ -1,19 +1,6 @@
 import { useQuery, useQueryClient, useMutation } from "@tanstack/vue-query";
-import axios from "axios";
+import apiClient from "./apiClient";
 import { useMainStore } from "@/stores/main";
-import { useApiKey } from "./ueApiKey";
-
-const apiKey = useApiKey();
-
-const apiClient = axios.create({
-  baseURL: "/api/v1",
-  withCredentials: false,
-  headers: {
-    Accept: "application/json",
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${apiKey}`,
-  },
-});
 
 function handleApiError(error, message) {
   const mainstore = useMainStore();

--- a/frontend/src/composables/budgetsComposable.js
+++ b/frontend/src/composables/budgetsComposable.js
@@ -1,19 +1,6 @@
 import { useQuery, useQueryClient, useMutation } from "@tanstack/vue-query";
-import axios from "axios";
+import apiClient from "./apiClient";
 import { useMainStore } from "@/stores/main";
-import { useApiKey } from "./ueApiKey";
-
-const apiKey = useApiKey();
-
-const apiClient = axios.create({
-  baseURL: "/api/v1",
-  withCredentials: false,
-  headers: {
-    Accept: "application/json",
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${apiKey}`,
-  },
-});
 
 function handleApiError(error, message) {
   const mainstore = useMainStore();

--- a/frontend/src/composables/calculatorComposable.js
+++ b/frontend/src/composables/calculatorComposable.js
@@ -1,19 +1,6 @@
 import { useQuery, useQueryClient, useMutation } from "@tanstack/vue-query";
-import axios from "axios";
+import apiClient from "./apiClient";
 import { useMainStore } from "@/stores/main";
-import { useApiKey } from "./ueApiKey";
-
-const apiKey = useApiKey();
-
-const apiClient = axios.create({
-  baseURL: "/api/v1",
-  withCredentials: false,
-  headers: {
-    Accept: "application/json",
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${apiKey}`,
-  },
-});
 
 function handleApiError(error, message) {
   const mainstore = useMainStore();

--- a/frontend/src/composables/contributionsComposable.js
+++ b/frontend/src/composables/contributionsComposable.js
@@ -1,19 +1,6 @@
 import { useQuery, useQueryClient, useMutation } from "@tanstack/vue-query";
-import axios from "axios";
+import apiClient from "./apiClient";
 import { useMainStore } from "@/stores/main";
-import { useApiKey } from "./ueApiKey";
-
-const apiKey = useApiKey();
-
-const apiClient = axios.create({
-  baseURL: "/api/v1",
-  withCredentials: false,
-  headers: {
-    Accept: "application/json",
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${apiKey}`,
-  },
-});
 
 function handleApiError(error, message) {
   const mainstore = useMainStore();

--- a/frontend/src/composables/descriptionHistoryComposable.js
+++ b/frontend/src/composables/descriptionHistoryComposable.js
@@ -1,19 +1,6 @@
 import { useQuery, useQueryClient } from "@tanstack/vue-query";
-import axios from "axios";
+import apiClient from "./apiClient";
 import { useMainStore } from "@/stores/main";
-import { useApiKey } from "./ueApiKey";
-
-const apiKey = useApiKey();
-
-const apiClient = axios.create({
-  baseURL: "/api/v1",
-  withCredentials: false,
-  headers: {
-    Accept: "application/json",
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${apiKey}`,
-  },
-});
 
 function handleApiError(error, message) {
   const mainstore = useMainStore();

--- a/frontend/src/composables/errorLevelsComposable.js
+++ b/frontend/src/composables/errorLevelsComposable.js
@@ -1,19 +1,6 @@
 import { useQuery, useQueryClient } from "@tanstack/vue-query";
-import axios from "axios";
+import apiClient from "./apiClient";
 import { useMainStore } from "@/stores/main";
-import { useApiKey } from "./ueApiKey";
-
-const apiKey = useApiKey();
-
-const apiClient = axios.create({
-  baseURL: "/api/v1",
-  withCredentials: false,
-  headers: {
-    Accept: "application/json",
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${apiKey}`,
-  },
-});
 
 function handleApiError(error, message) {
   const mainstore = useMainStore();

--- a/frontend/src/composables/fileImportComposable.js
+++ b/frontend/src/composables/fileImportComposable.js
@@ -1,18 +1,5 @@
-import axios from "axios";
+import apiClient from "./apiClient";
 import { useMainStore } from "@/stores/main";
-import { useApiKey } from "./ueApiKey";
-
-const apiKey = useApiKey();
-
-const apiClient = axios.create({
-  baseURL: "/api/v1",
-  withCredentials: false,
-  headers: {
-    Accept: "application/json",
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${apiKey}`,
-  },
-});
 
 function handleApiError(error, message) {
   const mainstore = useMainStore();

--- a/frontend/src/composables/forecastsComposable.js
+++ b/frontend/src/composables/forecastsComposable.js
@@ -1,19 +1,6 @@
 import { useQuery, useQueryClient } from "@tanstack/vue-query";
-import axios from "axios";
+import apiClient from "./apiClient";
 import { useMainStore } from "@/stores/main";
-import { useApiKey } from "./ueApiKey";
-
-const apiKey = useApiKey();
-
-const apiClient = axios.create({
-  baseURL: "/api/v1",
-  withCredentials: false,
-  headers: {
-    Accept: "application/json",
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${apiKey}`,
-  },
-});
 
 function handleApiError(error, message) {
   const mainstore = useMainStore();

--- a/frontend/src/composables/logentriesComposable.js
+++ b/frontend/src/composables/logentriesComposable.js
@@ -1,19 +1,6 @@
 import { useQuery, useQueryClient } from "@tanstack/vue-query";
-import axios from "axios";
+import apiClient from "./apiClient";
 import { useMainStore } from "@/stores/main";
-import { useApiKey } from "./ueApiKey";
-
-const apiKey = useApiKey();
-
-const apiClient = axios.create({
-  baseURL: "/api/v1",
-  withCredentials: false,
-  headers: {
-    Accept: "application/json",
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${apiKey}`,
-  },
-});
 
 function handleApiError(error, message) {
   const mainstore = useMainStore();

--- a/frontend/src/composables/messagesComposable.js
+++ b/frontend/src/composables/messagesComposable.js
@@ -1,20 +1,7 @@
 import { useQuery, useQueryClient, useMutation } from "@tanstack/vue-query";
-import axios from "axios";
+import apiClient from "./apiClient";
 import { useMainStore } from "@/stores/main";
 import { onUnmounted } from "vue";
-import { useApiKey } from "./ueApiKey";
-
-const apiKey = useApiKey();
-
-const apiClient = axios.create({
-  baseURL: "/api/v1",
-  withCredentials: false,
-  headers: {
-    Accept: "application/json",
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${apiKey}`,
-  },
-});
 
 function handleApiError(error, message) {
   const mainstore = useMainStore();

--- a/frontend/src/composables/notesComposable.js
+++ b/frontend/src/composables/notesComposable.js
@@ -1,19 +1,6 @@
 import { useQuery, useQueryClient, useMutation } from "@tanstack/vue-query";
-import axios from "axios";
+import apiClient from "./apiClient";
 import { useMainStore } from "@/stores/main";
-import { useApiKey } from "./ueApiKey";
-
-const apiKey = useApiKey();
-
-const apiClient = axios.create({
-  baseURL: "/api/v1",
-  withCredentials: false,
-  headers: {
-    Accept: "application/json",
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${apiKey}`,
-  },
-});
 
 function handleApiError(error, message) {
   const mainstore = useMainStore();

--- a/frontend/src/composables/optionsComposable.js
+++ b/frontend/src/composables/optionsComposable.js
@@ -1,19 +1,6 @@
 import { useQuery, useQueryClient, useMutation } from "@tanstack/vue-query";
-import axios from "axios";
+import apiClient from "./apiClient";
 import { useMainStore } from "@/stores/main";
-import { useApiKey } from "./ueApiKey";
-
-const apiKey = useApiKey();
-
-const apiClient = axios.create({
-  baseURL: "/api/v1",
-  withCredentials: false,
-  headers: {
-    Accept: "application/json",
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${apiKey}`,
-  },
-});
 
 async function handleApiError(error, message) {
   const mainstore = useMainStore();

--- a/frontend/src/composables/payeesComposable.js
+++ b/frontend/src/composables/payeesComposable.js
@@ -1,19 +1,6 @@
 import { useQuery, useQueryClient, useMutation } from "@tanstack/vue-query";
-import axios from "axios";
+import apiClient from "./apiClient";
 import { useMainStore } from "@/stores/main";
-import { useApiKey } from "./ueApiKey";
-
-const apiKey = useApiKey();
-
-const apiClient = axios.create({
-  baseURL: "/api/v1",
-  withCredentials: false,
-  headers: {
-    Accept: "application/json",
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${apiKey}`,
-  },
-});
 
 function handleApiError(error, message) {
   const mainstore = useMainStore();

--- a/frontend/src/composables/planningGraphComposable.js
+++ b/frontend/src/composables/planningGraphComposable.js
@@ -1,19 +1,6 @@
 import { useQuery, useQueryClient } from "@tanstack/vue-query";
-import axios from "axios";
+import apiClient from "./apiClient";
 import { useMainStore } from "@/stores/main";
-import { useApiKey } from "./ueApiKey";
-
-const apiKey = useApiKey();
-
-const apiClient = axios.create({
-  baseURL: "/api/v1",
-  withCredentials: false,
-  headers: {
-    Accept: "application/json",
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${apiKey}`,
-  },
-});
 
 function handleApiError(error, message) {
   const mainstore = useMainStore();

--- a/frontend/src/composables/remindersComposable.js
+++ b/frontend/src/composables/remindersComposable.js
@@ -1,19 +1,6 @@
 import { useQuery, useQueryClient, useMutation } from "@tanstack/vue-query";
-import axios from "axios";
+import apiClient from "./apiClient";
 import { useMainStore } from "@/stores/main";
-import { useApiKey } from "./ueApiKey";
-
-const apiKey = useApiKey();
-
-const apiClient = axios.create({
-  baseURL: "/api/v1",
-  withCredentials: false,
-  headers: {
-    Accept: "application/json",
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${apiKey}`,
-  },
-});
 
 function handleApiError(error, message) {
   const mainstore = useMainStore();

--- a/frontend/src/composables/repeatsComposable.js
+++ b/frontend/src/composables/repeatsComposable.js
@@ -1,19 +1,6 @@
 import { useQuery, useQueryClient } from "@tanstack/vue-query";
-import axios from "axios";
+import apiClient from "./apiClient";
 import { useMainStore } from "@/stores/main";
-import { useApiKey } from "./ueApiKey";
-
-const apiKey = useApiKey();
-
-const apiClient = axios.create({
-  baseURL: "/api/v1",
-  withCredentials: false,
-  headers: {
-    Accept: "application/json",
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${apiKey}`,
-  },
-});
 
 function handleApiError(error, message) {
   const mainstore = useMainStore();

--- a/frontend/src/composables/retirementComposable.js
+++ b/frontend/src/composables/retirementComposable.js
@@ -1,19 +1,6 @@
 import { useQuery, useQueryClient } from "@tanstack/vue-query";
-import axios from "axios";
+import apiClient from "./apiClient";
 import { useMainStore } from "@/stores/main";
-import { useApiKey } from "./ueApiKey";
-
-const apiKey = useApiKey();
-
-const apiClient = axios.create({
-  baseURL: "/api/v1",
-  withCredentials: false,
-  headers: {
-    Accept: "application/json",
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${apiKey}`,
-  },
-});
 
 function handleApiError(error, message) {
   const mainstore = useMainStore();

--- a/frontend/src/composables/tagsComposable.js
+++ b/frontend/src/composables/tagsComposable.js
@@ -1,19 +1,6 @@
 import { useQuery, useQueryClient, useMutation } from "@tanstack/vue-query";
-import axios from "axios";
+import apiClient from "./apiClient";
 import { useMainStore } from "@/stores/main";
-import { useApiKey } from "./ueApiKey";
-
-const apiKey = useApiKey();
-
-const apiClient = axios.create({
-  baseURL: "/api/v1",
-  withCredentials: false,
-  headers: {
-    Accept: "application/json",
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${apiKey}`,
-  },
-});
 
 function handleApiError(error, message) {
   const mainstore = useMainStore();

--- a/frontend/src/composables/tagtypesComposable.js
+++ b/frontend/src/composables/tagtypesComposable.js
@@ -1,19 +1,6 @@
 import { useQuery, useQueryClient } from "@tanstack/vue-query";
-import axios from "axios";
+import apiClient from "./apiClient";
 import { useMainStore } from "@/stores/main";
-import { useApiKey } from "./ueApiKey";
-
-const apiKey = useApiKey();
-
-const apiClient = axios.create({
-  baseURL: "/api/v1",
-  withCredentials: false,
-  headers: {
-    Accept: "application/json",
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${apiKey}`,
-  },
-});
 
 function handleApiError(error, message) {
   const mainstore = useMainStore();

--- a/frontend/src/composables/transactionStatusesComposable.js
+++ b/frontend/src/composables/transactionStatusesComposable.js
@@ -1,19 +1,6 @@
 import { useQuery, useQueryClient } from "@tanstack/vue-query";
-import axios from "axios";
+import apiClient from "./apiClient";
 import { useMainStore } from "@/stores/main";
-import { useApiKey } from "./ueApiKey";
-
-const apiKey = useApiKey();
-
-const apiClient = axios.create({
-  baseURL: "/api/v1",
-  withCredentials: false,
-  headers: {
-    Accept: "application/json",
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${apiKey}`,
-  },
-});
 
 function handleApiError(error, message) {
   const mainstore = useMainStore();

--- a/frontend/src/composables/transactionTypesComposable.js
+++ b/frontend/src/composables/transactionTypesComposable.js
@@ -1,19 +1,6 @@
 import { useQuery, useQueryClient } from "@tanstack/vue-query";
-import axios from "axios";
+import apiClient from "./apiClient";
 import { useMainStore } from "@/stores/main";
-import { useApiKey } from "./ueApiKey";
-
-const apiKey = useApiKey();
-
-const apiClient = axios.create({
-  baseURL: "/api/v1",
-  withCredentials: false,
-  headers: {
-    Accept: "application/json",
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${apiKey}`,
-  },
-});
 
 function handleApiError(error, message) {
   const mainstore = useMainStore();

--- a/frontend/src/composables/transactionsComposable.js
+++ b/frontend/src/composables/transactionsComposable.js
@@ -4,22 +4,9 @@ import {
   useMutation,
   keepPreviousData,
 } from "@tanstack/vue-query";
-import axios from "axios";
+import apiClient from "./apiClient";
 import { useMainStore } from "@/stores/main";
 import { useTransactionsStore } from "@/stores/transactions";
-import { useApiKey } from "./ueApiKey";
-
-const apiKey = useApiKey();
-
-const apiClient = axios.create({
-  baseURL: "/api/v1",
-  withCredentials: false,
-  headers: {
-    Accept: "application/json",
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${apiKey}`,
-  },
-});
 
 function handleApiError(error, message) {
   const mainstore = useMainStore();

--- a/frontend/src/composables/useBackendReady.js
+++ b/frontend/src/composables/useBackendReady.js
@@ -1,21 +1,8 @@
 // useBackendReady.js
 import { ref, onMounted } from "vue";
-import axios from "axios";
-import { useApiKey } from "./ueApiKey";
-
-const apiKey = useApiKey();
+import apiClient from "./apiClient";
 
 const backendReady = ref(false);
-
-const apiClient = axios.create({
-  baseURL: "/api/v1",
-  withCredentials: false,
-  headers: {
-    Accept: "application/json",
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${apiKey}`,
-  },
-});
 
 export function useBackendReady() {
   onMounted(async () => {

--- a/frontend/src/composables/versionComposable.js
+++ b/frontend/src/composables/versionComposable.js
@@ -1,19 +1,6 @@
 import { useQuery, useQueryClient } from "@tanstack/vue-query";
-import axios from "axios";
+import apiClient from "./apiClient";
 import { useMainStore } from "@/stores/main";
-import { useApiKey } from "./ueApiKey";
-
-const apiKey = useApiKey();
-
-const apiClient = axios.create({
-  baseURL: "/api/v1",
-  withCredentials: false,
-  headers: {
-    Accept: "application/json",
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${apiKey}`,
-  },
-});
 
 async function handleApiError(error, message) {
   const mainstore = useMainStore();

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -16,8 +16,15 @@ import ExpensesView from "@/views/ExpensesView.vue";
 import NotesView from "@/views/NotesView.vue";
 import RetirementView from "@/views/RetirementView.vue";
 import BudgetsView from "@/views/BudgetsView.vue";
+import LoginView from "@/views/LoginView.vue";
 
 const routes = [
+  {
+    path: "/login",
+    name: "login",
+    component: LoginView,
+    meta: { public: true },
+  },
   {
     path: "/",
     name: "dashboard",
@@ -110,16 +117,31 @@ const router = createRouter({
   routes,
 });
 
-// Add a global beforeEach guard
-router.beforeEach((to, from, next) => {
+router.beforeEach(async (to, from, next) => {
   const isPageReload = sessionStorage.getItem("isPageReload");
   sessionStorage.removeItem("isPageReload");
 
-  if (isPageReload && to.fullPath !== "/") {
-    next("/");
-  } else {
-    next();
+  if (isPageReload && to.fullPath !== "/" && !to.meta.public) {
+    return next("/");
   }
+
+  if (to.meta.public) {
+    return next();
+  }
+
+  // Lazy import to avoid circular dependency at module load time
+  const { useAuthStore } = await import("@/stores/auth");
+  const authStore = useAuthStore();
+
+  if (!authStore.isAuthenticated) {
+    await authStore.fetchCurrentUser();
+  }
+
+  if (!authStore.isAuthenticated) {
+    return next({ name: "login", query: { redirect: to.fullPath } });
+  }
+
+  next();
 });
 
 // Set a flag to detect page reload

--- a/frontend/src/stores/auth.js
+++ b/frontend/src/stores/auth.js
@@ -1,0 +1,41 @@
+import { defineStore } from "pinia";
+import { ref, computed } from "vue";
+import axios from "axios";
+
+const apiClient = axios.create({
+  baseURL: "/api/v1",
+  withCredentials: true,
+  headers: { Accept: "application/json", "Content-Type": "application/json" },
+});
+
+export const useAuthStore = defineStore("auth", () => {
+  const user = ref(null);
+
+  const isAuthenticated = computed(() => user.value !== null);
+  const isFullAccess = computed(() => user.value?.group === "full_access");
+  const isReadonly = computed(() => user.value?.group === "readonly");
+
+  async function fetchCurrentUser() {
+    try {
+      const response = await apiClient.get("/auth/me");
+      user.value = response.data;
+    } catch {
+      user.value = null;
+    }
+  }
+
+  async function login(username, password) {
+    const response = await apiClient.post("/auth/login", { username, password });
+    user.value = response.data;
+  }
+
+  async function logout() {
+    try {
+      await apiClient.post("/auth/logout");
+    } finally {
+      user.value = null;
+    }
+  }
+
+  return { user, isAuthenticated, isFullAccess, isReadonly, fetchCurrentUser, login, logout };
+});

--- a/frontend/src/views/AppNavigationVue.vue
+++ b/frontend/src/views/AppNavigationVue.vue
@@ -56,6 +56,7 @@
         :color="isDark ? '#F5F5F5' : '#121212'"
         size="small"
       ></v-btn>
+      <v-btn icon="mdi-logout" size="small" @click="handleLogout"></v-btn>
       <v-menu location="start">
         <template v-slot:activator="{ props }">
           <v-btn class="text-none" stacked v-bind="props">
@@ -200,6 +201,7 @@
   import { useRouter } from "vue-router";
   import { useTransactionsStore } from "@/stores/transactions";
   import { useThemeStore } from "@/stores/themeStore";
+  import { useAuthStore } from "@/stores/auth";
 
   const theme = useTheme();
   const themeStore = useThemeStore();
@@ -220,6 +222,7 @@
   const { messages, markRead, deleteAll } = useMessages();
   const { mdAndUp, smAndDown } = useDisplay();
   const isMobile = smAndDown;
+  const authStore = useAuthStore();
   const nav_toggle = ref(true);
 
   const setAccount = (account, forecast) => {
@@ -246,5 +249,10 @@
 
   function handleToggle() {
     themeStore.toggleTheme();
+  }
+
+  async function handleLogout() {
+    await authStore.logout();
+    router.push({ name: "login" });
   }
 </script>

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -1,0 +1,85 @@
+<template>
+  <v-container class="fill-height" fluid>
+    <v-row align="center" justify="center">
+      <v-col cols="12" sm="8" md="4">
+        <v-card class="pa-6" elevation="4" rounded="lg">
+          <v-card-title class="text-h5 text-center mb-4">LenoreFin</v-card-title>
+
+          <v-form @submit.prevent="handleLogin">
+            <v-text-field
+              v-model="username"
+              label="Username"
+              prepend-inner-icon="mdi-account"
+              variant="outlined"
+              density="comfortable"
+              :disabled="loading"
+              autofocus
+              class="mb-3"
+            />
+
+            <v-text-field
+              v-model="password"
+              label="Password"
+              prepend-inner-icon="mdi-lock"
+              :type="showPassword ? 'text' : 'password'"
+              :append-inner-icon="showPassword ? 'mdi-eye-off' : 'mdi-eye'"
+              variant="outlined"
+              density="comfortable"
+              :disabled="loading"
+              class="mb-4"
+              @click:append-inner="showPassword = !showPassword"
+            />
+
+            <v-alert v-if="error" type="error" density="compact" class="mb-4">
+              {{ error }}
+            </v-alert>
+
+            <v-btn
+              type="submit"
+              color="primary"
+              block
+              size="large"
+              :loading="loading"
+            >
+              Sign in
+            </v-btn>
+          </v-form>
+        </v-card>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script setup>
+  import { ref } from "vue";
+  import { useRouter, useRoute } from "vue-router";
+  import { useAuthStore } from "@/stores/auth";
+
+  const router = useRouter();
+  const route = useRoute();
+  const authStore = useAuthStore();
+
+  const username = ref("");
+  const password = ref("");
+  const showPassword = ref(false);
+  const loading = ref(false);
+  const error = ref("");
+
+  async function handleLogin() {
+    if (!username.value || !password.value) {
+      error.value = "Please enter your username and password.";
+      return;
+    }
+    loading.value = true;
+    error.value = "";
+    try {
+      await authStore.login(username.value, password.value);
+      const redirect = route.query.redirect || "/";
+      router.push(redirect);
+    } catch {
+      error.value = "Invalid username or password.";
+    } finally {
+      loading.value = false;
+    }
+  }
+</script>

--- a/frontend/src/views/RemindersView.vue
+++ b/frontend/src/views/RemindersView.vue
@@ -7,7 +7,7 @@
     </v-row>
     <v-row class="pa-1 ga-1 rounded" no-gutters>
       <v-col class="rounded">
-        <RemindersWidget :allowEdit="true" variant="full" />
+        <RemindersWidget :allowEdit="authStore.isFullAccess" variant="full" />
       </v-col>
     </v-row>
   </div>
@@ -15,4 +15,6 @@
 <script setup>
   import RemindersWidget from "@/components/RemindersWidget.vue";
   import ReminderHeaderWidget from "@/components/ReminderHeaderWidget.vue";
+  import { useAuthStore } from "@/stores/auth";
+  const authStore = useAuthStore();
 </script>


### PR DESCRIPTION
## Summary

- **Backend**: Replaces static Bearer API-key auth with Django session auth. New `SessionAuth` (read) and `FullAccessAuth` (mutations) Ninja dependencies gate all endpoints. Login/logout/me endpoints at `/api/v1/auth/`. Full Access and Readonly groups created via data migration (0017). All 20 mutation view files updated to require `FullAccessAuth`.
- **Frontend**: Shared `apiClient.js` with `withCredentials: true` and a global 401 interceptor that redirects to `/login`. All 26 composables migrated from per-file Bearer-header axios instances to the shared client. New `auth` Pinia store, login page (Vuetify), and router navigation guard that calls `/auth/me` on load and protects all non-public routes.
- **Readonly UI**: Mutation controls hidden for Readonly users — add/edit/delete/clear transactions, add/edit/delete reminders, add/edit/delete/adjust-balance accounts, file import button.

## Test plan

- [ ] Login with Full Access user → redirected to `/`, all mutation buttons visible
- [ ] Login with Readonly user → redirected to `/`, add/edit/delete/clear buttons hidden
- [ ] Unauthenticated request to any protected route → redirected to `/login`
- [ ] After login, redirect query param (`?redirect=...`) takes user to intended page
- [ ] Logout button in nav bar ends session and redirects to `/login`
- [ ] 401 from any API call redirects to `/login` (test by clearing session cookie)
- [ ] Backend: `pytest -m api` — all 409 tests pass
- [ ] Readonly user hitting a mutation endpoint directly → 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)