### PR TITLE
ci: sync all workflows to match LenoreTemplate

### DIFF
--- a/.github/workflows/announce_reddit.yml
+++ b/.github/workflows/announce_reddit.yml
@@ -1,6 +1,11 @@
 name: Announce on Reddit
 
 on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to announce (e.g. v1.3.0)"
+        required: true
   release:
     types: [published]
 
@@ -8,14 +13,15 @@ permissions:
   contents: read
 
 env:
-  VERSION: ${{ github.event.release.tag_name }}
-  IS_PRERELEASE: ${{ github.event.release.prerelease }}
+  VERSION: ${{ github.event.release.tag_name || inputs.tag }}
+  IS_PRERELEASE: ${{ github.event.release.prerelease || 'false' }}
 
 jobs:
   reddit:
-   runs-on: self-hosted
+    if: github.repository != 'Novanglus96/LenoreTemplate'
+    runs-on: self-hosted
 
-   steps:
+    steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
@@ -25,7 +31,6 @@ jobs:
           MAJOR=$(echo $VERSION | cut -d. -f1 | sed 's/v//')
           MINOR=$(echo $VERSION | cut -d. -f2)
           PATCH=$(echo $VERSION | cut -d. -f3)
-          # Determine release type
           if [ "$PATCH" = "0" ]; then
             echo "type=release" >> "$GITHUB_OUTPUT"
           else
@@ -34,11 +39,10 @@ jobs:
 
       - name: Skip non-minor/major releases
         if: steps.version_parts.outputs.type != 'release'
-        run: |
-          echo "Not a minor or major release. Skipping Reddit post."
-          exit 0
+        run: echo "Not a minor or major release. Skipping Reddit post."
 
       - name: Get release notes
+        if: steps.version_parts.outputs.type == 'release'
         id: release_notes
         uses: actions/github-script@v7
         with:
@@ -51,8 +55,9 @@ jobs:
             return release.data.body || "No changelog found.";
 
       - name: Post to Reddit
+        if: steps.version_parts.outputs.type == 'release'
         env:
-          COMMIT_TAG: ${{ github.event.release.tag_name }}
+          COMMIT_TAG: ${{ github.event.release.tag_name || inputs.tag }}
           RELEASE_NOTES: ${{ steps.release_notes.outputs.result }}
           REDDIT_CLIENT_ID: ${{ secrets.REDDIT_CLIENT_ID }}
           REDDIT_CLIENT_SECRET: ${{ secrets.REDDIT_CLIENT_SECRET }}

--- a/.github/workflows/build_publish.yml
+++ b/.github/workflows/build_publish.yml
@@ -13,6 +13,7 @@ env:
 
 jobs:
   docker:
+   if: github.repository != 'Novanglus96/LenoreTemplate'
    runs-on: self-hosted
    steps:
       - uses: actions/checkout@v4
@@ -49,10 +50,19 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD}}
-      
+
+      - name: Compute project identifiers
+        shell: bash
+        run: |
+          SLUG="$(echo "${{ github.event.repository.name }}" \
+            | tr '[:upper:]' '[:lower:]')"
+
+          echo "FRONTEND_NAME=${SLUG}_frontend" >> "GITHUB_ENV"
+          echo "BACKEND_NAME=${SLUG}_backend" >> "GITHUB_ENV"
+          echo "WORKER_NAME=${SLUG}_worker" >> "GITHUB_ENV"
+
       - name: Check if Docker tag exists
         env:
-          FRONTEND_NAME: lenorefin_frontend
           DOCKER_HUB_REPO: ${{ secrets.DOCKER_USERNAME }}
         id: docker_tag_check
         run: |
@@ -74,9 +84,6 @@ jobs:
       - name: Publish Docker Images
         if: steps.docker_tag_check.outputs.exists == 'false'
         env:
-          BACKEND_NAME: lenorefin_backend
-          FRONTEND_NAME: lenorefin_frontend
-          WORKER_NAME: lenorefin_worker
           DOCKER_HUB_REPO: ${{ secrets.DOCKER_USERNAME }}
         run: |
           echo "Publishing Docker images to $DOCKER_HUB_REPO..."

--- a/.github/workflows/delete-merged-branches.yml
+++ b/.github/workflows/delete-merged-branches.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   delete-branch:
-    if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true && github.repository != 'Novanglus96/LenoreTemplate'
     runs-on: self-hosted
     steps:
       - name: Delete branch if merged

--- a/.github/workflows/deploy-docs-release.yml
+++ b/.github/workflows/deploy-docs-release.yml
@@ -9,6 +9,7 @@ permissions:
 
 jobs:
   deploy:
+    if: github.repository != 'Novanglus96/LenoreTemplate'
     runs-on: self-hosted
 
     steps:

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   deploy:
+    if: github.repository != 'Novanglus96/LenoreTemplate'
     runs-on: self-hosted
 
     steps:

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,0 +1,31 @@
+name: Lint PR Title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  lint:
+    if: github.repository != 'Novanglus96/LenoreTemplate'
+    runs-on: self-hosted
+    steps:
+      - name: Validate PR title
+        uses: amannn/action-semantic-pull-request@v5
+        with:
+          requireScope: false
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            test
+            chore
+            perf
+            ci
+            build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}

--- a/.github/workflows/version-release.yml
+++ b/.github/workflows/version-release.yml
@@ -15,13 +15,14 @@ permissions:
 
 jobs:
   release:
+    if: github.repository != 'Novanglus96/LenoreTemplate'
     name: Release
     runs-on: self-hosted
     permissions:
-      contents: write # to be able to publish a GitHub release
-      issues: write # to be able to comment on released issues
-      pull-requests: write # to be able to comment on released pull requests
-      id-token: write # to enable use of OIDC for npm provenance
+      contents: write
+      issues: write
+      pull-requests: write
+      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- **Add** `pr-title-lint.yml` — was missing entirely; enforces conventional commit PR titles on all PRs
- **All workflows** — add `if: github.repository != 'Novanglus96/LenoreTemplate'` job guard for template parity
- **`announce_reddit.yml`** — add `workflow_dispatch` with tag input; `inputs.tag` fallback on `VERSION`/`IS_PRERELEASE`/`COMMIT_TAG`; add `if:` guards on get-release-notes and post steps so they're skipped for patch releases; fix indentation; remove spurious `exit 0`
- **`build_publish.yml`** — add "Compute project identifiers" step that dynamically derives image names from repo slug; remove hardcoded `lenorefin_*` names
- **`version-release.yml`** — clean up permission comments; `backend/VERSION` path intentionally kept (differs from template's `scripts/version.txt`)

## Test plan
- [ ] Verify semantic-release still runs cleanly on alpha after merge
- [ ] Confirm pr-title-lint runs on next PR opened

🤖 Generated with [Claude Code](https://claude.com/claude-code)