### PR TITLE
ci: add --update-aliases to mike alias in release docs deploy workflow

### DIFF
--- a/.github/workflows/deploy-docs-release.yml
+++ b/.github/workflows/deploy-docs-release.yml
@@ -46,5 +46,5 @@ jobs:
           mike deploy "$MAJOR_MINOR" --push --update-aliases --config-file backend/mkdocs.yml
 
           if [[ "${{ github.event.release.prerelease }}" != "true" ]]; then
-            mike alias "$MAJOR_MINOR" latest --push --config-file backend/mkdocs.yml
+            mike alias "$MAJOR_MINOR" latest --push --update-aliases --config-file backend/mkdocs.yml
           fi


### PR DESCRIPTION
## Summary

- `mike alias` was missing `--update-aliases`, causing `alias 'latest' already exists` on every release after the first

## Test plan

- [ ] Merge and re-run the Deploy MkDocs (Release) workflow for v1.3.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)