### PR TITLE
ci: restore npm install step for semantic-release plugins

### DIFF
--- a/.github/workflows/version-release.yml
+++ b/.github/workflows/version-release.yml
@@ -31,14 +31,13 @@ jobs:
         with:
           node-version: 20
 
+      - name: Install dependencies
+        run: npm install --save-dev semantic-release @semantic-release/changelog @semantic-release/git @semantic-release/exec
+
       - name: Run Semantic Release
         uses: cycjimmy/semantic-release-action@v4
         with:
           semantic_version: 21.0.2
-          extra_plugins: |
-            @semantic-release/changelog
-            @semantic-release/exec
-            @semantic-release/git
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}
           GH_TOKEN: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
## Summary
- Restores the original `npm install` step that was working before the disk space incident
- Prior fix attempts (#68, #69, #70) all failed — #68 and #69 used the wrong approach, and #70's squash merge was silently a no-op because the net diff of the branch against its original merge base was zero for this file

## Test plan
- [ ] Verify semantic-release workflow completes successfully on alpha after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)