### PR TITLE
fix: correct CC payment calculation, deduplication, and cache invalidation

### DIFF
--- a/backend/reminders/apps.py
+++ b/backend/reminders/apps.py
@@ -6,4 +6,4 @@ class RemindersConfig(AppConfig):
     name = "reminders"
 
     def ready(self):
-        pass
+        import reminders.signals  # noqa: F401

--- a/backend/reminders/signals.py
+++ b/backend/reminders/signals.py
@@ -26,6 +26,15 @@ def update_reminder_cache_on_delete(sender, instance, **kwargs):
     Remove entries from the reminder scratch table when a Reminder is deleted.
     """
     ReminderCacheTransaction.objects.filter(reminder=instance).delete()
+    async_task(
+        "transactions.tasks.update_cc_forecast_cache",
+        instance.reminder_source_account.id,
+    )
+    if instance.reminder_destination_account is not None:
+        async_task(
+            "transactions.tasks.update_cc_forecast_cache",
+            instance.reminder_destination_account.id,
+        )
 
 
 @receiver(post_save, sender=Reminder)

--- a/backend/transactions/api/views/transaction.py
+++ b/backend/transactions/api/views/transaction.py
@@ -219,15 +219,9 @@ def delete_transaction(request, payload: TransactionList):
     """
 
     try:
-        transactions = Transaction.objects.filter(id__in=payload.transactions)
-        account_ids = set()
+        transactions = list(Transaction.objects.filter(id__in=payload.transactions))
         for t in transactions:
-            account_ids.add(t.source_account_id)
-            if t.destination_account_id:
-                account_ids.add(t.destination_account_id)
-        transactions.delete()
-        for account_id in account_ids:
-            delete_pattern(account_all(account_id))
+            t.delete()
         for transaction in payload.transactions:
             api_logger.info(f"Transaction deleted : #{transaction}")
         return {"success": True}

--- a/backend/transactions/signals.py
+++ b/backend/transactions/signals.py
@@ -1,83 +1,25 @@
 from django.db.models.signals import post_save, post_delete
 from django.dispatch import receiver
 from transactions.models import Transaction
-from django_q.tasks import async_task
 from core.cache.helpers import delete_pattern
-from core.cache.keys import (
-    account_financials,
-    account_real_transactions,
-    account_all_balances,
-    account_combined_transactions,
-)
+from core.cache.keys import account_all
+
+
+def _refresh_account(account_id):
+    from transactions.tasks import update_cc_forecast_cache
+    delete_pattern(account_all(account_id))
+    update_cc_forecast_cache(account_id)
 
 
 @receiver(post_save, sender=Transaction)
 def update_forecast_cache_on_save(sender, instance, **kwargs):
-    """
-    Update the reminder scratch/cache table when a Reminder is created or updated.
-    """
-    async_task(
-        "transactions.tasks.update_cc_forecast_cache",
-        instance.source_account.id,
-    )
-    if instance.destination_account is not None:
-        async_task(
-            "transactions.tasks.update_cc_forecast_cache",
-            instance.destination_account.id,
-        )
+    _refresh_account(instance.source_account_id)
+    if instance.destination_account_id is not None:
+        _refresh_account(instance.destination_account_id)
 
 
 @receiver(post_delete, sender=Transaction)
 def update_forecast_cache_on_delete(sender, instance, **kwargs):
-    """
-    Remove entries from the reminder scratch table when a Reminder is deleted.
-    """
-    async_task(
-        "transactions.tasks.update_cc_forecast_cache",
-        instance.source_account.id,
-    )
-    if instance.destination_account is not None:
-        async_task(
-            "transactions.tasks.update_cc_forecast_cache",
-            instance.destination_account.id,
-        )
-
-
-@receiver(post_save, sender=Transaction)
-def invalidate_cache_on_save(sender, instance, **kwargs):
-    """
-    Update the reminder scratch/cache table when a Reminder is created or updated.
-    """
-    delete_pattern(account_combined_transactions(instance.source_account.id))
-    delete_pattern(account_all_balances(instance.source_account.id))
-    delete_pattern(account_financials(instance.source_account.id))
-    delete_pattern(account_real_transactions(instance.source_account.id))
-    if instance.destination_account is not None:
-        delete_pattern(
-            account_combined_transactions(instance.destination_account.id)
-        )
-        delete_pattern(account_all_balances(instance.destination_account.id))
-        delete_pattern(account_financials(instance.destination_account.id))
-        delete_pattern(
-            account_real_transactions(instance.destination_account.id)
-        )
-
-
-@receiver(post_delete, sender=Transaction)
-def invalidate_cache_on_delete(sender, instance, **kwargs):
-    """
-    Remove entries from the reminder scratch table when a Reminder is deleted.
-    """
-    delete_pattern(account_combined_transactions(instance.source_account.id))
-    delete_pattern(account_all_balances(instance.source_account.id))
-    delete_pattern(account_financials(instance.source_account.id))
-    delete_pattern(account_real_transactions(instance.source_account.id))
-    if instance.destination_account is not None:
-        delete_pattern(
-            account_combined_transactions(instance.destination_account.id)
-        )
-        delete_pattern(account_all_balances(instance.destination_account.id))
-        delete_pattern(account_financials(instance.destination_account.id))
-        delete_pattern(
-            account_real_transactions(instance.destination_account.id)
-        )
+    _refresh_account(instance.source_account_id)
+    if instance.destination_account_id is not None:
+        _refresh_account(instance.destination_account_id)

--- a/backend/transactions/tasks.py
+++ b/backend/transactions/tasks.py
@@ -66,6 +66,7 @@ from transactions.api.dependencies.get_transactions_by_tag import (
 from typing import Optional
 from decimal import Decimal, ROUND_HALF_UP
 from core.cache.helpers import delete_pattern
+from core.cache.keys import account_all_transactions
 import logging
 
 api_logger = logging.getLogger("api")
@@ -752,17 +753,11 @@ def update_reminder_cache(reminder_id):
                     )
 
         create_transactions(transactions_to_create, "reminder")
-        pattern = f"*account_{reminder.reminder_source_account.id}_reminder_transactions*"
-        delete_pattern(pattern)
-        pattern = (
-            f"*account_{reminder.reminder_source_account.id}_transactions*"
-        )
-        delete_pattern(pattern)
+        delete_pattern(account_all_transactions(reminder.reminder_source_account.id))
+        update_cc_forecast_cache(reminder.reminder_source_account.id)
         if reminder.reminder_destination_account is not None:
-            pattern = f"*account_{reminder.reminder_destination_account.id}_reminder_transactions*"
-            delete_pattern(pattern)
-            pattern = f"*account_{reminder.reminder_destination_account.id}_transactions*"
-            delete_pattern(pattern)
+            delete_pattern(account_all_transactions(reminder.reminder_destination_account.id))
+            update_cc_forecast_cache(reminder.reminder_destination_account.id)
     except Exception as e:
         task_logger.warning("There was an error creating cache")
         error_logger.warning(f"{str(e)}")
@@ -783,7 +778,7 @@ def update_cc_forecast_cache(account_id):
         account = Account.objects.get(id=account_id)
 
         # Exit if not cc account
-        if account.account_type.id != 1:
+        if account.account_type.slug != 'credit-card':
             return
 
         # Delete any existing cache entries for this reminder
@@ -935,42 +930,60 @@ def update_cc_forecast_cache(account_id):
                     else:
                         cycle_payment = abs(cycle_balance) + abs(cycle_interest)
                 if cycle["statement_due"] > today:
-                    tags = []
-                    tag_obj = CustomTag(
-                        tag_name="Credit Card",
-                        tag_amount=abs(cycle_payment),
-                        tag_id=9,
-                        tag_full_toggle=True,
+                    next_statement_end = increment_date(
+                        cycle["statement_end"], statement_cycle_period, statement_cycle_length
                     )
-                    tags.append(tag_obj)
-                    transaction = FullTransaction(
-                        transaction_date=cycle["statement_pay_day"],
-                        total_amount=abs(cycle_payment),
-                        status_id=status.id,
-                        memo=None,
-                        description=f"({account.account_name} Estimated Payment)",
-                        edit_date=today,
-                        add_date=today,
-                        transaction_type_id=transfer_type_id,
-                        paycheck_id=None,
+                    payment_window_filter = dict(
                         source_account_id=funding_account.id,
                         destination_account_id=account_id,
-                        tags=tags,
-                        checkNumber=None,
+                        transaction_type_id=transfer_type_id,
+                        transaction_date__gt=cycle["statement_end"],
+                        transaction_date__lte=next_statement_end,
                     )
-                    transactions_to_create.append(transaction)
-                    total_payments += cycle_payment
-                    temp_id -= 1
+                    existing_payment_sum = (
+                        transactions_qs.filter(**payment_window_filter)
+                        .aggregate(sum=Sum("pretty_total"))["sum"]
+                        or Decimal(0)
+                    ) + (
+                        reminder_cache_qs.filter(**payment_window_filter)
+                        .aggregate(sum=Sum("pretty_total"))["sum"]
+                        or Decimal(0)
+                    )
+                    remaining_payment = cycle_payment - existing_payment_sum
+                    if remaining_payment > 0:
+                        tags = []
+                        tag_obj = CustomTag(
+                            tag_name="Credit Card",
+                            tag_amount=abs(remaining_payment),
+                            tag_id=9,
+                            tag_full_toggle=True,
+                        )
+                        tags.append(tag_obj)
+                        transaction = FullTransaction(
+                            transaction_date=cycle["statement_pay_day"],
+                            total_amount=abs(remaining_payment),
+                            status_id=status.id,
+                            memo=None,
+                            description=f"({account.account_name} Estimated Payment)",
+                            edit_date=today,
+                            add_date=today,
+                            transaction_type_id=transfer_type_id,
+                            paycheck_id=None,
+                            source_account_id=funding_account.id,
+                            destination_account_id=account_id,
+                            tags=tags,
+                            checkNumber=None,
+                        )
+                        transactions_to_create.append(transaction)
+                        total_payments += remaining_payment
+                        temp_id -= 1
             if x == 0:
                 account.last_statement_amount = cycle_payment
                 account.save()
             x += 1
 
         create_transactions(transactions_to_create, "forecast")
-        pattern = f"*account_{account_id}_forecast_transactions*"
-        delete_pattern(pattern)
-        pattern = f"*account_{account_id}_transactions*"
-        delete_pattern(pattern)
+        delete_pattern(account_all_transactions(account_id))
     except Exception as e:
         api_logger.warning("There was an error creating cache")
         error_logger.warning(f"{str(e)}")

--- a/backend/transactions/tests/unit/test_transaction_signals.py
+++ b/backend/transactions/tests/unit/test_transaction_signals.py
@@ -2,151 +2,65 @@ import pytest
 from unittest.mock import patch, call
 from django.core.files.uploadedfile import SimpleUploadedFile
 from transactions.models import TransactionImage
-from core.cache.keys import (
-    account_financials,
-    account_real_transactions,
-    account_all_balances,
-    account_combined_transactions,
-)
+from core.cache.keys import account_all
 
 
 @pytest.mark.django_db
-@patch("transactions.signals.async_task")
-def test_transaction_save_triggers_source_account_forecast_update(
-    mock_async_task, test_transaction
+@patch("transactions.signals._refresh_account")
+def test_transaction_save_triggers_source_account_refresh(
+    mock_refresh, test_transaction
 ):
     test_transaction.destination_account = None
     test_transaction.save()
 
-    mock_async_task.assert_called_once_with(
-        "transactions.tasks.update_cc_forecast_cache",
-        test_transaction.source_account.id,
-    )
+    mock_refresh.assert_called_once_with(test_transaction.source_account_id)
 
 
 @pytest.mark.django_db
-@patch("transactions.signals.async_task")
-def test_transaction_save_triggers_both_account_forecast_updates(
-    mock_async_task, test_transaction, test_savings_account
+@patch("transactions.signals._refresh_account")
+def test_transaction_save_triggers_both_account_refreshes(
+    mock_refresh, test_transaction, test_savings_account
 ):
     test_transaction.destination_account = test_savings_account
     test_transaction.save()
 
     expected_calls = [
-        call(
-            "transactions.tasks.update_cc_forecast_cache",
-            test_transaction.source_account.id,
-        ),
-        call(
-            "transactions.tasks.update_cc_forecast_cache",
-            test_transaction.destination_account.id,
-        ),
+        call(test_transaction.source_account_id),
+        call(test_transaction.destination_account_id),
     ]
-
-    mock_async_task.assert_has_calls(expected_calls, any_order=True)
-    assert mock_async_task.call_count == 2
+    mock_refresh.assert_has_calls(expected_calls, any_order=True)
+    assert mock_refresh.call_count == 2
 
 
 @pytest.mark.django_db
-@patch("transactions.signals.async_task")
-def test_transaction_delete_triggers_both_account_forecast_updates(
-    mock_async_task, test_transaction, test_savings_account
+@patch("transactions.signals._refresh_account")
+def test_transaction_delete_triggers_both_account_refreshes(
+    mock_refresh, test_transaction, test_savings_account
 ):
     test_transaction.destination_account = test_savings_account
     test_transaction.save()
 
-    source_id = test_transaction.source_account.id
-    dest_id = test_transaction.destination_account.id
-    mock_async_task.reset_mock()
+    source_id = test_transaction.source_account_id
+    dest_id = test_transaction.destination_account_id
+    mock_refresh.reset_mock()
     test_transaction.delete()
 
-    expected_calls = [
-        call("transactions.tasks.update_cc_forecast_cache", source_id),
-        call("transactions.tasks.update_cc_forecast_cache", dest_id),
-    ]
-
-    mock_async_task.assert_has_calls(expected_calls, any_order=True)
-    assert mock_async_task.call_count == 2
+    expected_calls = [call(source_id), call(dest_id)]
+    mock_refresh.assert_has_calls(expected_calls, any_order=True)
+    assert mock_refresh.call_count == 2
 
 
 @pytest.mark.django_db
+@patch("transactions.tasks.update_cc_forecast_cache")
 @patch("transactions.signals.delete_pattern")
-def test_transaction_save_invalidates_source_cache_only(
-    mock_delete_pattern, test_transaction
+def test_refresh_account_clears_cache_then_recalculates(
+    mock_delete, mock_forecast, test_transaction
 ):
-    test_transaction.destination_account = None
-    test_transaction.save()
+    from transactions.signals import _refresh_account
+    _refresh_account(test_transaction.source_account_id)
 
-    expected_calls = [
-        call(account_combined_transactions(test_transaction.source_account.id)),
-        call(account_all_balances(test_transaction.source_account.id)),
-        call(account_financials(test_transaction.source_account.id)),
-        call(account_real_transactions(test_transaction.source_account.id)),
-    ]
-
-    mock_delete_pattern.assert_has_calls(
-        expected_calls,
-        any_order=True,
-    )
-
-    assert mock_delete_pattern.call_count == 4
-
-
-@pytest.mark.django_db
-@patch("transactions.signals.delete_pattern")
-def test_transaction_save_invalidates_both_account_caches(
-    mock_delete_pattern, test_transaction, test_savings_account
-):
-    test_transaction.destination_account = test_savings_account
-    test_transaction.save()
-
-    expected_calls = [
-        call(account_combined_transactions(test_transaction.source_account.id)),
-        call(account_all_balances(test_transaction.source_account.id)),
-        call(account_financials(test_transaction.source_account.id)),
-        call(account_real_transactions(test_transaction.source_account.id)),
-        call(
-            account_combined_transactions(
-                test_transaction.destination_account.id
-            )
-        ),
-        call(account_all_balances(test_transaction.destination_account.id)),
-        call(account_financials(test_transaction.destination_account.id)),
-        call(
-            account_real_transactions(test_transaction.destination_account.id)
-        ),
-    ]
-
-    mock_delete_pattern.assert_has_calls(expected_calls, any_order=True)
-    assert mock_delete_pattern.call_count == 8
-
-
-@pytest.mark.django_db
-@patch("transactions.signals.delete_pattern")
-def test_transaction_delete_invalidates_both_account_caches(
-    mock_delete_pattern, test_transaction, test_savings_account
-):
-    test_transaction.destination_account = test_savings_account
-    test_transaction.save()
-
-    source_id = test_transaction.source_account.id
-    dest_id = test_transaction.destination_account.id
-    mock_delete_pattern.reset_mock()
-    test_transaction.delete()
-
-    expected_calls = [
-        call(account_combined_transactions(source_id)),
-        call(account_all_balances(source_id)),
-        call(account_financials(source_id)),
-        call(account_real_transactions(source_id)),
-        call(account_combined_transactions(dest_id)),
-        call(account_all_balances(dest_id)),
-        call(account_financials(dest_id)),
-        call(account_real_transactions(dest_id)),
-    ]
-
-    mock_delete_pattern.assert_has_calls(expected_calls, any_order=True)
-    assert mock_delete_pattern.call_count == 8
+    mock_delete.assert_called_once_with(account_all(test_transaction.source_account_id))
+    mock_forecast.assert_called_once_with(test_transaction.source_account_id)
 
 
 @pytest.mark.django_db
@@ -163,5 +77,4 @@ def test_transaction_image_file_is_deleted_on_model_delete(test_transaction, tmp
         transaction=test_transaction,
     )
 
-    # no mocking needed — just ensure delete doesn't explode
     image.delete()


### PR DESCRIPTION
## Summary

- **CC account type check**: replaced hardcoded PK `id != 1` with `slug != 'credit-card'`
- **Payment deduplication**: switched from `.exists()` to summing existing payments so a partial or $0 scheduled reminder payment generates a forecast for the remaining shortfall instead of suppressing it entirely
- **Transaction delete**: changed queryset `.delete()` to per-instance `.delete()` so `post_delete` signals fire correctly
- **Signal timing fix**: `update_cc_forecast_cache` is now called synchronously in transaction signals (same pattern as `update_reminder_cache`), ensuring forecast DB records are rebuilt before the response returns — eliminating the window where the frontend could read stale forecast data
- **Reminder signals registered**: `reminders/apps.py` was calling `pass` in `ready()`, so all reminder signals were silently never connected; CC recalc, cache invalidation, and reminder cache cleanup on save/delete were all dead code
- **Reminder → CC recalc**: `update_reminder_cache` now calls `update_cc_forecast_cache` after rebuilding entries; reminder delete signal now queues CC recalc
- **Cache key bug**: `update_cc_forecast_cache` and `update_reminder_cache` were clearing patterns with underscores (`account_123_transactions`) but all cache keys use colons (`account:123:transactions`) — replaced with `account_all_transactions()` key function

## Test plan

- [ ] Delete a manual CC payment → virtual estimated payment appears in transaction list immediately
- [ ] Delete a reminder → reminder transactions removed from list and CC forecast recalculates
- [ ] Add/edit a reminder with a future expense on a CC account → forecast payment appears for that statement
- [ ] Scheduled reminder payment covers full balance → no duplicate forecast payment generated
- [ ] Scheduled reminder payment covers partial balance → forecast generated for the shortfall only
- [ ] $0 scheduled reminder payment → full forecast payment still generated
- [ ] All 421 backend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)