### PR TITLE
perf: async forecast cache updates, N+1 elimination, and query invalidation fixes

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -263,6 +263,7 @@ Q_CLUSTER = {
     "max_attempts": 1,
     "label": "Tasks",
     "catch_up": False,
+    "poll": 1,
 }
 
 JAZZMIN_SETTINGS = {

--- a/backend/reminders/signals.py
+++ b/backend/reminders/signals.py
@@ -7,87 +7,59 @@ from transactions.models import (
 from django_q.tasks import async_task
 from core.cache.helpers import delete_pattern
 from core.cache.keys import (
+    account_all,
     account_combined_transactions,
     account_reminder_transactions,
 )
 
 
 @receiver(post_save, sender=Reminder)
-def update_reminder_cache_on_save(sender, instance, **kwargs):
-    """
-    Update the reminder scratch/cache table when a Reminder is created or updated.
-    """
+def update_and_invalidate_cache_on_save(sender, instance, **kwargs):
     async_task("transactions.tasks.update_reminder_cache", instance.id)
+    delete_pattern(
+        account_reminder_transactions(instance.reminder_source_account.id)
+    )
+    delete_pattern(
+        account_combined_transactions(instance.reminder_source_account.id)
+    )
+    if instance.reminder_destination_account is not None:
+        delete_pattern(
+            account_reminder_transactions(instance.reminder_destination_account.id)
+        )
+        delete_pattern(
+            account_combined_transactions(instance.reminder_destination_account.id)
+        )
 
 
 @receiver(post_delete, sender=Reminder)
-def update_reminder_cache_on_delete(sender, instance, **kwargs):
-    """
-    Remove entries from the reminder scratch table when a Reminder is deleted.
-    """
+def update_and_invalidate_cache_on_delete(sender, instance, **kwargs):
     ReminderCacheTransaction.objects.filter(reminder=instance).delete()
+    source = instance.reminder_source_account
+    delete_pattern(account_reminder_transactions(source.id))
+    delete_pattern(account_combined_transactions(source.id))
+    # If source is a CC account, its funding account holds the payment forecast —
+    # clear that cache too so it doesn't serve stale payment entries.
+    if source.funding_account_id:
+        delete_pattern(account_all(source.funding_account_id))
     async_task(
         "transactions.tasks.update_cc_forecast_cache",
-        instance.reminder_source_account.id,
+        source.id,
     )
     async_task(
         "transactions.tasks.update_interest_forecast_cache",
-        instance.reminder_source_account.id,
+        source.id,
     )
     if instance.reminder_destination_account is not None:
+        dest = instance.reminder_destination_account
+        delete_pattern(account_reminder_transactions(dest.id))
+        delete_pattern(account_combined_transactions(dest.id))
+        if dest.funding_account_id:
+            delete_pattern(account_all(dest.funding_account_id))
         async_task(
             "transactions.tasks.update_cc_forecast_cache",
-            instance.reminder_destination_account.id,
+            dest.id,
         )
         async_task(
             "transactions.tasks.update_interest_forecast_cache",
-            instance.reminder_destination_account.id,
-        )
-
-
-@receiver(post_save, sender=Reminder)
-def invalidate_cache_on_save(sender, instance, **kwargs):
-    """
-    Update the reminder scratch/cache table when a Reminder is created or updated.
-    """
-    delete_pattern(
-        account_reminder_transactions(instance.reminder_source_account.id)
-    )
-    delete_pattern(
-        account_combined_transactions(instance.reminder_source_account.id)
-    )
-    if instance.reminder_destination_account is not None:
-        delete_pattern(
-            account_reminder_transactions(
-                instance.reminder_destination_account.id
-            )
-        )
-        delete_pattern(
-            account_combined_transactions(
-                instance.reminder_destination_account.id
-            )
-        )
-
-
-@receiver(post_delete, sender=Reminder)
-def invalidate_cache_on_delete(sender, instance, **kwargs):
-    """
-    Remove entries from the reminder scratch table when a Reminder is deleted.
-    """
-    delete_pattern(
-        account_reminder_transactions(instance.reminder_source_account.id)
-    )
-    delete_pattern(
-        account_combined_transactions(instance.reminder_source_account.id)
-    )
-    if instance.reminder_destination_account is not None:
-        delete_pattern(
-            account_reminder_transactions(
-                instance.reminder_destination_account.id
-            )
-        )
-        delete_pattern(
-            account_combined_transactions(
-                instance.reminder_destination_account.id
-            )
+            dest.id,
         )

--- a/backend/transactions/api/dependencies/get_transactions_by_account.py
+++ b/backend/transactions/api/dependencies/get_transactions_by_account.py
@@ -45,11 +45,15 @@ def get_transactions_by_account(
     Returns:
         transactions: List of transaction objects
     """
-    # Check Cache
+    # Forecast results depend on async task completion — skip cache to ensure freshness.
+    # Non-forecast results are safe to cache since they only change via mutations which
+    # clear the cache immediately.
+    use_cache = not forecast
     key = f"{account_combined_transactions(account_id)}:{end_date}:{totals_only}:{forecast}:{start_date}:{cleared_only}"
-    data = cache.get(key)
-    if data:
-        return data
+    if use_cache:
+        data = cache.get(key)
+        if data:
+            return data
 
     # Setup variables
     today = get_todays_date_timezone_adjusted()
@@ -220,9 +224,9 @@ def get_transactions_by_account(
             else:
                 previous_balance = previous_transactions[-1].balance
         my_tuple = (filtered_transactions, previous_balance)
-        cache.set(key, my_tuple, timeout=60 * 60)
         return my_tuple
     else:
         my_tuple = (transactions, Decimal(0.00))
-        cache.set(key, my_tuple, timeout=60 * 60)
+        if use_cache:
+            cache.set(key, my_tuple, timeout=60 * 60)
         return my_tuple

--- a/backend/transactions/api/dependencies/transaction_utilities.py
+++ b/backend/transactions/api/dependencies/transaction_utilities.py
@@ -213,40 +213,48 @@ def add_tags_to_transactions(
 
     _extended_summary_
     """
-    # Add tags to transactions
-    for transaction in transactions:
-        transaction_details = None
-        if type == "t":
-            transaction_details = TransactionDetail.objects.filter(
-                transaction_id=transaction.id
-            )
-        if type == "r":
-            transaction_details = ReminderCacheTransactionDetail.objects.filter(
-                transaction_id=transaction.id
-            )
-        if type == "f":
-            transaction_details = ForecastCacheTransactionDetail.objects.filter(
-                transaction_id=transaction.id
-            )
-        details = list(transaction_details)
-        tag_list = list(
-            transaction_details.annotate(
-                parent_tag=F("tag__parent__tag_name"),
-                child_tag=F("tag__child__tag_name"),
-                tag_name_combined=Case(
-                    When(child_tag__isnull=True, then=F("parent_tag")),
-                    default=Concat(
-                        F("parent_tag"), Value(" / "), F("child_tag")
-                    ),
-                    output_field=CharField(),
+    transaction_list = list(transactions)
+    if not transaction_list:
+        return transactions
+
+    txn_ids = [t.id for t in transaction_list]
+
+    if type == "t":
+        detail_model = TransactionDetail
+    elif type == "r":
+        detail_model = ReminderCacheTransactionDetail
+    else:
+        detail_model = ForecastCacheTransactionDetail
+
+    all_details = list(
+        detail_model.objects.filter(transaction_id__in=txn_ids)
+        .select_related("transaction", "tag")
+        .annotate(
+            parent_tag=F("tag__parent__tag_name"),
+            child_tag=F("tag__child__tag_name"),
+            tag_name_combined=Case(
+                When(child_tag__isnull=True, then=F("parent_tag")),
+                default=Concat(
+                    F("parent_tag"), Value(" / "), F("child_tag")
                 ),
-            )
-            .exclude(tag_name_combined__isnull=True)
-            .values_list("tag_name_combined", flat=True)
+                output_field=CharField(),
+            ),
         )
-        transaction.tags = tag_list
-        transaction.details = details
-    return transactions
+    )
+
+    details_by_txn: dict = {}
+    tags_by_txn: dict = {}
+    for detail in all_details:
+        tid = detail.transaction_id
+        details_by_txn.setdefault(tid, []).append(detail)
+        if detail.tag_name_combined:
+            tags_by_txn.setdefault(tid, []).append(detail.tag_name_combined)
+
+    for transaction in transaction_list:
+        transaction.tags = tags_by_txn.get(transaction.id, [])
+        transaction.details = details_by_txn.get(transaction.id, [])
+
+    return transaction_list
 
 
 def sort_transaction_list(

--- a/backend/transactions/services/transactions_and_balances.py
+++ b/backend/transactions/services/transactions_and_balances.py
@@ -85,19 +85,19 @@ def get_account_transactions_and_balances(
     all_transactions = Transaction.objects.filter(
         Q(source_account_id=account_id) | Q(destination_account_id=account_id),
         transaction_date__lt=end_date,
-    ).exclude(status__slug='archived')
+    ).exclude(status__slug='archived').select_related("status", "transaction_type")
 
     # Get Reminder transactions
     reminder_transactions = ReminderCacheTransaction.objects.filter(
         Q(source_account_id=account_id) | Q(destination_account_id=account_id),
         transaction_date__lt=end_date,
-    ).exclude(status__slug='archived')
+    ).exclude(status__slug='archived').select_related("status", "transaction_type")
 
     # Get Forecast transactions
     forecast_transactions = ForecastCacheTransaction.objects.filter(
         Q(source_account_id=account_id) | Q(destination_account_id=account_id),
         transaction_date__lt=end_date,
-    ).exclude(status__slug='archived')
+    ).exclude(status__slug='archived').select_related("status", "transaction_type")
 
     # If not totals only, annotate transactions with pretty information
     if not totals_only:

--- a/backend/transactions/services/transactions_and_balances.py
+++ b/backend/transactions/services/transactions_and_balances.py
@@ -59,11 +59,13 @@ def get_account_transactions_and_balances(
     Returns:
         transactions: List of transaction objects
     """
-    # Check Cache
+    # Forecast results depend on async task completion — skip cache to ensure freshness.
+    use_cache = not forecast
     key = f"{account_combined_transactions(account_id)}:{end_date}:{totals_only}:{forecast}:{start_date}:{cleared_only}"
-    data = cache.get(key)
-    if data:
-        return data
+    if use_cache:
+        data = cache.get(key)
+        if data:
+            return data
 
     # Setup variables
     today = get_todays_date_timezone_adjusted()
@@ -234,11 +236,11 @@ def get_account_transactions_and_balances(
             else:
                 previous_balance = previous_transactions[-1].balance
         my_tuple = (filtered_transactions, previous_balance)
-        cache.set(key, my_tuple, timeout=60 * 60)
         return my_tuple
     else:
         my_tuple = (transactions, Decimal(0.00))
-        cache.set(key, my_tuple, timeout=60 * 60)
+        if use_cache:
+            cache.set(key, my_tuple, timeout=60 * 60)
         return my_tuple
 
 

--- a/backend/transactions/signals.py
+++ b/backend/transactions/signals.py
@@ -1,15 +1,15 @@
 from django.db.models.signals import post_save, post_delete
 from django.dispatch import receiver
 from transactions.models import Transaction
+from django_q.tasks import async_task
 from core.cache.helpers import delete_pattern
 from core.cache.keys import account_all
 
 
 def _refresh_account(account_id):
-    from transactions.tasks import update_cc_forecast_cache, update_interest_forecast_cache
     delete_pattern(account_all(account_id))
-    update_cc_forecast_cache(account_id)
-    update_interest_forecast_cache(account_id)
+    async_task("transactions.tasks.update_cc_forecast_cache", account_id)
+    async_task("transactions.tasks.update_interest_forecast_cache", account_id)
 
 
 @receiver(post_save, sender=Transaction)

--- a/backend/transactions/tasks.py
+++ b/backend/transactions/tasks.py
@@ -66,7 +66,7 @@ from transactions.api.dependencies.get_transactions_by_tag import (
 from typing import Optional
 from decimal import Decimal, ROUND_HALF_UP
 from core.cache.helpers import delete_pattern
-from core.cache.keys import account_all_transactions
+from core.cache.keys import account_all, account_all_transactions
 import logging
 
 api_logger = logging.getLogger("api")
@@ -895,7 +895,7 @@ def update_interest_forecast_cache(account_id):
             period_start = period_end
 
         create_transactions(transactions_to_create, 'forecast')
-        delete_pattern(account_all_transactions(account_id))
+        delete_pattern(account_all(account_id))
     except Exception as e:
         error_logger.exception(
             f"Error calculating interest forecast for account {account_id}: {e}"
@@ -1118,7 +1118,9 @@ def update_cc_forecast_cache(account_id):
             x += 1
 
         create_transactions(transactions_to_create, "forecast")
-        delete_pattern(account_all_transactions(account_id))
+        delete_pattern(account_all(account_id))
+        if funding_account:
+            delete_pattern(account_all(funding_account.id))
     except Exception as e:
         error_logger.exception(f"Error calculating CC forecast for account {account_id}: {e}")
 

--- a/backend/transactions/tasks.py
+++ b/backend/transactions/tasks.py
@@ -67,6 +67,7 @@ from typing import Optional
 from decimal import Decimal, ROUND_HALF_UP
 from core.cache.helpers import delete_pattern
 from core.cache.keys import account_all, account_all_transactions
+from django.db import transaction as db_transaction
 import logging
 
 api_logger = logging.getLogger("api")
@@ -816,11 +817,11 @@ def update_interest_forecast_cache(account_id):
     if account.account_type.slug not in {'savings', 'investment'}:
         return
 
-    ForecastCacheTransaction.objects.filter(
-        Q(source_account_id=account_id) | Q(destination_account_id=account_id)
-    ).delete()
-
     if not account.calculate_interest or not account.annual_rate:
+        ForecastCacheTransaction.objects.filter(
+            Q(source_account_id=account_id) | Q(destination_account_id=account_id)
+        ).delete()
+        delete_pattern(account_all(account_id))
         return
 
     try:
@@ -894,7 +895,11 @@ def update_interest_forecast_cache(account_id):
 
             period_start = period_end
 
-        create_transactions(transactions_to_create, 'forecast')
+        with db_transaction.atomic():
+            ForecastCacheTransaction.objects.filter(
+                Q(source_account_id=account_id) | Q(destination_account_id=account_id)
+            ).delete()
+            create_transactions(transactions_to_create, 'forecast')
         delete_pattern(account_all(account_id))
     except Exception as e:
         error_logger.exception(
@@ -921,14 +926,13 @@ def update_cc_forecast_cache(account_id):
     if account.account_type.slug != 'credit-card':
         return
 
-    # Delete any existing cache entries for this account
-    ForecastCacheTransaction.objects.filter(
-        Q(source_account_id=account_id)
-        | Q(destination_account_id=account_id)
-    ).delete()
-
-    # Exit if cc calculations are turned off
+    # Exit if cc calculations are turned off — clear any stale records and bail
     if not account.calculate_payments:
+        ForecastCacheTransaction.objects.filter(
+            Q(source_account_id=account_id)
+            | Q(destination_account_id=account_id)
+        ).delete()
+        delete_pattern(account_all(account_id))
         return
 
     try:
@@ -1117,7 +1121,12 @@ def update_cc_forecast_cache(account_id):
                 account.save()
             x += 1
 
-        create_transactions(transactions_to_create, "forecast")
+        with db_transaction.atomic():
+            ForecastCacheTransaction.objects.filter(
+                Q(source_account_id=account_id)
+                | Q(destination_account_id=account_id)
+            ).delete()
+            create_transactions(transactions_to_create, "forecast")
         delete_pattern(account_all(account_id))
         if funding_account:
             delete_pattern(account_all(funding_account.id))

--- a/backend/transactions/tests/unit/test_transaction_signals.py
+++ b/backend/transactions/tests/unit/test_transaction_signals.py
@@ -51,16 +51,23 @@ def test_transaction_delete_triggers_both_account_refreshes(
 
 
 @pytest.mark.django_db
-@patch("transactions.tasks.update_cc_forecast_cache")
+@patch("transactions.signals.async_task")
 @patch("transactions.signals.delete_pattern")
 def test_refresh_account_clears_cache_then_recalculates(
-    mock_delete, mock_forecast, test_transaction
+    mock_delete, mock_async_task, test_transaction
 ):
     from transactions.signals import _refresh_account
     _refresh_account(test_transaction.source_account_id)
 
     mock_delete.assert_called_once_with(account_all(test_transaction.source_account_id))
-    mock_forecast.assert_called_once_with(test_transaction.source_account_id)
+    mock_async_task.assert_any_call(
+        "transactions.tasks.update_cc_forecast_cache",
+        test_transaction.source_account_id,
+    )
+    mock_async_task.assert_any_call(
+        "transactions.tasks.update_interest_forecast_cache",
+        test_transaction.source_account_id,
+    )
 
 
 @pytest.mark.django_db

--- a/frontend/src/composables/messagesComposable.js
+++ b/frontend/src/composables/messagesComposable.js
@@ -1,7 +1,6 @@
 import { useQuery, useQueryClient, useMutation } from "@tanstack/vue-query";
 import apiClient from "./apiClient";
 import { useMainStore } from "@/stores/main";
-import { onUnmounted } from "vue";
 
 function handleApiError(error, message) {
   if (error.response?.status === 401) throw error;
@@ -74,16 +73,13 @@ async function readAllMessagesFunction() {
 
 export function useMessages() {
   const queryClient = useQueryClient();
-  const {
-    data: messages,
-    isLoading,
-    refetch,
-  } = useQuery({
+  const { data: messages, isLoading } = useQuery({
     queryKey: ["messages"],
     queryFn: () => getMessagesFunction(),
     select: response => response,
     client: queryClient,
-    refetchInterval: 180000,
+    staleTime: 0,
+    refetchInterval: 60000,
     refetchIntervalInBackground: true,
   });
 
@@ -109,16 +105,6 @@ export function useMessages() {
       console.log("Success deleting all messages");
       queryClient.invalidateQueries({ queryKey: ["messages"] });
     },
-  });
-
-  const refetchMessages = async () => {
-    await refetch();
-  };
-
-  const intervalId = setInterval(refetchMessages, 1 * 60 * 1000);
-
-  onUnmounted(() => {
-    clearInterval(intervalId);
   });
 
   async function addMessage(newMessage) {

--- a/frontend/src/composables/transactionsComposable.js
+++ b/frontend/src/composables/transactionsComposable.js
@@ -150,6 +150,20 @@ function invalidateTransactionDependencies(queryClient, extra = []) {
   );
 }
 
+// Forecast cache is rebuilt asynchronously after mutations. Re-invalidate after
+// a short delay to pick up the updated ForecastCacheTransaction records once
+// the background task completes (poll: 1 in Q_CLUSTER means tasks start within ~1s).
+function scheduleForecastRefetch(queryClient) {
+  setTimeout(() => {
+    queryClient.invalidateQueries({ queryKey: ["transactions"] });
+    queryClient.invalidateQueries({ queryKey: ["accounts"] });
+  }, 3500);
+  setTimeout(() => {
+    queryClient.invalidateQueries({ queryKey: ["transactions"] });
+    queryClient.invalidateQueries({ queryKey: ["accounts"] });
+  }, 8000);
+}
+
 export function useTransactions() {
   const queryClient = useQueryClient();
   const transcation_store = useTransactionsStore();
@@ -170,6 +184,7 @@ export function useTransactions() {
     onSuccess: data => {
       console.log("Success adding transaction", data);
       invalidateTransactionDependencies(queryClient, [["description-history"]]);
+      scheduleForecastRefetch(queryClient);
     },
   });
 
@@ -178,6 +193,7 @@ export function useTransactions() {
     onSuccess: () => {
       console.log("Success deleting transaction");
       invalidateTransactionDependencies(queryClient);
+      scheduleForecastRefetch(queryClient);
     },
   });
 
@@ -186,6 +202,7 @@ export function useTransactions() {
     onSuccess: () => {
       console.log("Success clearing transaction");
       invalidateTransactionDependencies(queryClient);
+      scheduleForecastRefetch(queryClient);
     },
   });
 
@@ -194,6 +211,7 @@ export function useTransactions() {
     onSuccess: () => {
       console.log("Success editing dates of transactions");
       invalidateTransactionDependencies(queryClient);
+      scheduleForecastRefetch(queryClient);
     },
   });
 
@@ -202,6 +220,7 @@ export function useTransactions() {
     onSuccess: () => {
       console.log("Success updating transaction");
       invalidateTransactionDependencies(queryClient, [["description-history"]]);
+      scheduleForecastRefetch(queryClient);
     },
   });
 

--- a/frontend/src/composables/transactionsComposable.js
+++ b/frontend/src/composables/transactionsComposable.js
@@ -150,18 +150,15 @@ function invalidateTransactionDependencies(queryClient, extra = []) {
   );
 }
 
-// Forecast cache is rebuilt asynchronously after mutations. Re-invalidate after
-// a short delay to pick up the updated ForecastCacheTransaction records once
-// the background task completes (poll: 1 in Q_CLUSTER means tasks start within ~1s).
+// Forecast results are not cached on the backend, so this delayed invalidation
+// reliably gets fresh DB data once the async forecast task completes (~1-2s with
+// poll:1). The 3.5s window gives comfortable margin over the task execution time.
 function scheduleForecastRefetch(queryClient) {
   setTimeout(() => {
     queryClient.invalidateQueries({ queryKey: ["transactions"] });
+    queryClient.invalidateQueries({ queryKey: ["account_forecast"] });
     queryClient.invalidateQueries({ queryKey: ["accounts"] });
   }, 3500);
-  setTimeout(() => {
-    queryClient.invalidateQueries({ queryKey: ["transactions"] });
-    queryClient.invalidateQueries({ queryKey: ["accounts"] });
-  }, 8000);
 }
 
 export function useTransactions() {

--- a/frontend/src/composables/transactionsComposable.js
+++ b/frontend/src/composables/transactionsComposable.js
@@ -135,10 +135,13 @@ const TRANSACTION_DEPENDENT_KEYS = [
   ["accounts"],
   ["account_forecast"],
   ["tag_graph"],
+  ["tag_graph_items"],
   ["calculator"],
   ["expense_graph"],
   ["pay_graph"],
+  ["budgets"],
   ["retirement_forecast"],
+  ["retirement_transactions"],
 ];
 
 function invalidateTransactionDependencies(queryClient, extra = []) {

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -5,7 +5,7 @@ import router from "./router";
 import piniaPluginPersistedState from "pinia-plugin-persistedstate";
 import vuetify from "./plugins/vuetify";
 import { loadFonts } from "./plugins/webfontloader";
-import { VueQueryPlugin } from "@tanstack/vue-query";
+import { VueQueryPlugin, QueryClient } from "@tanstack/vue-query";
 
 loadFonts();
 
@@ -13,10 +13,18 @@ const pinia = createPinia();
 pinia.use(piniaPluginPersistedState);
 const app = createApp(App);
 
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 5 * 60 * 1000,
+    },
+  },
+});
+
 app.use(router);
 app.use(pinia);
 app.use(vuetify);
-app.use(VueQueryPlugin);
+app.use(VueQueryPlugin, { queryClient });
 app.mount("#app");
 
 // If the browser restores a page from bfcache (back/forward navigation),


### PR DESCRIPTION
## Summary

- **Async forecast rebuilds**: CC/interest forecast cache recalculation moved out of the HTTP path via `async_task`; transaction save/delete signals now return immediately
- **Cache key correctness**: Both forecast tasks now bust `account_all` (not just `account_all_transactions`) so the combined transaction view is properly invalidated after rebuild; funding account cache is also cleared when a CC forecast updates
- **N+1 elimination**: `add_tags_to_transactions` replaced a per-transaction loop with a single bulk query grouped in Python; `select_related("transaction", "tag")` prevents `DoesNotExist` race conditions during Pydantic `from_orm` when the async worker deletes a `ForecastCacheTransaction` mid-serialization
- **QuerySet optimization**: `select_related("status", "transaction_type")` added to all three base QuerySets in `transactions_and_balances` to eliminate per-row FK lookups during serialization
- **Frontend staleTime**: Global TanStack Query `staleTime: 5m` prevents unnecessary refetches on every component mount; messages composable converted from manual `setInterval` to `refetchInterval`
- **Query invalidation gaps closed**: `budgets`, `tag_graph_items`, and `retirement_transactions` added to `TRANSACTION_DEPENDENT_KEYS` so dashboard widgets update correctly after transaction mutations

## Test plan

- [ ] All 165 backend transaction tests pass
- [ ] Add a transaction — budget graph and dashboard pie chart update
- [ ] Delete a transaction — CC bill details update correctly (not empty list)
- [ ] Delete a reminder on a CC account — funding account forecast updates
- [ ] View forecast tab, delete a transaction — forecast list returns updated results (not empty)
- [ ] No `ForecastCacheTransaction.DoesNotExist` snackbar errors during forecast operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)