### PR TITLE
fix: disabling an account no longer wipes open_date

### DIFF
--- a/frontend/src/composables/accountsComposable.js
+++ b/frontend/src/composables/accountsComposable.js
@@ -73,12 +73,15 @@ async function deleteAccountFunction(deletedAccount) {
 }
 
 async function updateAccountFunction(updatedAccount) {
-  const updated = {
-    ...updatedAccount,
-    open_date: formatDateToYYYYMMDD(updatedAccount.open_date),
-    due_date: formatDateToYYYYMMDD(updatedAccount.due_date),
-    next_cycle_date: formatDateToYYYYMMDD(updatedAccount.next_cycle_date),
-  };
+  const updated = { ...updatedAccount };
+  if ("open_date" in updatedAccount)
+    updated.open_date = formatDateToYYYYMMDD(updatedAccount.open_date);
+  if ("due_date" in updatedAccount)
+    updated.due_date = formatDateToYYYYMMDD(updatedAccount.due_date);
+  if ("next_cycle_date" in updatedAccount)
+    updated.next_cycle_date = formatDateToYYYYMMDD(
+      updatedAccount.next_cycle_date,
+    );
   try {
     const response = await apiClient.patch(
       "/accounts/update/" + updatedAccount.id,


### PR DESCRIPTION
## Summary
Fixes a bug where disabling (or re-enabling) an account would clear its `open_date`, `due_date`, and `next_cycle_date` fields.

**Root cause:** `updateAccountFunction` in `accountsComposable.js` always spread all three date fields into the outgoing PATCH payload, converting any missing (`undefined`) field to `null` via `formatDateToYYYYMMDD`. The disable flow only sends `{id, active}`, so all three dates were `undefined` → sent as `null` → applied to the model by `apply_patch`.

**Fix:** Only include a date field in the payload if it was explicitly present in the input object (`'open_date' in updatedAccount`). Partial updates that don't touch dates will no longer send them at all.

## Test plan
- [ ] Disable an account — verify `open_date` is unchanged after disabling
- [ ] Re-enable an account — verify `open_date` is still intact
- [ ] Edit an account with explicit date changes — verify dates still save correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)