### PR TITLE
feat: add custom JSON backup/restore system with scheduled automation

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -86,6 +86,9 @@ COPY . $APP_HOME
 # chown all the files to the app user
 RUN chown -R app:app $APP_HOME
 
+# create backups directory owned by app user so the volume initialises correctly
+RUN mkdir -p /backups && chown app:app /backups
+
 # change to the app user
 USER app
 

--- a/backend/administration/api/routers/backup.py
+++ b/backend/administration/api/routers/backup.py
@@ -1,0 +1,5 @@
+from ninja import Router
+from administration.api.views.backup import backup_router
+
+router = Router()
+router.add_router("/", backup_router)

--- a/backend/administration/api/schemas/backup.py
+++ b/backend/administration/api/schemas/backup.py
@@ -1,0 +1,25 @@
+from ninja import Schema
+from typing import Optional
+from datetime import datetime
+
+
+class BackupConfigOut(Schema):
+    id: int
+    backup_enabled: bool
+    frequency: str
+    backup_time: str
+    copies_to_keep: int
+
+
+class BackupConfigIn(Schema):
+    backup_enabled: Optional[bool] = None
+    frequency: Optional[str] = None
+    backup_time: Optional[str] = None
+    copies_to_keep: Optional[int] = None
+
+
+class BackupFileOut(Schema):
+    filename: str
+    size: int
+    created_at: datetime
+    backup_type: str

--- a/backend/administration/api/views/backup.py
+++ b/backend/administration/api/views/backup.py
@@ -1,0 +1,203 @@
+from ninja import Router, UploadedFile, File
+from ninja.errors import HttpError
+from administration.models import BackupConfig
+from administration.api.schemas.backup import BackupConfigOut, BackupConfigIn, BackupFileOut
+from administration.api.dependencies.auth import FullAccessAuth
+from django.conf import settings
+from django.core.management import call_command
+from django.http import FileResponse
+from typing import List
+from datetime import datetime
+import os
+import logging
+import tempfile
+
+api_logger = logging.getLogger("api")
+error_logger = logging.getLogger("error")
+
+backup_router = Router(tags=["Backup"])
+
+
+def _backup_location():
+    return settings.DBBACKUP_STORAGE_OPTIONS.get("location", "/backups/")
+
+
+def _list_backup_files():
+    location = _backup_location()
+    if not os.path.exists(location):
+        return []
+    files = []
+    for filename in os.listdir(location):
+        filepath = os.path.join(location, filename)
+        if not os.path.isfile(filepath):
+            continue
+        if not (filename.endswith(".json.gz") or filename.endswith(".json")):
+            continue
+        stat = os.stat(filepath)
+        files.append(
+            BackupFileOut(
+                filename=filename,
+                size=stat.st_size,
+                created_at=datetime.fromtimestamp(stat.st_mtime),
+                backup_type="database",
+            )
+        )
+    files.sort(key=lambda f: f.created_at, reverse=True)
+    return files
+
+
+@backup_router.get("/config", response=BackupConfigOut)
+def get_backup_config(request):
+    try:
+        config = BackupConfig.load()
+        return config
+    except Exception as e:
+        error_logger.exception(f"Error retrieving backup config: {e}")
+        raise HttpError(500, "Error retrieving backup config")
+
+
+@backup_router.patch("/config", response=BackupConfigOut, auth=FullAccessAuth())
+def update_backup_config(request, payload: BackupConfigIn):
+    try:
+        config = BackupConfig.load()
+        for attr, value in payload.dict(exclude_none=True).items():
+            setattr(config, attr, value)
+        config.save()
+        _reschedule_backup(config)
+        return config
+    except Exception as e:
+        error_logger.exception(f"Error updating backup config: {e}")
+        raise HttpError(500, "Error updating backup config")
+
+
+@backup_router.get("/files", response=List[BackupFileOut])
+def list_backups(request):
+    try:
+        return _list_backup_files()
+    except Exception as e:
+        error_logger.exception(f"Error listing backups: {e}")
+        raise HttpError(500, "Error listing backups")
+
+
+@backup_router.post("/run", auth=FullAccessAuth())
+def run_backup(request):
+    try:
+        from django_q.tasks import async_task
+        async_task("transactions.tasks.create_backup")
+        api_logger.info("Manual backup triggered")
+        return {"success": True}
+    except Exception as e:
+        error_logger.exception(f"Error triggering backup: {e}")
+        raise HttpError(500, "Error triggering backup")
+
+
+@backup_router.get("/files/{filename}/download")
+def download_backup(request, filename: str):
+    try:
+        location = _backup_location()
+        filepath = os.path.join(location, filename)
+        if not os.path.exists(filepath):
+            raise HttpError(404, "Backup file not found")
+        # Prevent path traversal
+        if not os.path.abspath(filepath).startswith(os.path.abspath(location)):
+            raise HttpError(400, "Invalid filename")
+        return FileResponse(open(filepath, "rb"), as_attachment=True, filename=filename)
+    except HttpError:
+        raise
+    except Exception as e:
+        error_logger.exception(f"Error downloading backup {filename}: {e}")
+        raise HttpError(500, "Error downloading backup")
+
+
+@backup_router.delete("/files/{filename}", auth=FullAccessAuth())
+def delete_backup(request, filename: str):
+    try:
+        location = _backup_location()
+        filepath = os.path.join(location, filename)
+        if not os.path.exists(filepath):
+            raise HttpError(404, "Backup file not found")
+        if not os.path.abspath(filepath).startswith(os.path.abspath(location)):
+            raise HttpError(400, "Invalid filename")
+        os.remove(filepath)
+        api_logger.info(f"Backup deleted: {filename}")
+        return {"success": True}
+    except HttpError:
+        raise
+    except Exception as e:
+        error_logger.exception(f"Error deleting backup {filename}: {e}")
+        raise HttpError(500, "Error deleting backup")
+
+
+@backup_router.post("/restore/database", auth=FullAccessAuth())
+def restore_database(request, filename: str):
+    try:
+        location = _backup_location()
+        filepath = os.path.join(location, filename)
+        if not os.path.exists(filepath):
+            raise HttpError(404, "Backup file not found")
+        if not os.path.abspath(filepath).startswith(os.path.abspath(location)):
+            raise HttpError(400, "Invalid filename")
+        call_command("import_user_data", filepath)
+        api_logger.info(f"Database restored from: {filename}")
+        return {"success": True}
+    except HttpError:
+        raise
+    except Exception as e:
+        error_logger.exception(f"Error restoring database from {filename}: {e}")
+        raise HttpError(500, f"Restore failed: {str(e)}")
+
+
+@backup_router.post("/restore/upload", auth=FullAccessAuth())
+def restore_from_upload(request, file: UploadedFile = File(...)):
+    try:
+        name = file.name or "upload.json.gz"
+        suffix = ".json.gz" if name.endswith(".json.gz") else os.path.splitext(name)[1] or ".json.gz"
+        with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
+            for chunk in file.chunks():
+                tmp.write(chunk)
+            tmp_path = tmp.name
+        try:
+            call_command("import_user_data", tmp_path)
+            api_logger.info(f"Database restored from uploaded file: {file.name}")
+            return {"success": True}
+        finally:
+            os.unlink(tmp_path)
+    except HttpError:
+        raise
+    except Exception as e:
+        error_logger.exception(f"Error restoring from upload: {e}")
+        raise HttpError(500, f"Restore failed: {str(e)}")
+
+
+def _reschedule_backup(config):
+    from django_q.models import Schedule
+    from django.utils import timezone
+    import pytz
+    from datetime import timedelta
+
+    tz = pytz.timezone(os.environ.get("TIMEZONE", "UTC"))
+    today = timezone.now().astimezone(tz).date()
+    tomorrow = today + timedelta(days=1)
+    current_timezone = timezone.get_current_timezone()
+
+    schedule_map = {
+        "HOURLY": Schedule.HOURLY,
+        "DAILY": Schedule.DAILY,
+        "WEEKLY": Schedule.WEEKLY,
+    }
+
+    start_date = today if config.frequency == "HOURLY" else tomorrow
+    next_run = datetime.combine(
+        start_date, datetime.strptime(config.backup_time, "%H:%M").time()
+    )
+    next_run = tz.localize(next_run).astimezone(current_timezone)
+
+    Schedule.objects.update_or_create(
+        name="Backup Database",
+        defaults={
+            "func": "transactions.tasks.create_backup",
+            "args": "",
+            "schedule_type": schedule_map.get(config.frequency, Schedule.DAILY),
+            "next_run": next_run,
+        },
+    )

--- a/backend/administration/management/commands/export_user_data.py
+++ b/backend/administration/management/commands/export_user_data.py
@@ -1,0 +1,340 @@
+import gzip
+import json
+import os
+from datetime import datetime
+from django.core.management.base import BaseCommand
+from django.conf import settings
+
+
+class Command(BaseCommand):
+    help = "Export user data to a version-agnostic gzipped JSON backup"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--output",
+            type=str,
+            default=None,
+            help="Output file path. Defaults to <backup_location>/lenorefin-backup-YYYY-MM-DD-HHMMSS.json.gz",
+        )
+
+    def handle(self, *args, **options):
+        output = options["output"]
+        if output is None:
+            location = settings.DBBACKUP_STORAGE_OPTIONS.get("location", "/backups/")
+            os.makedirs(location, exist_ok=True)
+            timestamp = datetime.now().strftime("%Y-%m-%d-%H%M%S")
+            output = os.path.join(location, f"lenorefin-backup-{timestamp}.json.gz")
+
+        data = self._collect_data()
+
+        json_bytes = json.dumps(data, indent=2, default=str).encode("utf-8")
+        with gzip.open(output, "wb") as f:
+            f.write(json_bytes)
+
+        self.stdout.write(self.style.SUCCESS(f"Backup written to: {output}"))
+        return output
+
+    def _collect_data(self):
+        from administration.models import Payee, DescriptionHistory, Option, BackupConfig
+        from accounts.models import Bank, Account, Reward
+        from tags.models import Tag, MainTag, SubTag
+        from transactions.models import Transaction, Paycheck, TransactionDetail
+        from reminders.models import Reminder, ReminderExclusion
+        from planning.models import ContribRule, Contribution, Note, ChristmasGift, Budget, CalculationRule
+
+        data = {}
+
+        # Build helper maps for converting PKs to natural keys
+        all_tags = list(Tag.objects.all().select_related("parent", "child", "tag_type"))
+        tag_pk_to_slug = {t.pk: t.slug for t in all_tags}
+        account_pk_to_name = {a.pk: a.account_name for a in Account.objects.all()}
+
+        def convert_id_json_array(id_str, pk_to_key):
+            """Convert a JSON array of PKs stored as a string to a JSON array of natural keys."""
+            if not id_str:
+                return id_str
+            try:
+                pk_list = json.loads(id_str)
+                if not isinstance(pk_list, list):
+                    return id_str
+                return json.dumps([pk_to_key.get(pk, pk) for pk in pk_list])
+            except (json.JSONDecodeError, TypeError):
+                return id_str
+
+        # 1. Payees
+        data["payees"] = [
+            {"payee_name": p.payee_name}
+            for p in Payee.objects.all()
+        ]
+
+        # 2. Banks
+        data["banks"] = [
+            {"bank_name": b.bank_name}
+            for b in Bank.objects.all()
+        ]
+
+        # 3. MainTags (user-created only)
+        data["main_tags"] = [
+            {
+                "slug": mt.slug,
+                "tag_name": mt.tag_name,
+                "tag_type_slug": mt.tag_type.slug if mt.tag_type else None,
+            }
+            for mt in MainTag.objects.filter(is_system=False).select_related("tag_type")
+        ]
+
+        # 4. SubTags (user-created only)
+        data["sub_tags"] = [
+            {
+                "slug": st.slug,
+                "tag_name": st.tag_name,
+                "tag_type_slug": st.tag_type.slug if st.tag_type else None,
+            }
+            for st in SubTag.objects.filter(is_system=False).select_related("tag_type")
+        ]
+
+        # 5. Tags (user-created only)
+        data["tags"] = [
+            {
+                "slug": t.slug,
+                "parent_slug": t.parent.slug if t.parent else None,
+                "child_slug": t.child.slug if t.child else None,
+                "tag_type_slug": t.tag_type.slug if t.tag_type else None,
+            }
+            for t in Tag.objects.filter(is_system=False).select_related("parent", "child", "tag_type")
+        ]
+
+        # 6. Accounts
+        data["accounts"] = [
+            {
+                "account_name": a.account_name,
+                "account_type_slug": a.account_type.slug if a.account_type else None,
+                "opening_balance": str(a.opening_balance),
+                "annual_rate": str(a.annual_rate) if a.annual_rate is not None else None,
+                "active": a.active,
+                "open_date": str(a.open_date) if a.open_date else None,
+                "statement_cycle_length": a.statement_cycle_length,
+                "statement_cycle_period": a.statement_cycle_period,
+                "credit_limit": str(a.credit_limit) if a.credit_limit is not None else None,
+                "bank_name": a.bank.bank_name,
+                "statement_balance": str(a.statement_balance) if a.statement_balance is not None else None,
+                "archive_balance": str(a.archive_balance) if a.archive_balance is not None else None,
+                "funding_account_name": a.funding_account.account_name if a.funding_account else None,
+                "calculate_payments": a.calculate_payments,
+                "calculate_interest": a.calculate_interest,
+                "payment_strategy": a.payment_strategy,
+                "payment_amount": str(a.payment_amount) if a.payment_amount is not None else None,
+                "minimum_payment_amount": str(a.minimum_payment_amount) if a.minimum_payment_amount is not None else None,
+                "statement_day": a.statement_day,
+                "due_day": a.due_day,
+                "pay_day": a.pay_day,
+                "interest_deposit_day": a.interest_deposit_day,
+            }
+            for a in Account.objects.all().select_related("account_type", "bank", "funding_account")
+        ]
+
+        # 7. DescriptionHistory
+        data["description_history"] = [
+            {
+                "description_normalized": dh.description_normalized,
+                "description_pretty": dh.description_pretty,
+                "tag_slug": dh.tag.slug if dh.tag else None,
+            }
+            for dh in DescriptionHistory.objects.all().select_related("tag")
+        ]
+
+        # 8. Rewards
+        data["rewards"] = [
+            {
+                "reward_date": str(r.reward_date),
+                "reward_amount": str(r.reward_amount),
+                "account_name": r.reward_account.account_name,
+            }
+            for r in Reward.objects.all().select_related("reward_account")
+        ]
+
+        # 9. Paychecks
+        data["paychecks"] = [
+            {
+                "_id": p.id,
+                "gross": str(p.gross),
+                "net": str(p.net),
+                "taxes": str(p.taxes),
+                "health": str(p.health),
+                "pension": str(p.pension),
+                "fsa": str(p.fsa),
+                "dca": str(p.dca),
+                "union_dues": str(p.union_dues),
+                "four_fifty_seven_b": str(p.four_fifty_seven_b),
+                "payee_name": p.payee.payee_name if p.payee else None,
+            }
+            for p in Paycheck.objects.all().select_related("payee")
+        ]
+
+        # 10. Transactions
+        data["transactions"] = [
+            {
+                "_id": t.id,
+                "transaction_date": str(t.transaction_date),
+                "total_amount": str(t.total_amount),
+                "status_slug": t.status.slug if t.status else None,
+                "memo": t.memo,
+                "description": t.description,
+                "edit_date": str(t.edit_date),
+                "add_date": str(t.add_date),
+                "transaction_type_slug": t.transaction_type.slug if t.transaction_type else None,
+                "paycheck_id": t.paycheck_id,
+                "checkNumber": t.checkNumber,
+                "source_account_name": t.source_account.account_name if t.source_account else None,
+                "destination_account_name": t.destination_account.account_name if t.destination_account else None,
+            }
+            for t in Transaction.objects.all().select_related(
+                "status", "transaction_type", "paycheck",
+                "source_account", "destination_account"
+            )
+        ]
+
+        # 11. TransactionDetails
+        data["transaction_details"] = [
+            {
+                "transaction_id": td.transaction_id,
+                "detail_amt": str(td.detail_amt),
+                "tag_slug": td.tag.slug if td.tag else None,
+            }
+            for td in TransactionDetail.objects.all().select_related("tag")
+        ]
+
+        # 12. Reminders
+        data["reminders"] = [
+            {
+                "_id": r.id,
+                "tag_slug": r.tag.slug if r.tag else None,
+                "amount": str(r.amount),
+                "source_account_name": r.reminder_source_account.account_name if r.reminder_source_account else None,
+                "destination_account_name": r.reminder_destination_account.account_name if r.reminder_destination_account else None,
+                "description": r.description,
+                "transaction_type_slug": r.transaction_type.slug if r.transaction_type else None,
+                "start_date": str(r.start_date),
+                "next_date": str(r.next_date) if r.next_date else None,
+                "end_date": str(r.end_date) if r.end_date else None,
+                "repeat_slug": r.repeat.slug if r.repeat else None,
+                "auto_add": r.auto_add,
+                "memo": r.memo,
+            }
+            for r in Reminder.objects.all().select_related(
+                "tag", "reminder_source_account", "reminder_destination_account",
+                "transaction_type", "repeat"
+            )
+        ]
+
+        # 13. ReminderExclusions
+        data["reminder_exclusions"] = [
+            {
+                "reminder_id": re.reminder_id,
+                "exclude_date": str(re.exclude_date),
+            }
+            for re in ReminderExclusion.objects.all()
+        ]
+
+        # 14. ContribRules
+        data["contrib_rules"] = [
+            {"rule": cr.rule, "cap": cr.cap, "order": cr.order}
+            for cr in ContribRule.objects.all()
+        ]
+
+        # 15. Contributions
+        data["contributions"] = [
+            {
+                "contribution": c.contribution,
+                "per_paycheck": str(c.per_paycheck),
+                "emergency_amt": str(c.emergency_amt),
+                "emergency_diff": str(c.emergency_diff),
+                "cap": str(c.cap),
+                "active": c.active,
+            }
+            for c in Contribution.objects.all()
+        ]
+
+        # 16. Notes
+        data["notes"] = [
+            {"note_text": n.note_text, "note_date": str(n.note_date)}
+            for n in Note.objects.all()
+        ]
+
+        # 17. ChristmasGifts
+        data["christmas_gifts"] = [
+            {
+                "budget": str(cg.budget),
+                "tag_slug": cg.tag.slug if cg.tag else None,
+            }
+            for cg in ChristmasGift.objects.all().select_related("tag")
+        ]
+
+        # 18. Budgets (convert tag_ids PK array to slug array)
+        data["budgets"] = [
+            {
+                "tag_ids": convert_id_json_array(b.tag_ids, tag_pk_to_slug),
+                "name": b.name,
+                "amount": str(b.amount),
+                "roll_over": b.roll_over,
+                "repeat_slug": b.repeat.slug if b.repeat else None,
+                "start_day": str(b.start_day),
+                "roll_over_amt": str(b.roll_over_amt),
+                "active": b.active,
+                "widget": b.widget,
+                "next_start": str(b.next_start),
+            }
+            for b in Budget.objects.all().select_related("repeat")
+        ]
+
+        # 19. CalculationRules (convert tag_ids and account IDs)
+        data["calculation_rules"] = []
+        for cr in CalculationRule.objects.all():
+            data["calculation_rules"].append({
+                "tag_ids": convert_id_json_array(cr.tag_ids, tag_pk_to_slug),
+                "name": cr.name,
+                "source_account_name": account_pk_to_name.get(cr.source_account_id),
+                "destination_account_name": account_pk_to_name.get(cr.destination_account_id),
+            })
+
+        # 20. Option singleton
+        option = Option.load()
+        if option:
+            data["option"] = {
+                "alert_balance": str(option.alert_balance) if option.alert_balance is not None else None,
+                "alert_period": option.alert_period,
+                "widget1_graph_name": option.widget1_graph_name,
+                "widget1_tag_slug": tag_pk_to_slug.get(option.widget1_tag_id) if option.widget1_tag_id else None,
+                "widget1_type_slug": option.widget1_type.slug if option.widget1_type else None,
+                "widget1_month": option.widget1_month,
+                "widget1_exclude": convert_id_json_array(option.widget1_exclude, tag_pk_to_slug),
+                "widget2_graph_name": option.widget2_graph_name,
+                "widget2_tag_slug": tag_pk_to_slug.get(option.widget2_tag_id) if option.widget2_tag_id else None,
+                "widget2_type_slug": option.widget2_type.slug if option.widget2_type else None,
+                "widget2_month": option.widget2_month,
+                "widget2_exclude": convert_id_json_array(option.widget2_exclude, tag_pk_to_slug),
+                "widget3_graph_name": option.widget3_graph_name,
+                "widget3_tag_slug": tag_pk_to_slug.get(option.widget3_tag_id) if option.widget3_tag_id else None,
+                "widget3_type_slug": option.widget3_type.slug if option.widget3_type else None,
+                "widget3_month": option.widget3_month,
+                "widget3_exclude": convert_id_json_array(option.widget3_exclude, tag_pk_to_slug),
+                "auto_archive": option.auto_archive,
+                "archive_length": option.archive_length,
+                "enable_cc_bill_calculation": option.enable_cc_bill_calculation,
+                "report_main": option.report_main,
+                "report_individual": option.report_individual,
+                "retirement_accounts": convert_id_json_array(option.retirement_accounts, account_pk_to_name),
+                "christmas_accounts": convert_id_json_array(option.christmas_accounts, account_pk_to_name),
+                "christmas_rewards": convert_id_json_array(option.christmas_rewards, account_pk_to_name),
+            }
+
+        # 21. BackupConfig singleton
+        config = BackupConfig.load()
+        data["backup_config"] = {
+            "backup_enabled": config.backup_enabled,
+            "frequency": config.frequency,
+            "backup_time": config.backup_time,
+            "copies_to_keep": config.copies_to_keep,
+        }
+
+        return data

--- a/backend/administration/management/commands/import_user_data.py
+++ b/backend/administration/management/commands/import_user_data.py
@@ -1,0 +1,400 @@
+import gzip
+import json
+import os
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction as db_transaction
+
+
+class Command(BaseCommand):
+    help = "Restore user data from a version-agnostic JSON backup (.json.gz)"
+
+    def add_arguments(self, parser):
+        parser.add_argument("input", type=str, help="Path to backup file (.json.gz or .json)")
+
+    def handle(self, *args, **options):
+        filepath = options["input"]
+        if not os.path.exists(filepath):
+            raise CommandError(f"File not found: {filepath}")
+
+        self.stdout.write(f"Reading backup from: {filepath}")
+        if filepath.endswith(".gz"):
+            with gzip.open(filepath, "rb") as f:
+                data = json.loads(f.read().decode("utf-8"))
+        else:
+            with open(filepath, "r") as f:
+                data = json.load(f)
+
+        self.stdout.write("Starting restore (atomic)...")
+        with db_transaction.atomic():
+            self._clear_user_data()
+            self._restore_data(data)
+
+        self.stdout.write(self.style.SUCCESS("Restore completed successfully."))
+
+    def _clear_user_data(self):
+        from transactions.models import (
+            TransactionDetail, Transaction, Paycheck,
+            ReminderCacheTransaction, ForecastCacheTransaction,
+        )
+        from accounts.models import Account, Bank, Reward
+        from administration.models import Payee, DescriptionHistory
+        from reminders.models import Reminder, ReminderExclusion
+        from tags.models import Tag, MainTag, SubTag
+        from planning.models import (
+            ContribRule, Contribution, Note, ChristmasGift,
+            Budget, CalculationRule,
+        )
+
+        # Cache tables first (generated data, not user data)
+        ForecastCacheTransaction.objects.all().delete()
+        ReminderCacheTransaction.objects.all().delete()
+
+        # Leaf records before parents
+        TransactionDetail.objects.all().delete()
+        Transaction.objects.all().delete()
+        Paycheck.objects.all().delete()
+        Reward.objects.all().delete()
+        DescriptionHistory.objects.all().delete()
+        ReminderExclusion.objects.all().delete()
+        Reminder.objects.all().delete()
+
+        # Accounts: clear self-referential FK before delete
+        Account.objects.update(funding_account=None)
+        Account.objects.all().delete()
+        Bank.objects.all().delete()
+
+        # User-created tags only; system tags remain (re-seeded by fixtures)
+        Tag.objects.filter(is_system=False).delete()
+        SubTag.objects.filter(is_system=False).delete()
+        MainTag.objects.filter(is_system=False).delete()
+
+        Payee.objects.all().delete()
+        ChristmasGift.objects.all().delete()
+        Budget.objects.all().delete()
+        CalculationRule.objects.all().delete()
+        Note.objects.all().delete()
+        Contribution.objects.all().delete()
+        ContribRule.objects.all().delete()
+
+        self.stdout.write("Cleared existing user data.")
+
+    def _restore_data(self, data):
+        from administration.models import Payee, DescriptionHistory, Option, BackupConfig, GraphType
+        from accounts.models import AccountType, Bank, Account, Reward
+        from tags.models import TagType, MainTag, SubTag, Tag
+        from transactions.models import (
+            TransactionStatus, TransactionType,
+            Transaction, Paycheck, TransactionDetail,
+        )
+        from reminders.models import Repeat, Reminder, ReminderExclusion
+        from planning.models import ContribRule, Contribution, Note, ChristmasGift, Budget, CalculationRule
+
+        # --- System lookup tables (slug → object) ---
+        account_type_by_slug = {o.slug: o for o in AccountType.objects.all()}
+        status_by_slug = {o.slug: o for o in TransactionStatus.objects.all()}
+        ttype_by_slug = {o.slug: o for o in TransactionType.objects.all()}
+        repeat_by_slug = {o.slug: o for o in Repeat.objects.all()}
+        tag_type_by_slug = {o.slug: o for o in TagType.objects.all()}
+        graph_type_by_slug = {o.slug: o for o in GraphType.objects.all()}
+
+        def convert_slug_json_array(slug_str, slug_to_pk):
+            """Convert JSON array of natural keys back to a JSON array of current PKs."""
+            if not slug_str:
+                return slug_str
+            try:
+                slug_list = json.loads(slug_str)
+                if not isinstance(slug_list, list):
+                    return slug_str
+                return json.dumps([slug_to_pk.get(s, s) for s in slug_list])
+            except (json.JSONDecodeError, TypeError):
+                return slug_str
+
+        # --- 1. Payees ---
+        for item in data.get("payees", []):
+            Payee.objects.create(payee_name=item["payee_name"])
+        payee_by_name = {p.payee_name: p for p in Payee.objects.all()}
+
+        # --- 2. Banks ---
+        for item in data.get("banks", []):
+            Bank.objects.get_or_create(bank_name=item["bank_name"])
+        bank_by_name = {b.bank_name: b for b in Bank.objects.all()}
+
+        # --- 3. MainTags (user-created) ---
+        main_tag_by_slug = {}
+        for item in data.get("main_tags", []):
+            mt = MainTag.objects.create(
+                tag_name=item["tag_name"],
+                tag_type=tag_type_by_slug.get(item["tag_type_slug"]) if item.get("tag_type_slug") else None,
+            )
+            main_tag_by_slug[item["slug"]] = mt
+        # Include system main tags so their slugs resolve correctly in tag lookups
+        for mt in MainTag.objects.filter(is_system=True):
+            main_tag_by_slug[mt.slug] = mt
+
+        # --- 4. SubTags (user-created) ---
+        sub_tag_by_slug = {}
+        for item in data.get("sub_tags", []):
+            st = SubTag.objects.create(
+                tag_name=item["tag_name"],
+                tag_type=tag_type_by_slug.get(item["tag_type_slug"]) if item.get("tag_type_slug") else None,
+            )
+            sub_tag_by_slug[item["slug"]] = st
+        for st in SubTag.objects.filter(is_system=True):
+            sub_tag_by_slug[st.slug] = st
+
+        # --- 5. Tags (user-created) ---
+        tag_by_slug = {}
+        for item in data.get("tags", []):
+            t = Tag.objects.create(
+                parent=main_tag_by_slug.get(item["parent_slug"]) if item.get("parent_slug") else None,
+                child=sub_tag_by_slug.get(item["child_slug"]) if item.get("child_slug") else None,
+                tag_type=tag_type_by_slug.get(item["tag_type_slug"]) if item.get("tag_type_slug") else None,
+            )
+            tag_by_slug[item["slug"]] = t
+        for t in Tag.objects.filter(is_system=True).select_related("parent", "child"):
+            tag_by_slug[t.slug] = t
+
+        tag_slug_to_pk = {slug: t.pk for slug, t in tag_by_slug.items()}
+
+        # --- 6. Accounts (first pass: no funding_account) ---
+        account_by_name = {}
+        for item in data.get("accounts", []):
+            a = Account(
+                account_name=item["account_name"],
+                account_type=account_type_by_slug.get(item["account_type_slug"]) if item.get("account_type_slug") else None,
+                opening_balance=item["opening_balance"],
+                annual_rate=item.get("annual_rate"),
+                active=item["active"],
+                open_date=item.get("open_date"),
+                statement_cycle_length=item.get("statement_cycle_length", 0),
+                statement_cycle_period=item.get("statement_cycle_period", "d"),
+                credit_limit=item.get("credit_limit"),
+                bank=bank_by_name[item["bank_name"]],
+                statement_balance=item.get("statement_balance"),
+                archive_balance=item.get("archive_balance"),
+                funding_account=None,
+                calculate_payments=item.get("calculate_payments", False),
+                calculate_interest=item.get("calculate_interest", False),
+                payment_strategy=item.get("payment_strategy", "F"),
+                payment_amount=item.get("payment_amount"),
+                minimum_payment_amount=item.get("minimum_payment_amount"),
+                statement_day=item.get("statement_day", 15),
+                due_day=item.get("due_day", 15),
+                pay_day=item.get("pay_day", 15),
+                interest_deposit_day=item.get("interest_deposit_day"),
+            )
+            a.save()
+            account_by_name[a.account_name] = a
+
+        # Second pass: set funding_account
+        for item in data.get("accounts", []):
+            if item.get("funding_account_name"):
+                funding = account_by_name.get(item["funding_account_name"])
+                if funding:
+                    acct = account_by_name[item["account_name"]]
+                    acct.funding_account = funding
+                    acct.save()
+
+        account_name_to_pk = {name: a.pk for name, a in account_by_name.items()}
+
+        # --- 7. DescriptionHistory ---
+        for item in data.get("description_history", []):
+            DescriptionHistory.objects.create(
+                description_normalized=item["description_normalized"],
+                description_pretty=item.get("description_pretty"),
+                tag=tag_by_slug.get(item["tag_slug"]) if item.get("tag_slug") else None,
+            )
+
+        # --- 8. Rewards ---
+        for item in data.get("rewards", []):
+            acct = account_by_name.get(item["account_name"])
+            if acct:
+                Reward.objects.create(
+                    reward_date=item["reward_date"],
+                    reward_amount=item["reward_amount"],
+                    reward_account=acct,
+                )
+
+        # --- 9. Paychecks ---
+        paycheck_id_map = {}
+        for item in data.get("paychecks", []):
+            p = Paycheck.objects.create(
+                gross=item["gross"],
+                net=item["net"],
+                taxes=item["taxes"],
+                health=item["health"],
+                pension=item["pension"],
+                fsa=item["fsa"],
+                dca=item["dca"],
+                union_dues=item["union_dues"],
+                four_fifty_seven_b=item["four_fifty_seven_b"],
+                payee=payee_by_name.get(item["payee_name"]) if item.get("payee_name") else None,
+            )
+            paycheck_id_map[item["_id"]] = p
+
+        # --- 10. Transactions (bulk create for performance) ---
+        transaction_id_map = {}
+        transaction_rows = []
+        for item in data.get("transactions", []):
+            transaction_rows.append((
+                item["_id"],
+                Transaction(
+                    transaction_date=item["transaction_date"],
+                    total_amount=item["total_amount"],
+                    status=status_by_slug.get(item["status_slug"]) if item.get("status_slug") else None,
+                    memo=item.get("memo"),
+                    description=item["description"],
+                    edit_date=item["edit_date"],
+                    add_date=item["add_date"],
+                    transaction_type=ttype_by_slug.get(item["transaction_type_slug"]) if item.get("transaction_type_slug") else None,
+                    paycheck=paycheck_id_map.get(item["paycheck_id"]) if item.get("paycheck_id") else None,
+                    checkNumber=item.get("checkNumber"),
+                    source_account=account_by_name.get(item["source_account_name"]) if item.get("source_account_name") else None,
+                    destination_account=account_by_name.get(item["destination_account_name"]) if item.get("destination_account_name") else None,
+                ),
+            ))
+
+        created_transactions = Transaction.objects.bulk_create([t for _, t in transaction_rows])
+        for (old_id, _), new_obj in zip(transaction_rows, created_transactions):
+            transaction_id_map[old_id] = new_obj
+
+        # --- 11. TransactionDetails (bulk create) ---
+        detail_batch = []
+        for item in data.get("transaction_details", []):
+            t = transaction_id_map.get(item["transaction_id"])
+            if t:
+                detail_batch.append(TransactionDetail(
+                    transaction=t,
+                    detail_amt=item["detail_amt"],
+                    tag=tag_by_slug.get(item["tag_slug"]) if item.get("tag_slug") else None,
+                ))
+        if detail_batch:
+            TransactionDetail.objects.bulk_create(detail_batch)
+
+        # --- 12. Reminders ---
+        reminder_id_map = {}
+        for item in data.get("reminders", []):
+            r = Reminder.objects.create(
+                tag=tag_by_slug.get(item["tag_slug"]) if item.get("tag_slug") else None,
+                amount=item["amount"],
+                reminder_source_account=account_by_name.get(item["source_account_name"]) if item.get("source_account_name") else None,
+                reminder_destination_account=account_by_name.get(item["destination_account_name"]) if item.get("destination_account_name") else None,
+                description=item["description"],
+                transaction_type=ttype_by_slug.get(item["transaction_type_slug"]) if item.get("transaction_type_slug") else None,
+                start_date=item["start_date"],
+                next_date=item.get("next_date"),
+                end_date=item.get("end_date"),
+                repeat=repeat_by_slug.get(item["repeat_slug"]) if item.get("repeat_slug") else None,
+                auto_add=item["auto_add"],
+                memo=item.get("memo"),
+            )
+            reminder_id_map[item["_id"]] = r
+
+        # --- 13. ReminderExclusions ---
+        for item in data.get("reminder_exclusions", []):
+            r = reminder_id_map.get(item["reminder_id"])
+            if r:
+                ReminderExclusion.objects.create(
+                    reminder=r,
+                    exclude_date=item["exclude_date"],
+                )
+
+        # --- 14. ContribRules ---
+        for item in data.get("contrib_rules", []):
+            ContribRule.objects.create(
+                rule=item["rule"],
+                cap=item.get("cap"),
+                order=item.get("order", 0),
+            )
+
+        # --- 15. Contributions ---
+        for item in data.get("contributions", []):
+            Contribution.objects.create(
+                contribution=item["contribution"],
+                per_paycheck=item["per_paycheck"],
+                emergency_amt=item["emergency_amt"],
+                emergency_diff=item["emergency_diff"],
+                cap=item["cap"],
+                active=item["active"],
+            )
+
+        # --- 16. Notes ---
+        for item in data.get("notes", []):
+            Note.objects.create(note_text=item["note_text"], note_date=item["note_date"])
+
+        # --- 17. ChristmasGifts ---
+        for item in data.get("christmas_gifts", []):
+            ChristmasGift.objects.create(
+                budget=item["budget"],
+                tag=tag_by_slug.get(item["tag_slug"]) if item.get("tag_slug") else None,
+            )
+
+        # --- 18. Budgets (convert tag slug array back to PK array) ---
+        for item in data.get("budgets", []):
+            Budget.objects.create(
+                tag_ids=convert_slug_json_array(item["tag_ids"], tag_slug_to_pk),
+                name=item["name"],
+                amount=item["amount"],
+                roll_over=item["roll_over"],
+                repeat=repeat_by_slug.get(item["repeat_slug"]) if item.get("repeat_slug") else None,
+                start_day=item["start_day"],
+                roll_over_amt=item["roll_over_amt"],
+                active=item["active"],
+                widget=item["widget"],
+                next_start=item["next_start"],
+            )
+
+        # --- 19. CalculationRules ---
+        for item in data.get("calculation_rules", []):
+            CalculationRule.objects.create(
+                tag_ids=convert_slug_json_array(item["tag_ids"], tag_slug_to_pk),
+                name=item["name"],
+                source_account_id=account_name_to_pk.get(item.get("source_account_name"), 0),
+                destination_account_id=account_name_to_pk.get(item.get("destination_account_name"), 0),
+            )
+
+        # --- 20. Option singleton (update in place) ---
+        if "option" in data:
+            opt = data["option"]
+            option = Option.load()
+            if option is None:
+                return  # Cannot create; load_options management command handles initial creation
+
+            option.alert_balance = opt.get("alert_balance")
+            option.alert_period = opt.get("alert_period", 3)
+            option.widget1_graph_name = opt.get("widget1_graph_name", "")
+            option.widget1_tag_id = tag_slug_to_pk.get(opt["widget1_tag_slug"]) if opt.get("widget1_tag_slug") else None
+            option.widget1_type = graph_type_by_slug.get(opt["widget1_type_slug"]) if opt.get("widget1_type_slug") else None
+            option.widget1_month = opt.get("widget1_month", 0)
+            option.widget1_exclude = convert_slug_json_array(opt.get("widget1_exclude"), tag_slug_to_pk)
+            option.widget2_graph_name = opt.get("widget2_graph_name", "")
+            option.widget2_tag_id = tag_slug_to_pk.get(opt["widget2_tag_slug"]) if opt.get("widget2_tag_slug") else None
+            option.widget2_type = graph_type_by_slug.get(opt["widget2_type_slug"]) if opt.get("widget2_type_slug") else None
+            option.widget2_month = opt.get("widget2_month", 0)
+            option.widget2_exclude = convert_slug_json_array(opt.get("widget2_exclude"), tag_slug_to_pk)
+            option.widget3_graph_name = opt.get("widget3_graph_name", "")
+            option.widget3_tag_id = tag_slug_to_pk.get(opt["widget3_tag_slug"]) if opt.get("widget3_tag_slug") else None
+            option.widget3_type = graph_type_by_slug.get(opt["widget3_type_slug"]) if opt.get("widget3_type_slug") else None
+            option.widget3_month = opt.get("widget3_month", 0)
+            option.widget3_exclude = convert_slug_json_array(opt.get("widget3_exclude"), tag_slug_to_pk)
+            option.auto_archive = opt.get("auto_archive", True)
+            option.archive_length = opt.get("archive_length", 2)
+            option.enable_cc_bill_calculation = opt.get("enable_cc_bill_calculation", True)
+            option.report_main = opt.get("report_main")
+            option.report_individual = opt.get("report_individual")
+            option.retirement_accounts = convert_slug_json_array(opt.get("retirement_accounts"), account_name_to_pk)
+            option.christmas_accounts = convert_slug_json_array(opt.get("christmas_accounts"), account_name_to_pk)
+            option.christmas_rewards = convert_slug_json_array(opt.get("christmas_rewards"), account_name_to_pk)
+            option.save()
+
+        # --- 21. BackupConfig singleton (update in place) ---
+        if "backup_config" in data:
+            bc = data["backup_config"]
+            config = BackupConfig.load()
+            config.backup_enabled = bc.get("backup_enabled", True)
+            config.frequency = bc.get("frequency", "DAILY")
+            config.backup_time = bc.get("backup_time", "02:00")
+            config.copies_to_keep = bc.get("copies_to_keep", 2)
+            config.save()
+
+        self.stdout.write("Data restored.")

--- a/backend/administration/migrations/0021_backupconfig.py
+++ b/backend/administration/migrations/0021_backupconfig.py
@@ -1,0 +1,43 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("administration", "0020_graphtype_slug_data"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="BackupConfig",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("backup_enabled", models.BooleanField(default=True)),
+                (
+                    "frequency",
+                    models.CharField(
+                        choices=[
+                            ("HOURLY", "Hourly"),
+                            ("DAILY", "Daily"),
+                            ("WEEKLY", "Weekly"),
+                        ],
+                        default="DAILY",
+                        max_length=10,
+                    ),
+                ),
+                ("backup_time", models.CharField(default="02:00", max_length=5)),
+                ("copies_to_keep", models.IntegerField(default=2)),
+            ],
+            options={
+                "abstract": False,
+            },
+        ),
+    ]

--- a/backend/administration/models.py
+++ b/backend/administration/models.py
@@ -204,6 +204,26 @@ class Version(SingletonModel):
         return self.version_number
 
 
+class BackupConfig(SingletonModel):
+    FREQUENCY_CHOICES = [
+        ("HOURLY", "Hourly"),
+        ("DAILY", "Daily"),
+        ("WEEKLY", "Weekly"),
+    ]
+
+    backup_enabled = models.BooleanField(default=True)
+    frequency = models.CharField(
+        max_length=10, choices=FREQUENCY_CHOICES, default="DAILY"
+    )
+    backup_time = models.CharField(max_length=5, default="02:00")
+    copies_to_keep = models.IntegerField(default=2)
+
+    @classmethod
+    def load(cls):
+        obj, _ = cls.objects.get_or_create(pk=1)
+        return obj
+
+
 class DescriptionHistory(models.Model):
     """
     Model representing a history of transaction descriptions.

--- a/backend/administration/tests/api/test_backup_api.py
+++ b/backend/administration/tests/api/test_backup_api.py
@@ -1,0 +1,258 @@
+import gzip
+import json
+import os
+import pytest
+from unittest.mock import patch
+from django.test import override_settings
+
+
+AUTH = {"Authorization": "Bearer test-api-key"}
+
+
+@pytest.fixture
+def backup_dir(tmp_path):
+    return str(tmp_path)
+
+
+@pytest.fixture
+def backup_settings(backup_dir):
+    return override_settings(DBBACKUP_STORAGE_OPTIONS={"location": backup_dir})
+
+
+@pytest.fixture
+def sample_backup_file(backup_dir):
+    """Create a minimal valid .json.gz backup in the temp dir."""
+    data = {
+        "payees": [], "banks": [], "main_tags": [], "sub_tags": [], "tags": [],
+        "accounts": [], "description_history": [], "rewards": [], "paychecks": [],
+        "transactions": [], "transaction_details": [], "reminders": [],
+        "reminder_exclusions": [], "contrib_rules": [], "contributions": [],
+        "notes": [], "christmas_gifts": [], "budgets": [], "calculation_rules": [],
+        "backup_config": {"backup_enabled": True, "frequency": "DAILY",
+                          "backup_time": "02:00", "copies_to_keep": 2},
+    }
+    filename = "lenorefin-backup-2025-01-01-120000.json.gz"
+    filepath = os.path.join(backup_dir, filename)
+    with gzip.open(filepath, "wb") as f:
+        f.write(json.dumps(data).encode())
+    return filename
+
+
+# ---------------------------------------------------------------------------
+# Config endpoints
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+@pytest.mark.api
+def test_get_backup_config(api_client):
+    response = api_client.get("/administration/backups/config", headers=AUTH)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert "backup_enabled" in data
+    assert "frequency" in data
+    assert "backup_time" in data
+    assert "copies_to_keep" in data
+
+
+@pytest.mark.django_db
+@pytest.mark.api
+def test_update_backup_config(api_client):
+    response = api_client.patch(
+        "/administration/backups/config",
+        json={"frequency": "WEEKLY", "copies_to_keep": 5},
+        headers=AUTH,
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["frequency"] == "WEEKLY"
+    assert data["copies_to_keep"] == 5
+
+    from administration.models import BackupConfig
+    config = BackupConfig.load()
+    assert config.frequency == "WEEKLY"
+    assert config.copies_to_keep == 5
+
+
+# ---------------------------------------------------------------------------
+# File listing
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+@pytest.mark.api
+def test_list_backups_empty(api_client, backup_settings, backup_dir):
+    with backup_settings:
+        response = api_client.get("/administration/backups/files", headers=AUTH)
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+@pytest.mark.django_db
+@pytest.mark.api
+def test_list_backups_returns_json_gz_files(api_client, backup_settings, sample_backup_file):
+    with backup_settings:
+        response = api_client.get("/administration/backups/files", headers=AUTH)
+
+    assert response.status_code == 200
+    files = response.json()
+    assert len(files) == 1
+    assert files[0]["filename"] == sample_backup_file
+    assert files[0]["backup_type"] == "database"
+    assert files[0]["size"] > 0
+
+
+@pytest.mark.django_db
+@pytest.mark.api
+def test_list_backups_ignores_non_json_gz(api_client, backup_settings, backup_dir):
+    # Write a file that should be ignored
+    open(os.path.join(backup_dir, "somefile.dump"), "w").close()
+    with backup_settings:
+        response = api_client.get("/administration/backups/files", headers=AUTH)
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+# ---------------------------------------------------------------------------
+# Run backup
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+@pytest.mark.api
+def test_run_backup_queues_async_task(api_client):
+    with patch("django_q.tasks.async_task") as mock_task:
+        response = api_client.post("/administration/backups/run", headers=AUTH)
+
+    assert response.status_code == 200
+    assert response.json()["success"] is True
+    mock_task.assert_called_once_with("transactions.tasks.create_backup")
+
+
+# ---------------------------------------------------------------------------
+# Download
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+@pytest.mark.api
+def test_download_backup(api_client, backup_settings, backup_dir, sample_backup_file):
+    with backup_settings:
+        response = api_client.get(
+            f"/administration/backups/files/{sample_backup_file}/download",
+            headers=AUTH,
+        )
+
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+@pytest.mark.api
+def test_download_backup_not_found(api_client, backup_settings):
+    with backup_settings:
+        response = api_client.get(
+            "/administration/backups/files/nonexistent.json.gz/download",
+            headers=AUTH,
+        )
+
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+@pytest.mark.api
+def test_download_backup_path_traversal_rejected(api_client, backup_settings):
+    with backup_settings:
+        response = api_client.get(
+            "/administration/backups/files/..%2F..%2Fetc%2Fpasswd/download",
+            headers=AUTH,
+        )
+
+    assert response.status_code in (400, 404)
+
+
+# ---------------------------------------------------------------------------
+# Delete
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+@pytest.mark.api
+def test_delete_backup(api_client, backup_settings, backup_dir, sample_backup_file):
+    filepath = os.path.join(backup_dir, sample_backup_file)
+    assert os.path.exists(filepath)
+
+    with backup_settings:
+        response = api_client.delete(
+            f"/administration/backups/files/{sample_backup_file}",
+            headers=AUTH,
+        )
+
+    assert response.status_code == 200
+    assert response.json()["success"] is True
+    assert not os.path.exists(filepath)
+
+
+@pytest.mark.django_db
+@pytest.mark.api
+def test_delete_backup_not_found(api_client, backup_settings):
+    with backup_settings:
+        response = api_client.delete(
+            "/administration/backups/files/nonexistent.json.gz",
+            headers=AUTH,
+        )
+
+    assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Restore from stored file
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+@pytest.mark.api
+def test_restore_database(api_client, backup_settings, sample_backup_file):
+    with backup_settings:
+        with patch("administration.api.views.backup.call_command") as mock_cmd:
+            response = api_client.post(
+                f"/administration/backups/restore/database?filename={sample_backup_file}",
+                headers=AUTH,
+            )
+
+    assert response.status_code == 200
+    assert response.json()["success"] is True
+    mock_cmd.assert_called_once()
+    assert mock_cmd.call_args[0][0] == "import_user_data"
+
+
+@pytest.mark.django_db
+@pytest.mark.api
+def test_restore_database_file_not_found(api_client, backup_settings):
+    with backup_settings:
+        response = api_client.post(
+            "/administration/backups/restore/database?filename=missing.json.gz",
+            headers=AUTH,
+        )
+
+    assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Restore from upload
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+@pytest.mark.api
+def test_restore_upload(api_client):
+    from django.core.files.uploadedfile import SimpleUploadedFile
+
+    uploaded = SimpleUploadedFile("backup.json.gz", b"fake backup content", content_type="application/gzip")
+    with patch("administration.api.views.backup.call_command") as mock_cmd:
+        response = api_client.post(
+            "/administration/backups/restore/upload",
+            FILES={"file": uploaded},
+            headers=AUTH,
+        )
+
+    assert response.status_code == 200
+    assert response.json()["success"] is True
+    mock_cmd.assert_called_once()
+    assert mock_cmd.call_args[0][0] == "import_user_data"

--- a/backend/administration/tests/unit/test_backup_commands.py
+++ b/backend/administration/tests/unit/test_backup_commands.py
@@ -1,0 +1,299 @@
+import gzip
+import json
+import pytest
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+
+# ---------------------------------------------------------------------------
+# Export smoke tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+def test_export_creates_gz_file(tmp_path):
+    output = str(tmp_path / "backup.json.gz")
+    call_command("export_user_data", output=output)
+
+    with gzip.open(output, "rb") as f:
+        data = json.loads(f.read())
+
+    for key in ("payees", "banks", "accounts", "transactions", "reminders", "budgets"):
+        assert key in data
+
+
+@pytest.mark.django_db
+def test_export_includes_user_data(tmp_path, test_payee, test_checking_account, test_tag):
+    output = str(tmp_path / "backup.json.gz")
+    call_command("export_user_data", output=output)
+
+    with gzip.open(output, "rb") as f:
+        data = json.loads(f.read())
+
+    assert any(p["payee_name"] == test_payee.payee_name for p in data["payees"])
+    assert any(a["account_name"] == test_checking_account.account_name for a in data["accounts"])
+    # User-created tag is present; slug is stored as a natural key
+    assert any(t["slug"] == test_tag.slug for t in data["tags"])
+
+
+@pytest.mark.django_db
+def test_export_stores_system_fks_as_slugs(
+    tmp_path, test_checking_account, test_transaction,
+    test_pending_transaction_status, test_expense_transaction_type,
+):
+    output = str(tmp_path / "backup.json.gz")
+    call_command("export_user_data", output=output)
+
+    with gzip.open(output, "rb") as f:
+        data = json.loads(f.read())
+
+    txn = next(t for t in data["transactions"] if t["description"] == test_transaction.description)
+    assert txn["status_slug"] == test_pending_transaction_status.slug
+    assert txn["transaction_type_slug"] == test_expense_transaction_type.slug
+
+    account = next(a for a in data["accounts"] if a["account_name"] == test_checking_account.account_name)
+    assert account["account_type_slug"] == test_checking_account.account_type.slug
+
+
+# ---------------------------------------------------------------------------
+# Round-trip: full export → import
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+def test_roundtrip_restores_all_core_models(
+    tmp_path,
+    test_payee,
+    test_checking_account,
+    test_savings_account,
+    test_tag,
+    test_transaction,
+    test_paycheck,
+    test_reminder,
+):
+    from accounts.models import Account, Bank, Reward
+    from administration.models import DescriptionHistory
+    from planning.models import Contribution, ContribRule, Note
+    from reminders.models import ReminderExclusion
+
+    DescriptionHistory.objects.create(
+        description_normalized="grocery store",
+        description_pretty="Grocery Store",
+        tag=test_tag,
+    )
+    Reward.objects.create(reward_amount="50.00", reward_account=test_checking_account)
+    ContribRule.objects.create(rule="401k", cap="5000", order=1)
+    Contribution.objects.create(
+        contribution="HSA",
+        per_paycheck="50.00",
+        emergency_amt="0.00",
+        emergency_diff="0.00",
+        cap="3600.00",
+        active=True,
+    )
+    Note.objects.create(note_text="Check budget monthly")
+    ReminderExclusion.objects.create(reminder=test_reminder, exclude_date="2025-01-01")
+
+    output = str(tmp_path / "backup.json.gz")
+    call_command("export_user_data", output=output)
+    call_command("import_user_data", output)
+
+    from transactions.models import Transaction, Paycheck
+
+    assert Account.objects.filter(account_name=test_checking_account.account_name).exists()
+    assert Account.objects.filter(account_name=test_savings_account.account_name).exists()
+    assert Bank.objects.filter(bank_name=test_checking_account.bank.bank_name).exists()
+    assert DescriptionHistory.objects.filter(description_normalized="grocery store").exists()
+    assert Reward.objects.filter(reward_amount="50.00").exists()
+    assert Paycheck.objects.filter(gross=test_paycheck.gross).exists()
+    assert Transaction.objects.filter(description=test_transaction.description).exists()
+    assert ContribRule.objects.filter(rule="401k").exists()
+    assert Contribution.objects.filter(contribution="HSA").exists()
+    assert Note.objects.filter(note_text="Check budget monthly").exists()
+    assert ReminderExclusion.objects.filter(exclude_date="2025-01-01").exists()
+
+
+@pytest.mark.django_db
+def test_roundtrip_remaps_transaction_detail_tag(
+    tmp_path, test_checking_account, test_tag,
+    test_pending_transaction_status, test_expense_transaction_type,
+):
+    """TransactionDetail.tag FK points to the re-created Tag after import."""
+    from transactions.models import Transaction, TransactionDetail
+    from tags.models import Tag
+
+    txn = Transaction.objects.create(
+        description="Tagged Expense",
+        status=test_pending_transaction_status,
+        transaction_type=test_expense_transaction_type,
+        source_account=test_checking_account,
+        total_amount="75.00",
+    )
+    TransactionDetail.objects.create(transaction=txn, detail_amt="75.00", tag=test_tag)
+
+    output = str(tmp_path / "backup.json.gz")
+    call_command("export_user_data", output=output)
+    call_command("import_user_data", output)
+
+    restored_tag = Tag.objects.get(slug=test_tag.slug)
+    restored_txn = Transaction.objects.get(description="Tagged Expense")
+    detail = TransactionDetail.objects.get(transaction=restored_txn)
+    assert detail.tag_id == restored_tag.pk
+
+
+@pytest.mark.django_db
+def test_roundtrip_remaps_paycheck_link(
+    tmp_path, test_checking_account, test_payee,
+    test_pending_transaction_status, test_expense_transaction_type,
+):
+    """Transaction.paycheck is remapped to the new Paycheck record after import."""
+    from transactions.models import Paycheck, Transaction
+
+    pc = Paycheck.objects.create(
+        gross="3000.00", net="2500.00", taxes="500.00",
+        health="0", pension="0", fsa="0", dca="0",
+        union_dues="0", four_fifty_seven_b="0", payee=test_payee,
+    )
+    Transaction.objects.create(
+        description="Paycheck Deposit",
+        status=test_pending_transaction_status,
+        transaction_type=test_expense_transaction_type,
+        source_account=test_checking_account,
+        paycheck=pc,
+    )
+
+    output = str(tmp_path / "backup.json.gz")
+    call_command("export_user_data", output=output)
+    call_command("import_user_data", output)
+
+    restored = Transaction.objects.get(description="Paycheck Deposit")
+    assert restored.paycheck is not None
+    assert str(restored.paycheck.gross) == "3000.00"
+
+
+@pytest.mark.django_db
+def test_roundtrip_funding_account(tmp_path, bank, checking_account_type, credit_card_account_type):
+    """Account.funding_account self-referential FK is correctly restored (two-pass import)."""
+    from accounts.models import Account
+
+    checking = Account.objects.create(
+        account_name="My Checking",
+        account_type=checking_account_type,
+        bank=bank,
+        opening_balance="1000.00",
+    )
+    Account.objects.create(
+        account_name="My CC",
+        account_type=credit_card_account_type,
+        bank=bank,
+        opening_balance="0.00",
+        funding_account=checking,
+    )
+
+    output = str(tmp_path / "backup.json.gz")
+    call_command("export_user_data", output=output)
+    call_command("import_user_data", output)
+
+    restored_cc = Account.objects.get(account_name="My CC")
+    assert restored_cc.funding_account is not None
+    assert restored_cc.funding_account.account_name == "My Checking"
+
+
+@pytest.mark.django_db
+def test_roundtrip_budget_tag_ids_converted(tmp_path, test_checking_account, test_tag):
+    """Budget.tag_ids PK array is converted to slugs on export and back to new PKs on import."""
+    from planning.models import Budget
+    from tags.models import Tag
+
+    Budget.objects.create(
+        tag_ids=json.dumps([test_tag.pk]),
+        name="Groceries Budget",
+        amount="500.00",
+        roll_over=True,
+        start_day="2025-01-01",
+        roll_over_amt="0.00",
+        next_start="2025-02-01",
+    )
+
+    output = str(tmp_path / "backup.json.gz")
+    call_command("export_user_data", output=output)
+
+    # Verify the export stored slugs, not PKs
+    with gzip.open(output, "rb") as f:
+        exported = json.loads(f.read())
+    budget_data = next(b for b in exported["budgets"] if b["name"] == "Groceries Budget")
+    assert json.loads(budget_data["tag_ids"]) == [test_tag.slug]
+
+    call_command("import_user_data", output)
+
+    restored_tag = Tag.objects.get(slug=test_tag.slug)
+    restored_budget = Budget.objects.get(name="Groceries Budget")
+    assert json.loads(restored_budget.tag_ids) == [restored_tag.pk]
+
+
+@pytest.mark.django_db
+def test_roundtrip_reminder_maps(
+    tmp_path, test_checking_account, test_savings_account,
+    test_tag, test_repeat,
+    test_expense_transaction_type,
+):
+    """Reminder FKs (tag, accounts, transaction_type, repeat) are all restored correctly."""
+    from reminders.models import Reminder
+
+    Reminder.objects.create(
+        tag=test_tag,
+        amount="100.00",
+        reminder_source_account=test_checking_account,
+        reminder_destination_account=test_savings_account,
+        description="Monthly Transfer",
+        transaction_type=test_expense_transaction_type,
+        repeat=test_repeat,
+        auto_add=False,
+    )
+
+    output = str(tmp_path / "backup.json.gz")
+    call_command("export_user_data", output=output)
+    call_command("import_user_data", output)
+
+
+    restored = Reminder.objects.get(description="Monthly Transfer")
+    assert restored.tag is not None
+    assert restored.tag.slug == test_tag.slug
+    assert restored.reminder_source_account.account_name == test_checking_account.account_name
+    assert restored.reminder_destination_account.account_name == test_savings_account.account_name
+    assert restored.repeat.slug == test_repeat.slug
+
+
+# ---------------------------------------------------------------------------
+# Atomic rollback
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+def test_import_raises_for_missing_file():
+    with pytest.raises(CommandError, match="File not found"):
+        call_command("import_user_data", "/nonexistent/backup.json.gz")
+
+
+@pytest.mark.django_db
+def test_import_rollback_on_restore_failure(tmp_path, test_checking_account):
+    """If restore fails mid-import, the clear is rolled back atomically."""
+    from accounts.models import Account
+
+    output = str(tmp_path / "backup.json.gz")
+    call_command("export_user_data", output=output)
+
+    # Corrupt the backup: account references a bank not in the banks list
+    with gzip.open(output, "rb") as f:
+        data = json.loads(f.read())
+    data["accounts"][0]["bank_name"] = "__nonexistent_bank__"
+    data["banks"] = [b for b in data["banks"] if b["bank_name"] != "__nonexistent_bank__"]
+
+    corrupt = str(tmp_path / "corrupt.json.gz")
+    with gzip.open(corrupt, "wb") as f:
+        f.write(json.dumps(data).encode())
+
+    original_count = Account.objects.count()
+
+    with pytest.raises(Exception):
+        call_command("import_user_data", corrupt)
+
+    # Clear was rolled back — accounts are still present
+    assert Account.objects.count() == original_count

--- a/backend/backend/api.py
+++ b/backend/backend/api.py
@@ -41,6 +41,7 @@ from planning.api.routers.planning_graph import planning_graph_router
 from planning.api.routers.budget import budget_router
 from planning.api.routers.retirement import retirement_router
 from administration.api.routers.health import health_router
+from administration.api.routers.backup import backup_router
 
 api = NinjaAPI(auth=SessionAuth())
 api.title = "LenoreFin API"
@@ -81,4 +82,5 @@ api.add_router("/planning/graph", planning_graph_router)
 api.add_router("/planning/budget", budget_router)
 api.add_router("/planning/retirement", retirement_router)
 api.add_router("/administration/health", health_router)
+api.add_router("/administration/backups", backup_router)
 api.add_router("/auth", auth_router)

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -158,7 +158,7 @@ CORS_ALLOW_ALL_ORIGINS = True
 CORS_ALLOW_CREDENTIALS = True
 
 DBBACKUP_STORAGE = "django.core.files.storage.FileSystemStorage"
-DBBACKUP_STORAGE_OPTIONS = {"location": "/backups/"}
+DBBACKUP_STORAGE_OPTIONS = {"location": os.environ.get("BACKUP_LOCATION", "/backups/")}
 DBBACKUP_CLEANUP_KEEP = 2
 DBBACKUP_CLEANUP_KEEP_MEDIA = 2
 

--- a/backend/start.dev.sh
+++ b/backend/start.dev.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+mkdir -p /backups
+
 python manage.py makemigrations --no-input
 python manage.py migrate --no-input
 python manage.py collectstatic --no-input
@@ -27,6 +29,7 @@ python manage.py scheduletasks
 python manage.py load_version_fixture
 python manage.py loaddata administration/fixtures/graph_types
 python manage.py load_options
+python manage.py load_backup_config
 python manage.py load_caches
 
 python manage.py runserver 0.0.0.0:8001 &

--- a/backend/start.sh
+++ b/backend/start.sh
@@ -27,6 +27,7 @@ python manage.py scheduletasks
 python manage.py load_version_fixture
 python manage.py loaddata administration/fixtures/graph_types
 python manage.py load_options
+python manage.py load_backup_config
 python manage.py load_caches
 
 gunicorn backend.wsgi:application --bind 0.0.0.0:8000

--- a/backend/start_worker.sh
+++ b/backend/start_worker.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+mkdir -p /backups
+
 python manage.py makemigrations --no-input
 python manage.py migrate --no-input
 python manage.py qcluster

--- a/backend/transactions/management/commands/load_backup_config.py
+++ b/backend/transactions/management/commands/load_backup_config.py
@@ -1,0 +1,25 @@
+from django.core.management.base import BaseCommand
+from administration.models import BackupConfig
+import logging
+
+task_logger = logging.getLogger("task")
+
+
+class Command(BaseCommand):
+    help = "Create the default BackupConfig singleton if it does not exist"
+
+    def handle(self, *args, **kwargs):
+        if not BackupConfig.objects.filter(pk=1).exists():
+            task_logger.info("Creating default BackupConfig")
+            BackupConfig.objects.create(
+                pk=1,
+                backup_enabled=True,
+                frequency="DAILY",
+                backup_time="02:00",
+                copies_to_keep=2,
+            )
+            task_logger.info("Default BackupConfig created.")
+        else:
+            task_logger.warning(
+                "BackupConfig already exists. Skipping."
+            )

--- a/backend/transactions/management/commands/scheduletasks.py
+++ b/backend/transactions/management/commands/scheduletasks.py
@@ -28,6 +28,12 @@ class Command(BaseCommand):
             **options: Additional keyword arguments.
         """
 
+        # Read backup config for dynamic scheduling
+        from administration.models import BackupConfig
+        backup_cfg = BackupConfig.load()
+        backup_frequency = backup_cfg.frequency
+        backup_time = backup_cfg.backup_time
+
         # Calculate the next run date for scheduled tasks
         today_utc = timezone.now()
         tz_timezone = pytz.timezone(os.environ.get("TIMEZONE"))
@@ -86,10 +92,10 @@ class Command(BaseCommand):
             {
                 "task_name": "Backup Database",
                 "function": "transactions.tasks.create_backup",
-                "time": "00:00",
-                "arguments": "True,0",
-                "type": "HOURLY",  # DAILY, HOURLY, MINUTES
-                "start_today": True,
+                "time": backup_time,
+                "arguments": "",
+                "type": backup_frequency,
+                "start_today": backup_frequency == "HOURLY",
                 "delete": False,
             },
             {
@@ -130,6 +136,8 @@ class Command(BaseCommand):
                 schedule_type = Schedule.DAILY
             elif task["type"] == "HOURLY":
                 schedule_type = Schedule.HOURLY
+            elif task["type"] == "WEEKLY":
+                schedule_type = Schedule.WEEKLY
             elif task["type"] == "MINUTES":
                 schedule_type = Schedule.MINUTES
                 next_run = timezone.now()

--- a/backend/transactions/tasks.py
+++ b/backend/transactions/tasks.py
@@ -75,15 +75,36 @@ error_logger = logging.getLogger("error")
 task_logger = logging.getLogger("task")
 
 
-def create_backup(clean=True, keep=0):
+def create_backup(*args, **kwargs):
     """
-    The function `create_backup` creates a database backup and optionally
-    keeps only the last x backups, default is 1.
+    Creates a user-data JSON backup and prunes old backups according to
+    BackupConfig.copies_to_keep.
+    """
+    call_command("export_user_data")
+    cleanup_old_backups()
 
-    Args:
+
+def cleanup_old_backups():
     """
-    call_command("dbbackup", "--clean", "--compress")
-    call_command("mediabackup", "--clean", "--compress")
+    Prunes backup files beyond BackupConfig.copies_to_keep.
+    """
+    from administration.models import BackupConfig
+    from django.conf import settings
+    config = BackupConfig.load()
+    keep = config.copies_to_keep
+    location = settings.DBBACKUP_STORAGE_OPTIONS.get("location", "/backups/")
+    if not os.path.exists(location):
+        return
+    backup_files = sorted(
+        [f for f in os.listdir(location) if f.endswith(".json.gz") or f.endswith(".json")],
+        key=lambda f: os.path.getmtime(os.path.join(location, f)),
+    )
+    for f in backup_files[:-keep] if len(backup_files) > keep else []:
+        try:
+            os.remove(os.path.join(location, f))
+            task_logger.info(f"Deleted old backup: {f}")
+        except OSError as e:
+            error_logger.exception(f"Failed to delete backup {f}: {e}")
 
 
 def create_message(message_text):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,6 @@ services:
     image: postgres:15
     volumes:
       - postgres_data:/var/lib/postgresql/data/
-      - postgres_bkp:/backups
     env_file:
       - ./.env.dev
     networks:

--- a/frontend/src/composables/backupComposable.js
+++ b/frontend/src/composables/backupComposable.js
@@ -1,0 +1,179 @@
+import { useQuery, useQueryClient, useMutation } from "@tanstack/vue-query";
+import apiClient from "./apiClient";
+import { useMainStore } from "@/stores/main";
+
+async function handleApiError(error, message) {
+  if (error.response?.status === 401) throw error;
+  const mainstore = useMainStore();
+  if (error.response) {
+    console.error("Response error:", error.response.data);
+  } else if (error.request) {
+    console.error("No response received:", error.request);
+  } else {
+    console.error("Error during request setup:", error.message);
+  }
+  mainstore.showSnackbar(message + " : " + (error.response?.data?.detail ?? error.message), "error");
+  throw error;
+}
+
+async function getBackupConfigFunction() {
+  try {
+    const response = await apiClient.get("/administration/backups/config");
+    return response.data;
+  } catch (error) {
+    return await handleApiError(error, "Failed to load backup config");
+  }
+}
+
+async function updateBackupConfigFunction(data) {
+  try {
+    const response = await apiClient.patch("/administration/backups/config", data);
+    return response.data;
+  } catch (error) {
+    return await handleApiError(error, "Failed to update backup config");
+  }
+}
+
+async function listBackupsFunction() {
+  try {
+    const response = await apiClient.get("/administration/backups/files");
+    return response.data;
+  } catch (error) {
+    return await handleApiError(error, "Failed to list backups");
+  }
+}
+
+async function runBackupFunction() {
+  try {
+    const response = await apiClient.post("/administration/backups/run");
+    return response.data;
+  } catch (error) {
+    return await handleApiError(error, "Failed to trigger backup");
+  }
+}
+
+async function deleteBackupFunction(filename) {
+  try {
+    const response = await apiClient.delete(`/administration/backups/files/${encodeURIComponent(filename)}`);
+    return response.data;
+  } catch (error) {
+    return await handleApiError(error, "Failed to delete backup");
+  }
+}
+
+async function restoreDatabaseFunction(filename) {
+  try {
+    const response = await apiClient.post(`/administration/backups/restore/database?filename=${encodeURIComponent(filename)}`);
+    return response.data;
+  } catch (error) {
+    return await handleApiError(error, "Failed to restore database");
+  }
+}
+
+async function restoreFromUploadFunction(file) {
+  try {
+    const formData = new FormData();
+    formData.append("file", file);
+    const response = await apiClient.post("/administration/backups/restore/upload", formData, {
+      headers: { "Content-Type": "multipart/form-data" },
+    });
+    return response.data;
+  } catch (error) {
+    return await handleApiError(error, "Failed to restore from upload");
+  }
+}
+
+export function useBackupConfig() {
+  const queryClient = useQueryClient();
+  const mainstore = useMainStore();
+
+  const { data: backupConfig, isLoading } = useQuery({
+    queryKey: ["backup_config"],
+    queryFn: getBackupConfigFunction,
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: updateBackupConfigFunction,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["backup_config"] });
+      mainstore.showSnackbar("Backup settings saved", "success");
+    },
+  });
+
+  function editBackupConfig(data) {
+    updateMutation.mutate(data);
+  }
+
+  return { backupConfig, isLoading, editBackupConfig };
+}
+
+export function useBackupFiles() {
+  const queryClient = useQueryClient();
+  const mainstore = useMainStore();
+
+  const { data: backupFiles, isLoading, refetch } = useQuery({
+    queryKey: ["backup_files"],
+    queryFn: listBackupsFunction,
+  });
+
+  const runBackupMutation = useMutation({
+    mutationFn: runBackupFunction,
+    onSuccess: () => {
+      mainstore.showSnackbar("Backup queued — it will appear in the list shortly", "success");
+      setTimeout(() => queryClient.invalidateQueries({ queryKey: ["backup_files"] }), 3000);
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: deleteBackupFunction,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["backup_files"] });
+      mainstore.showSnackbar("Backup deleted", "success");
+    },
+  });
+
+  const restoreMutation = useMutation({
+    mutationFn: restoreDatabaseFunction,
+    onSuccess: () => {
+      mainstore.showSnackbar("Database restored successfully", "success");
+    },
+  });
+
+  const restoreUploadMutation = useMutation({
+    mutationFn: restoreFromUploadFunction,
+    onSuccess: () => {
+      mainstore.showSnackbar("Database restored from uploaded file", "success");
+    },
+  });
+
+  function runBackup() {
+    runBackupMutation.mutate();
+  }
+
+  function deleteBackup(filename) {
+    deleteMutation.mutate(filename);
+  }
+
+  function restoreDatabase(filename) {
+    restoreMutation.mutate(filename);
+  }
+
+  function restoreFromUpload(file) {
+    restoreUploadMutation.mutate(file);
+  }
+
+  return {
+    backupFiles,
+    isLoading,
+    refetch,
+    runBackup,
+    deleteBackup,
+    restoreDatabase,
+    restoreFromUpload,
+    isRestoring: restoreMutation.isPending || restoreUploadMutation.isPending,
+  };
+}
+
+export function downloadBackup(filename) {
+  window.location.href = `/api/v1/administration/backups/files/${encodeURIComponent(filename)}/download`;
+}

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -16,6 +16,7 @@ import ExpensesView from "@/views/ExpensesView.vue";
 import NotesView from "@/views/NotesView.vue";
 import RetirementView from "@/views/RetirementView.vue";
 import BudgetsView from "@/views/BudgetsView.vue";
+import BackupView from "@/views/BackupView.vue";
 import LoginView from "@/views/LoginView.vue";
 
 const routes = [
@@ -104,6 +105,11 @@ const routes = [
     path: "/planning/retirement",
     name: "retirement",
     component: RetirementView,
+  },
+  {
+    path: "/backup",
+    name: "backup",
+    component: BackupView,
   },
   {
     path: "/:catchAll(.*)",

--- a/frontend/src/views/AppNavigationVue.vue
+++ b/frontend/src/views/AppNavigationVue.vue
@@ -172,6 +172,16 @@
             ></v-list-item>
           </template>
         </v-tooltip>
+        <v-tooltip text="Backup & Restore">
+          <template v-slot:activator="{ props }">
+            <v-list-item
+              prepend-icon="mdi-database-arrow-up"
+              to="/backup"
+              v-bind="props"
+              color="selected"
+            ></v-list-item>
+          </template>
+        </v-tooltip>
         <v-tooltip text="Settings">
           <template v-slot:activator="{ props }">
             <v-list-item

--- a/frontend/src/views/BackupView.vue
+++ b/frontend/src/views/BackupView.vue
@@ -1,0 +1,331 @@
+<template>
+  <v-container fluid>
+    <v-row>
+      <v-col>
+        <h4 class="text-h5 font-weight-bold mb-4">Backup & Restore</h4>
+      </v-col>
+    </v-row>
+
+    <!-- Backup Configuration -->
+    <v-row>
+      <v-col cols="12" md="6">
+        <v-sheet border rounded>
+          <v-container>
+            <v-row dense>
+              <v-col>
+                <h4 class="text-h6 font-weight-bold mb-2">Backup Schedule</h4>
+              </v-col>
+            </v-row>
+            <v-row dense>
+              <v-col>
+                <v-checkbox
+                  v-model="configForm.backup_enabled"
+                  label="Enable Automatic Backups"
+                ></v-checkbox>
+              </v-col>
+            </v-row>
+            <template v-if="configForm.backup_enabled">
+              <v-row dense>
+                <v-col>
+                  <v-select
+                    label="Frequency"
+                    :items="frequencyOptions"
+                    item-title="label"
+                    item-value="value"
+                    v-model="configForm.frequency"
+                    density="comfortable"
+                    variant="outlined"
+                  ></v-select>
+                </v-col>
+                <v-col v-if="configForm.frequency !== 'HOURLY'">
+                  <v-text-field
+                    label="Time (HH:MM)"
+                    v-model="configForm.backup_time"
+                    density="comfortable"
+                    variant="outlined"
+                    placeholder="02:00"
+                  ></v-text-field>
+                </v-col>
+              </v-row>
+            </template>
+            <v-row dense>
+              <v-col>
+                <v-text-field
+                  label="Copies to Keep"
+                  v-model.number="configForm.copies_to_keep"
+                  density="comfortable"
+                  variant="outlined"
+                  type="number"
+                  min="1"
+                ></v-text-field>
+              </v-col>
+              <v-col>
+                <v-spacer></v-spacer>
+              </v-col>
+            </v-row>
+            <v-row dense>
+              <v-col>
+                <v-btn color="primary" @click="saveConfig" :loading="isSaving">Save Settings</v-btn>
+              </v-col>
+            </v-row>
+          </v-container>
+        </v-sheet>
+      </v-col>
+
+      <!-- Manual Backup & Upload Restore -->
+      <v-col cols="12" md="6">
+        <v-sheet border rounded>
+          <v-container>
+            <v-row dense>
+              <v-col>
+                <h4 class="text-h6 font-weight-bold mb-2">Manual Backup</h4>
+              </v-col>
+            </v-row>
+            <v-row dense>
+              <v-col>
+                <v-btn color="primary" prepend-icon="mdi-database-arrow-up" @click="runBackup">
+                  Backup Now
+                </v-btn>
+              </v-col>
+            </v-row>
+            <v-row dense class="mt-4">
+              <v-col>
+                <h4 class="text-h6 font-weight-bold mb-2">Restore from File</h4>
+              </v-col>
+            </v-row>
+            <v-row dense>
+              <v-col>
+                <v-file-input
+                  label="Upload backup file"
+                  v-model="uploadFile"
+                  density="comfortable"
+                  variant="outlined"
+                  accept=".json.gz,.json"
+                  prepend-icon=""
+                  prepend-inner-icon="mdi-upload"
+                ></v-file-input>
+              </v-col>
+            </v-row>
+            <v-row dense>
+              <v-col>
+                <v-btn
+                  color="error"
+                  prepend-icon="mdi-database-import"
+                  :disabled="!uploadFile"
+                  @click="confirmRestoreUpload"
+                  :loading="isRestoring"
+                >
+                  Restore from Upload
+                </v-btn>
+              </v-col>
+            </v-row>
+          </v-container>
+        </v-sheet>
+      </v-col>
+    </v-row>
+
+    <!-- Backup Files -->
+    <v-row class="mt-2">
+      <v-col>
+        <v-sheet border rounded>
+          <v-container>
+            <v-row dense>
+              <v-col>
+                <h4 class="text-h6 font-weight-bold mb-2">Backup Files</h4>
+              </v-col>
+              <v-col class="d-flex justify-end">
+                <v-btn icon="mdi-refresh" size="small" variant="text" @click="refetch"></v-btn>
+              </v-col>
+            </v-row>
+            <v-row>
+              <v-col>
+                <v-data-table
+                  :headers="headers"
+                  :items="databaseBackups"
+                  :loading="filesLoading"
+                  density="compact"
+                  no-data-text="No backups found"
+                >
+                  <template v-slot:item.created_at="{ item }">
+                    {{ formatDate(item.created_at) }}
+                  </template>
+                  <template v-slot:item.size="{ item }">
+                    {{ formatSize(item.size) }}
+                  </template>
+                  <template v-slot:item.actions="{ item }">
+                    <v-btn
+                      icon="mdi-download"
+                      size="small"
+                      variant="text"
+                      @click="downloadBackup(item.filename)"
+                    ></v-btn>
+                    <v-btn
+                      icon="mdi-database-import"
+                      size="small"
+                      variant="text"
+                      color="warning"
+                      @click="confirmRestore(item.filename)"
+                    ></v-btn>
+                    <v-btn
+                      icon="mdi-delete"
+                      size="small"
+                      variant="text"
+                      color="error"
+                      @click="confirmDelete(item.filename)"
+                    ></v-btn>
+                  </template>
+                </v-data-table>
+              </v-col>
+            </v-row>
+          </v-container>
+        </v-sheet>
+      </v-col>
+    </v-row>
+
+    <!-- Restore Confirm Dialog -->
+    <v-dialog v-model="restoreDialog" max-width="480">
+      <v-card>
+        <v-card-title class="text-h6">Confirm Restore</v-card-title>
+        <v-card-text>
+          <v-alert type="warning" variant="tonal" class="mb-2">
+            This will <strong>replace all current data</strong> with the contents of
+            <strong>{{ pendingRestoreFile }}</strong>. The app may be briefly unavailable.
+            This cannot be undone.
+          </v-alert>
+          Are you sure you want to proceed?
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer></v-spacer>
+          <v-btn @click="restoreDialog = false">Cancel</v-btn>
+          <v-btn color="error" @click="doRestore" :loading="isRestoring">Restore</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <!-- Delete Confirm Dialog -->
+    <v-dialog v-model="deleteDialog" max-width="400">
+      <v-card>
+        <v-card-title class="text-h6">Delete Backup</v-card-title>
+        <v-card-text>
+          Delete <strong>{{ pendingDeleteFile }}</strong>? This cannot be undone.
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer></v-spacer>
+          <v-btn @click="deleteDialog = false">Cancel</v-btn>
+          <v-btn color="error" @click="doDelete">Delete</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+  </v-container>
+</template>
+
+<script setup>
+  import { ref, computed, watch } from "vue";
+  import {
+    useBackupConfig,
+    useBackupFiles,
+    downloadBackup,
+  } from "@/composables/backupComposable";
+
+  const { backupConfig, editBackupConfig } = useBackupConfig();
+  const {
+    backupFiles,
+    isLoading: filesLoading,
+    refetch,
+    runBackup,
+    deleteBackup,
+    restoreDatabase,
+    restoreFromUpload,
+    isRestoring,
+  } = useBackupFiles();
+
+  const configForm = ref({
+    backup_enabled: true,
+    frequency: "DAILY",
+    backup_time: "02:00",
+    copies_to_keep: 2,
+  });
+
+  const isSaving = ref(false);
+  const uploadFile = ref(null);
+  const restoreDialog = ref(false);
+  const deleteDialog = ref(false);
+  const pendingRestoreFile = ref(null);
+  const pendingDeleteFile = ref(null);
+  const isUploadRestore = ref(false);
+
+  const frequencyOptions = [
+    { label: "Hourly", value: "HOURLY" },
+    { label: "Daily", value: "DAILY" },
+    { label: "Weekly", value: "WEEKLY" },
+  ];
+
+  const headers = [
+    { title: "Filename", key: "filename" },
+    { title: "Date", key: "created_at" },
+    { title: "Size", key: "size" },
+    { title: "Actions", key: "actions", sortable: false },
+  ];
+
+  const databaseBackups = computed(() =>
+    (backupFiles.value ?? []).filter(f => f.backup_type === "database"),
+  );
+
+  watch(backupConfig, val => {
+    if (val) {
+      configForm.value = {
+        backup_enabled: val.backup_enabled,
+        frequency: val.frequency,
+        backup_time: val.backup_time,
+        copies_to_keep: val.copies_to_keep,
+      };
+    }
+  });
+
+  function saveConfig() {
+    isSaving.value = true;
+    editBackupConfig({ ...configForm.value });
+    setTimeout(() => (isSaving.value = false), 1000);
+  }
+
+  function confirmRestore(filename) {
+    pendingRestoreFile.value = filename;
+    isUploadRestore.value = false;
+    restoreDialog.value = true;
+  }
+
+  function confirmRestoreUpload() {
+    pendingRestoreFile.value = uploadFile.value?.name ?? "uploaded file";
+    isUploadRestore.value = true;
+    restoreDialog.value = true;
+  }
+
+  function doRestore() {
+    if (isUploadRestore.value) {
+      restoreFromUpload(uploadFile.value);
+    } else {
+      restoreDatabase(pendingRestoreFile.value);
+    }
+    restoreDialog.value = false;
+  }
+
+  function confirmDelete(filename) {
+    pendingDeleteFile.value = filename;
+    deleteDialog.value = true;
+  }
+
+  function doDelete() {
+    deleteBackup(pendingDeleteFile.value);
+    deleteDialog.value = false;
+  }
+
+  function formatDate(dt) {
+    return new Date(dt).toLocaleString();
+  }
+
+  function formatSize(bytes) {
+    if (bytes < 1024) return bytes + " B";
+    if (bytes < 1048576) return (bytes / 1024).toFixed(1) + " KB";
+    return (bytes / 1048576).toFixed(1) + " MB";
+  }
+</script>


### PR DESCRIPTION
## Summary

- Replaces django-dbbackup with a custom `export_user_data` / `import_user_data` pipeline that produces portable, version-agnostic gzipped JSON backups (system fixture data excluded; system FK references stored as slugs)
- `import_user_data` runs inside `db_transaction.atomic()` — rolls back the full clear+restore if anything fails
- New `BackupConfig` singleton controls schedule frequency, backup time, and copies-to-keep; synced into django-q2 on startup
- Full backup/restore UI: schedule config, manual backup trigger, file listing with download/restore/delete, and upload-and-restore from a local file
- Scheduled `create_backup` task hardened with `*args/**kwargs` to tolerate extra arguments from django-q2 scheduler

## Test plan

- [ ] Run `pytest backend/administration/tests/` — 14 API tests + 11 unit/command tests
- [ ] `docker compose up -d` and navigate to Backup & Restore page
- [ ] Verify schedule config saves and persists across reload
- [ ] Trigger manual backup and confirm `.json.gz` appears in the file list
- [ ] Download and inspect the backup file
- [ ] Restore from a stored file and confirm data is preserved
- [ ] Upload a backup file and restore from upload
- [ ] Confirm scheduled task runs without the "2 positional arguments" error in worker logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)