### PR TITLE
fix: correct budget percentage calculation when rollover produces negative starting balance

### DIFF
--- a/.github/workflows/version-release.yml
+++ b/.github/workflows/version-release.yml
@@ -31,9 +31,6 @@ jobs:
         with:
           node-version: 20
 
-      - name: Install dependencies
-        run: npm install --save-dev semantic-release @semantic-release/changelog @semantic-release/git @semantic-release/exec
-      
       - name: Run Semantic Release
         uses: cycjimmy/semantic-release-action@v4
         with:

--- a/backend/planning/api/views/budget.py
+++ b/backend/planning/api/views/budget.py
@@ -194,9 +194,12 @@ def list_budgets(
             budget_total = budget.amount
             if budget.roll_over:
                 budget_total += budget.roll_over_amt
-            if total:
+            if budget_total <= 0:
+                # Negative rollover already exceeds the budget for this period
+                used_percentage = 100
+            elif total:
                 used_percentage = min(
-                    100, round(abs(total) / abs(budget_total) * 100)
+                    100, round(abs(total) / budget_total * 100)
                 )
             else:
                 used_percentage = 0

--- a/backend/planning/tests/api/test_budget_api.py
+++ b/backend/planning/tests/api/test_budget_api.py
@@ -168,3 +168,35 @@ def test_delete_budget_not_found(api_client):
     response = api_client.delete("/planning/budget/delete/9999", headers=AUTH)
 
     assert response.status_code == 404
+
+
+@pytest.mark.django_db
+@pytest.mark.api
+def test_list_budgets_negative_rollover_is_fully_over(api_client, test_repeat):
+    """When rollover debt exceeds the period budget, used_percentage must be 100."""
+    from planning.models import Budget
+    from django.utils import timezone
+    import pytz
+
+    today = timezone.now().astimezone(pytz.timezone("America/New_York")).date()
+    Budget.objects.create(
+        tag_ids="[]",
+        name="Negative Rollover Budget",
+        amount=100.00,
+        roll_over=True,
+        repeat=test_repeat,
+        start_day=today,
+        roll_over_amt=-150.00,  # overspent $150 last period → budget_total = -$50
+        active=True,
+        widget=True,
+        next_start=today,
+    )
+
+    response = api_client.get("/planning/budget/list", headers=AUTH)
+    assert response.status_code == 200
+
+    budget = next(
+        b for b in response.json() if b["budget"]["name"] == "Negative Rollover Budget"
+    )
+    assert budget["used_percentage"] == 100
+    assert budget["remaining_percentage"] == 0


### PR DESCRIPTION
## Summary
- Fixes budget percentage display when rollover produces a negative starting balance
- Removes redundant `npm install` step from the semantic-release workflow (handled by `cycjimmy/semantic-release-action`)

## Test plan
- [ ] Verify budget percentage shows correctly when rollover amount causes a negative starting balance
- [ ] Confirm semantic-release workflow runs cleanly without the manual install step

🤖 Generated with [Claude Code](https://claude.com/claude-code)