### PR TITLE
fix: correct GITHUB_ENV writes in Compute project identifiers step

### DIFF
--- a/.github/workflows/build_publish.yml
+++ b/.github/workflows/build_publish.yml
@@ -57,9 +57,9 @@ jobs:
           SLUG="$(echo "${{ github.event.repository.name }}" \
             | tr '[:upper:]' '[:lower:]')"
 
-          echo "FRONTEND_NAME=${SLUG}_frontend" >> "GITHUB_ENV"
-          echo "BACKEND_NAME=${SLUG}_backend" >> "GITHUB_ENV"
-          echo "WORKER_NAME=${SLUG}_worker" >> "GITHUB_ENV"
+          echo "FRONTEND_NAME=${SLUG}_frontend" >> "$GITHUB_ENV"
+          echo "BACKEND_NAME=${SLUG}_backend" >> "$GITHUB_ENV"
+          echo "WORKER_NAME=${SLUG}_worker" >> "$GITHUB_ENV"
 
       - name: Check if Docker tag exists
         env:


### PR DESCRIPTION
## Summary
Fixes Docker build failure introduced in PR #72. The "Compute project identifiers" step was writing to a literal file named `GITHUB_ENV` in the working directory instead of the GitHub Actions environment file.

**Root cause:** `>> "GITHUB_ENV"` (literal string) instead of `>> "$GITHUB_ENV"` (variable expansion). All other `GITHUB_ENV` writes in the workflow correctly used `$GITHUB_ENV` — this step was the exception. Result: `BACKEND_NAME`, `FRONTEND_NAME`, and `WORKER_NAME` were empty in subsequent steps, causing `docker tag :production` to fail with an invalid reference error.

**Note:** LenoreTemplate has the same bug in its `build_publish.yml` and should be patched separately.

## Test plan
- [ ] Verify Docker build and publish completes successfully on next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)