### PR TITLE
fix: restore csrf=False on auth classes broken by django-ninja 1.6 upgrade

### DIFF
--- a/backend/administration/api/dependencies/auth.py
+++ b/backend/administration/api/dependencies/auth.py
@@ -5,6 +5,9 @@ from ninja.errors import HttpError
 class SessionAuth(NinjaSessionAuth):
     """Requires an authenticated Django session."""
 
+    def __init__(self):
+        super().__init__(csrf=False)
+
     def authenticate(self, request, token):
         if request.user.is_authenticated:
             return request.user
@@ -13,6 +16,9 @@ class SessionAuth(NinjaSessionAuth):
 
 class FullAccessAuth(NinjaSessionAuth):
     """Requires an authenticated session AND membership in the Full Access group."""
+
+    def __init__(self):
+        super().__init__(csrf=False)
 
     def authenticate(self, request, token):
         if not request.user.is_authenticated:


### PR DESCRIPTION
## Summary
Fixes mutation endpoints (clear, edit, create, delete) returning **403 CSRF check Failed** for all authenticated users after the django-ninja 1.6 upgrade.

**Root cause:** In django-ninja 1.6, `SessionAuth` now extends `APIKeyCookie` which defaults to `csrf=True`. The old `NinjaAPI(csrf=False)` was a global bypass removed when we upgraded (the parameter no longer exists). With `csrf=True` as the new default, every cookie-based auth call runs a CSRF check — and since the frontend doesn't send a CSRF token, all mutations failed with 403.

**Fix:** Pass `csrf=False` to `super().__init__()` in both `SessionAuth` and `FullAccessAuth`, restoring the original behaviour.

## Test plan
- [ ] Verify clear/edit/create/delete transactions works as a Full Access user
- [ ] Verify Readonly users still get 403 on mutations (the group check, not CSRF)
- [ ] 411 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)