### PR TITLE
fix: correct budget percentage when rollover produces negative starting balance

### DIFF
--- a/backend/planning/api/views/budget.py
+++ b/backend/planning/api/views/budget.py
@@ -194,9 +194,12 @@ def list_budgets(
             budget_total = budget.amount
             if budget.roll_over:
                 budget_total += budget.roll_over_amt
-            if total:
+            if budget_total <= 0:
+                # Negative rollover already exceeds the budget for this period
+                used_percentage = 100
+            elif total:
                 used_percentage = min(
-                    100, round(abs(total) / abs(budget_total) * 100)
+                    100, round(abs(total) / budget_total * 100)
                 )
             else:
                 used_percentage = 0

--- a/backend/planning/tests/api/test_budget_api.py
+++ b/backend/planning/tests/api/test_budget_api.py
@@ -168,3 +168,35 @@ def test_delete_budget_not_found(api_client):
     response = api_client.delete("/planning/budget/delete/9999", headers=AUTH)
 
     assert response.status_code == 404
+
+
+@pytest.mark.django_db
+@pytest.mark.api
+def test_list_budgets_negative_rollover_is_fully_over(api_client, test_repeat):
+    """When rollover debt exceeds the period budget, used_percentage must be 100."""
+    from planning.models import Budget
+    from django.utils import timezone
+    import pytz
+
+    today = timezone.now().astimezone(pytz.timezone("America/New_York")).date()
+    Budget.objects.create(
+        tag_ids="[]",
+        name="Negative Rollover Budget",
+        amount=100.00,
+        roll_over=True,
+        repeat=test_repeat,
+        start_day=today,
+        roll_over_amt=-150.00,  # overspent $150 last period → budget_total = -$50
+        active=True,
+        widget=True,
+        next_start=today,
+    )
+
+    response = api_client.get("/planning/budget/list", headers=AUTH)
+    assert response.status_code == 200
+
+    budget = next(
+        b for b in response.json() if b["budget"]["name"] == "Negative Rollover Budget"
+    )
+    assert budget["used_percentage"] == 100
+    assert budget["remaining_percentage"] == 0


### PR DESCRIPTION
## Summary

- When `roll_over_amt` creates a negative `budget_total` (prior period overspending exceeds the current budget), `abs()` was treating the negative total as positive and producing a misleading partial percentage
- Fix: when `budget_total <= 0`, immediately set `used_percentage = 100` / `remaining_percentage = 0` so the graph shows fully over-budget (correct red color, empty ring)
- Adds a regression test for the negative rollover case

## Test plan

- [ ] Create a budget with rollover enabled and a prior-period deficit larger than the current budget amount
- [ ] Confirm the progress ring is empty and color is red immediately (not partially filled)
- [ ] Confirm budgets without rollover or with positive rollover are unaffected

🤖 Generated with [Claude Code](https://claude.ai/claude-code)