### PR TITLE
feat: improve retirement forecast with area chart and transaction list

### DIFF
--- a/backend/planning/api/schemas/retirement.py
+++ b/backend/planning/api/schemas/retirement.py
@@ -1,6 +1,8 @@
 from ninja import Schema
 from typing import List, Optional
 from pydantic import condecimal
+from datetime import date
+from decimal import Decimal
 
 TensionDecimal = condecimal(max_digits=2, decimal_places=1)
 DataDecimal = condecimal(max_digits=12, decimal_places=2)
@@ -31,6 +33,7 @@ class DatasetObject(Schema):
     label: Optional[str] = None
     hoverBackgroundColor: Optional[str] = "rgba(75,192,192,0.6)"
     hoverBorderColor: Optional[str] = "rgba(75,192,192,1)"
+    fill: Optional[bool] = None
 
 
 # The class GraphData is a schema representing a graph data object.
@@ -43,3 +46,15 @@ class GraphData(Schema):
 class ForecastOut(Schema):
     labels: List[str]
     datasets: List[DatasetObject]
+
+
+class RetirementTransactionOut(Schema):
+    transaction_date: date
+    account_name: str
+    description: str
+    total_amount: Decimal
+    balance: Optional[Decimal] = None
+    status_name: str
+    transaction_type_name: str
+
+    model_config = {"from_attributes": True}

--- a/backend/planning/api/views/retirement.py
+++ b/backend/planning/api/views/retirement.py
@@ -1,7 +1,9 @@
 from ninja import Router
 from ninja.errors import HttpError
-from planning.api.schemas.retirement import DatasetObject, ForecastOut
+from typing import List
+from planning.api.schemas.retirement import DatasetObject, ForecastOut, RetirementTransactionOut
 from planning.services import get_retirement_forecast
+from planning.services.retirement import get_retirement_transactions
 import logging
 
 api_logger = logging.getLogger("api")
@@ -12,16 +14,6 @@ retirement_router = Router(tags=["Retirement"])
 
 @retirement_router.get("/get", response=ForecastOut)
 def get_forecast(request):
-    """
-    The function `get_forecast` retrieves the forecast data for the retirement
-    accounts
-
-    Args:
-        request (HttpRequest): The HTTP request object.
-
-    Returns:
-        ForecastOut: the forecast object
-    """
     try:
         domain = get_retirement_forecast()
         datasets = [
@@ -35,6 +27,7 @@ def get_forecast(request):
                 hitRadius=ds.hitRadius,
                 hoverRadius=ds.hoverRadius,
                 label=ds.label,
+                fill=ds.fill,
             )
             for ds in domain.datasets
         ]
@@ -42,5 +35,17 @@ def get_forecast(request):
         return ForecastOut(labels=domain.labels, datasets=datasets)
     except Exception as e:
         api_logger.error("Forecast not retrieved")
+        error_logger.error(f"{str(e)}")
+        raise HttpError(500, f"Record retrieval error : {str(e)}")
+
+
+@retirement_router.get("/transactions", response=List[RetirementTransactionOut])
+def get_transactions(request):
+    try:
+        transactions = get_retirement_transactions()
+        api_logger.debug("Retirement transactions retrieved")
+        return transactions
+    except Exception as e:
+        api_logger.error("Retirement transactions not retrieved")
         error_logger.error(f"{str(e)}")
         raise HttpError(500, f"Record retrieval error : {str(e)}")

--- a/backend/planning/dto.py
+++ b/backend/planning/dto.py
@@ -114,6 +114,7 @@ class DomainDataSetObject:
     label: Optional[str] = None
     hoverBackgroundColor: Optional[str] = "rgba(75,192,192,0.6)"
     hoverBorderColor: Optional[str] = "rgba(75,192,192,1)"
+    fill: Optional[bool] = None
 
 
 @dataclass

--- a/backend/planning/services/__init__.py
+++ b/backend/planning/services/__init__.py
@@ -1,2 +1,3 @@
 from planning.services.retirement import get_retirement_forecast as get_retirement_forecast
+from planning.services.retirement import get_retirement_transactions as get_retirement_transactions
 from planning.services.budget import calculate_repeat_window as calculate_repeat_window

--- a/backend/planning/services/retirement.py
+++ b/backend/planning/services/retirement.py
@@ -10,6 +10,7 @@ from utils.dates import (
     get_todays_date_timezone_adjusted,
 )
 from planning.dto import DomainForecast, DomainDataSetObject
+from planning.api.schemas.retirement import RetirementTransactionOut
 
 COLORS = [
     "#7fb1b1", "#597c7c", "#7f8cb1", "#7fb17f", "#597c59",
@@ -20,18 +21,26 @@ COLORS = [
 ]
 
 
-def get_retirement_forecast() -> DomainForecast:
+def _hex_to_rgba(hex_color: str, alpha: float = 0.5) -> str:
+    hex_color = hex_color.lstrip("#")
+    r, g, b = int(hex_color[0:2], 16), int(hex_color[2:4], 16), int(hex_color[4:6], 16)
+    return f"rgba({r},{g},{b},{alpha})"
+
+
+def _get_retirement_account_ids() -> list:
     try:
         option = Option.load()
         retirement_accounts_string = option.retirement_accounts if option else None
         if not retirement_accounts_string:
-            retirement_array = []
-        else:
-            retirement_array = ast.literal_eval(retirement_accounts_string)
-            if not isinstance(retirement_array, list):
-                retirement_array = []
+            return []
+        retirement_array = ast.literal_eval(retirement_accounts_string)
+        return retirement_array if isinstance(retirement_array, list) else []
     except (Option.DoesNotExist, ValueError, SyntaxError):
-        retirement_array = []
+        return []
+
+
+def get_retirement_forecast() -> DomainForecast:
+    retirement_array = _get_retirement_account_ids()
 
     today = get_todays_date_timezone_adjusted()
     jan_1st = date(today.year, 1, 1)
@@ -88,13 +97,15 @@ def get_retirement_forecast() -> DomainForecast:
             hitRadius=5,
             hoverRadius=5,
             label="Total",
+            fill=False,
         )
     ]
     for index, account in enumerate(account_info):
-        color = COLORS[index % len(COLORS)]
+        border_color = COLORS[index % len(COLORS)]
+        bg_color = _hex_to_rgba(border_color, 0.5)
         datasets.append(DomainDataSetObject(
-            borderColor=color,
-            backgroundColor=color,
+            borderColor=border_color,
+            backgroundColor=bg_color,
             tension=0.1,
             data=account["data"],
             pointStyle="line",
@@ -102,6 +113,58 @@ def get_retirement_forecast() -> DomainForecast:
             hitRadius=5,
             hoverRadius=5,
             label=account["name"],
+            fill=True,
         ))
 
     return DomainForecast(labels=labels, datasets=datasets)
+
+
+def get_retirement_transactions() -> list:
+    retirement_array = _get_retirement_account_ids()
+    if not retirement_array:
+        return []
+
+    today = get_todays_date_timezone_adjusted()
+    jan_1st = date(today.year, 1, 1)
+    dec_31st = date(today.year, 12, 31)
+    start_interval = (today - jan_1st).days
+    end_interval = (dec_31st - today).days
+    start_date = get_forecast_start_date(start_interval)
+    end_date = get_forecast_end_date(end_interval)
+
+    results = []
+    for account_id in retirement_array:
+        try:
+            account_obj = Account.objects.get(id=account_id)
+        except Account.DoesNotExist:
+            continue
+
+        transactions_list, _ = get_account_transactions_and_balances(
+            end_date, account_id, False, True, start_date, False
+        )
+        for t in transactions_list:
+            if isinstance(t, dict):
+                status = t.get("status") or {}
+                txn_type = t.get("transaction_type") or {}
+                results.append(RetirementTransactionOut(
+                    transaction_date=t["transaction_date"],
+                    account_name=account_obj.account_name,
+                    description=t.get("description", ""),
+                    total_amount=t.get("total_amount", 0),
+                    balance=t.get("balance"),
+                    status_name=status.get("transaction_status", "") if isinstance(status, dict) else getattr(status, "transaction_status", ""),
+                    transaction_type_name=txn_type.get("transaction_type", "") if isinstance(txn_type, dict) else getattr(txn_type, "transaction_type", ""),
+                ))
+            else:
+                results.append(RetirementTransactionOut(
+                    transaction_date=t.transaction_date,
+                    account_name=account_obj.account_name,
+                    description=t.description,
+                    total_amount=t.total_amount,
+                    balance=t.balance,
+                    status_name=t.status.transaction_status if t.status else "",
+                    transaction_type_name=t.transaction_type.transaction_type if t.transaction_type else "",
+                ))
+
+    results.sort(key=lambda x: x.transaction_date)
+    return results

--- a/frontend/src/components/RetirementForecastWidget.vue
+++ b/frontend/src/components/RetirementForecastWidget.vue
@@ -69,13 +69,38 @@
       </v-progress-circular>
       <Line
         :data="retirement_forecast"
-        :options="options"
+        :options="chartOptions"
         v-if="!isActive"
         ref="Forecast"
         aria-label="Account Forecast"
       >
         Unable to load forecast
       </Line>
+    </v-card-text>
+
+    <!-- Transaction List -->
+    <v-card-text>
+      <v-divider class="mb-3"></v-divider>
+      <div class="text-subtitle-2 text-primary mb-2">Transactions</div>
+      <v-data-table
+        :headers="txnHeaders"
+        :items="retirement_transactions ?? []"
+        :loading="txnLoading"
+        density="compact"
+        no-data-text="No transactions found"
+        :items-per-page="TXN_PAGE_SIZE"
+        v-model:page="txnPage"
+      >
+        <template v-slot:item.transaction_date="{ item }">
+          {{ formatDate(item.transaction_date) }}
+        </template>
+        <template v-slot:item.total_amount="{ item }">
+          {{ formatCurrency(item.total_amount) }}
+        </template>
+        <template v-slot:item.balance="{ item }">
+          {{ item.balance != null ? formatCurrency(item.balance) : "—" }}
+        </template>
+      </v-data-table>
     </v-card-text>
   </v-card>
 </template>
@@ -95,7 +120,7 @@
   } from "chart.js";
   import { Line } from "vue-chartjs";
   import annotationPlugin from "chartjs-plugin-annotation";
-  import { useRetirementForecast } from "@/composables/retirementComposable";
+  import { useRetirementForecast, useRetirementTransactions } from "@/composables/retirementComposable";
   import { useField, useForm } from "vee-validate";
   import { useOptions } from "@/composables/optionsComposable";
   import { useAccounts } from "@/composables/accountsComposable";
@@ -127,11 +152,13 @@
     { immediate: true },
   );
 
-  const { isLoading, retirement_forecast, isFetching } =
-    useRetirementForecast();
+  const { isLoading, retirement_forecast, isFetching } = useRetirementForecast();
+  const { retirement_transactions, isLoading: txnLoading } = useRetirementTransactions();
+
   const isActive = computed(
     () => !(isLoading.value === false && isFetching.value === false),
   );
+
   ChartJS.register(
     CategoryScale,
     LinearScale,
@@ -144,7 +171,31 @@
     annotationPlugin,
   );
 
-  const options = ref({
+  const TXN_PAGE_SIZE = 15;
+  const txnPage = ref(1);
+
+  watch(
+    retirement_transactions,
+    txns => {
+      if (!txns || txns.length === 0) return;
+      const today = new Date().toISOString().slice(0, 10);
+      const idx = txns.findIndex(t => t.transaction_date >= today);
+      const target = idx >= 0 ? idx : txns.length - 1;
+      txnPage.value = Math.floor(target / TXN_PAGE_SIZE) + 1;
+    },
+    { immediate: true },
+  );
+
+  const txnHeaders = [
+    { title: "Date", key: "transaction_date" },
+    { title: "Account", key: "account_name" },
+    { title: "Description", key: "description" },
+    { title: "Type", key: "transaction_type_name" },
+    { title: "Amount", key: "total_amount", align: "end" },
+    { title: "Balance", key: "balance", align: "end" },
+  ];
+
+  const chartOptions = ref({
     responsive: true,
     maintainAspectRatio: true,
     aspectRatio: "5",
@@ -186,10 +237,7 @@
         callbacks: {
           label: function (context) {
             let label = context.dataset.label || "";
-
-            if (label) {
-              label += ": ";
-            }
+            if (label) label += ": ";
             if (context.parsed.y !== null) {
               label += new Intl.NumberFormat("en-US", {
                 style: "currency",
@@ -207,7 +255,6 @@
     scales: {
       y: {
         ticks: {
-          // Include a dollar sign in the ticks
           callback: function (value) {
             return "$" + value;
           },
@@ -215,6 +262,21 @@
       },
     },
   });
+
+  function formatDate(d) {
+    return new Date(d + "T00:00:00").toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    });
+  }
+
+  function formatCurrency(val) {
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: "USD",
+    }).format(val);
+  }
 
   const submit = handleSubmit(values => {
     let data = {

--- a/frontend/src/components/RetirementForecastWidgetMobile.vue
+++ b/frontend/src/components/RetirementForecastWidgetMobile.vue
@@ -67,13 +67,35 @@
       </v-progress-circular>
       <Line
         :data="retirement_forecast"
-        :options="options"
+        :options="chartOptions"
         v-if="!isActive"
         ref="Forecast"
         aria-label="Account Forecast"
       >
         Unable to load forecast
       </Line>
+
+      <v-divider class="my-3"></v-divider>
+      <div class="text-subtitle-2 text-primary mb-2">Transactions</div>
+      <v-data-table
+        :headers="txnHeaders"
+        :items="retirement_transactions ?? []"
+        :loading="txnLoading"
+        density="compact"
+        no-data-text="No transactions found"
+        :items-per-page="TXN_PAGE_SIZE"
+        v-model:page="txnPage"
+      >
+        <template v-slot:item.transaction_date="{ item }">
+          {{ formatDate(item.transaction_date) }}
+        </template>
+        <template v-slot:item.total_amount="{ item }">
+          {{ formatCurrency(item.total_amount) }}
+        </template>
+        <template v-slot:item.balance="{ item }">
+          {{ item.balance != null ? formatCurrency(item.balance) : "—" }}
+        </template>
+      </v-data-table>
     </template>
   </v-card>
 </template>
@@ -92,7 +114,7 @@
   } from "chart.js";
   import { Line } from "vue-chartjs";
   import annotationPlugin from "chartjs-plugin-annotation";
-  import { useRetirementForecast } from "@/composables/retirementComposable";
+  import { useRetirementForecast, useRetirementTransactions } from "@/composables/retirementComposable";
   import { useField, useForm } from "vee-validate";
   import { useOptions } from "@/composables/optionsComposable";
   import { useAccounts } from "@/composables/accountsComposable";
@@ -123,11 +145,13 @@
     { immediate: true },
   );
 
-  const { isLoading, retirement_forecast, isFetching } =
-    useRetirementForecast();
+  const { isLoading, retirement_forecast, isFetching } = useRetirementForecast();
+  const { retirement_transactions, isLoading: txnLoading } = useRetirementTransactions();
+
   const isActive = computed(
     () => !(isLoading.value === false && isFetching.value === false),
   );
+
   ChartJS.register(
     CategoryScale,
     LinearScale,
@@ -140,7 +164,30 @@
     annotationPlugin,
   );
 
-  const options = ref({
+  const TXN_PAGE_SIZE = 10;
+  const txnPage = ref(1);
+
+  watch(
+    retirement_transactions,
+    txns => {
+      if (!txns || txns.length === 0) return;
+      const today = new Date().toISOString().slice(0, 10);
+      const idx = txns.findIndex(t => t.transaction_date >= today);
+      const target = idx >= 0 ? idx : txns.length - 1;
+      txnPage.value = Math.floor(target / TXN_PAGE_SIZE) + 1;
+    },
+    { immediate: true },
+  );
+
+  const txnHeaders = [
+    { title: "Date", key: "transaction_date" },
+    { title: "Account", key: "account_name" },
+    { title: "Description", key: "description" },
+    { title: "Amount", key: "total_amount", align: "end" },
+    { title: "Balance", key: "balance", align: "end" },
+  ];
+
+  const chartOptions = ref({
     responsive: true,
     maintainAspectRatio: true,
     aspectRatio: "1",
@@ -182,10 +229,7 @@
         callbacks: {
           label: function (context) {
             let label = context.dataset.label || "";
-
-            if (label) {
-              label += ": ";
-            }
+            if (label) label += ": ";
             if (context.parsed.y !== null) {
               label += new Intl.NumberFormat("en-US", {
                 style: "currency",
@@ -203,7 +247,6 @@
     scales: {
       y: {
         ticks: {
-          // Include a dollar sign in the ticks
           callback: function (value) {
             return "$" + value;
           },
@@ -211,6 +254,21 @@
       },
     },
   });
+
+  function formatDate(d) {
+    return new Date(d + "T00:00:00").toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    });
+  }
+
+  function formatCurrency(val) {
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: "USD",
+    }).format(val);
+  }
 
   const submit = handleSubmit(values => {
     let data = {

--- a/frontend/src/composables/retirementComposable.js
+++ b/frontend/src/composables/retirementComposable.js
@@ -27,6 +27,15 @@ async function getRetirementForecastFunction() {
   }
 }
 
+async function getRetirementTransactionsFunction() {
+  try {
+    const response = await apiClient.get("/planning/retirement/transactions");
+    return response.data;
+  } catch (error) {
+    handleApiError(error, "Retirement transactions not fetched: ");
+  }
+}
+
 export function useRetirementForecast() {
   const queryClient = useQueryClient();
   const {
@@ -44,5 +53,20 @@ export function useRetirementForecast() {
     isLoading,
     isFetching,
     retirement_forecast,
+  };
+}
+
+export function useRetirementTransactions() {
+  const queryClient = useQueryClient();
+  const { data: retirement_transactions, isLoading } = useQuery({
+    queryKey: ["retirement_transactions"],
+    queryFn: () => getRetirementTransactionsFunction(),
+    select: response => response,
+    client: queryClient,
+  });
+
+  return {
+    retirement_transactions,
+    isLoading,
   };
 }


### PR DESCRIPTION
## Summary

- Retirement graph upgraded from plain line chart to filled area chart — each account dataset fills to the x-axis with semi-transparent color; Total remains an unfilled line on top for a clean reference
- New `GET /planning/retirement/transactions` endpoint returns all transactions (historical + projected) across configured retirement accounts for the current year, sorted ascending by date
- Both desktop and mobile widgets show a paginated transaction table below the graph (date, account, description, type, amount, balance) that automatically jumps to the page containing today's date on load

## Test plan

- [ ] Navigate to Planning → Retirement
- [ ] Confirm chart renders as filled areas per account with Total line on top
- [ ] Confirm y-axis values match the lines (no inversion)
- [ ] Confirm transaction table appears below the chart
- [ ] Confirm table defaults to the page containing today's date
- [ ] Confirm transactions are sorted Jan → Dec
- [ ] Test with multiple retirement accounts selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)