### PR TITLE
ci: add workflow_dispatch to deploy-docs-release for manual runs

### DIFF
--- a/.github/workflows/deploy-docs-release.yml
+++ b/.github/workflows/deploy-docs-release.yml
@@ -3,6 +3,15 @@ name: Deploy MkDocs (Release)
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: "Release tag to deploy docs for (e.g. v1.3.0)"
+        required: true
+      prerelease:
+        description: "Is this a pre-release? (true/false)"
+        required: false
+        default: "false"
 
 permissions:
   contents: write
@@ -16,7 +25,7 @@ jobs:
       - name: Checkout release tag
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ github.event.release.tag_name || inputs.tag_name }}
           fetch-depth: 0
 
       - name: Set up Python
@@ -38,13 +47,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}
         run: |
-          VERSION=${{ github.event.release.tag_name }}
+          VERSION=${{ github.event.release.tag_name || inputs.tag_name }}
           VERSION=${VERSION#v}
 
           MAJOR_MINOR=$(echo "$VERSION" | cut -d. -f1,2)
 
+          IS_PRERELEASE=${{ github.event.release.prerelease || inputs.prerelease }}
+
           mike deploy "$MAJOR_MINOR" --push --update-aliases --config-file backend/mkdocs.yml
 
-          if [[ "${{ github.event.release.prerelease }}" != "true" ]]; then
+          if [[ "$IS_PRERELEASE" != "true" ]]; then
             mike alias "$MAJOR_MINOR" latest --push --update-aliases --config-file backend/mkdocs.yml
           fi


### PR DESCRIPTION
## Summary

- Adds `workflow_dispatch` trigger with `tag_name` and `prerelease` inputs so the docs deploy can be run manually without needing to re-publish a release
- Keeps the `--update-aliases` fix for `mike alias` so future releases don't fail
- Also updates LenoreTemplate copy

## Test plan

- [ ] Merge and manually trigger Deploy MkDocs (Release) with `tag_name: v1.3.0` to fix the pending v1.3.0 docs deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)