### PR TITLE
refactor: migrate all remaining forms to vee-validate + Yup validation

### DIFF
--- a/frontend/src/components/AddBankForm.vue
+++ b/frontend/src/components/AddBankForm.vue
@@ -1,74 +1,60 @@
 <template>
   <v-dialog v-model="dialog" persistent width="300">
     <template v-slot:activator="{ props }">
-      <v-btn
-        color="primary"
-        v-bind="props"
-        @click="
-          bankForm.bank_name = '';
-          bankSubmit = true;
-        "
-      >
-        Don't see your bank?
-      </v-btn>
+      <v-btn color="primary" v-bind="props">Don't see your bank?</v-btn>
     </template>
-    <v-card>
-      <v-card-title>
-        <span class="text-h5">Add Bank</span>
-      </v-card-title>
-      <v-card-text>
-        <v-container>
-          <v-row>
-            <v-col>
-              <v-text-field
-                label="Bank Name*"
-                required
-                :rules="required"
-                variant="outlined"
-                @update:model-value="checkBank"
-                v-model="bankForm.bank_name"
-              ></v-text-field>
-            </v-col>
-          </v-row>
-        </v-container>
-        <span class="text-error text-subtitle-2 font-italic">* required</span>
-      </v-card-text>
-      <v-card-actions>
-        <v-spacer></v-spacer>
-        <v-btn color="primary" variant="text" @click="dialog = false">
-          Close
-        </v-btn>
-        <v-btn
-          color="primary"
-          variant="text"
-          @click="submitForm"
-          :disabled="bankSubmit"
-        >
-          Save
-        </v-btn>
-      </v-card-actions>
-    </v-card>
+    <form @submit.prevent="submit">
+      <v-card>
+        <v-card-title>
+          <span class="text-h5">Add Bank</span>
+        </v-card-title>
+        <v-card-text>
+          <v-container>
+            <v-row>
+              <v-col>
+                <v-text-field
+                  label="Bank Name*"
+                  variant="outlined"
+                  v-model="bank_name.value.value"
+                  :error-messages="bank_name.errorMessage.value"
+                ></v-text-field>
+              </v-col>
+            </v-row>
+          </v-container>
+          <span class="text-error text-subtitle-2 font-italic">* required</span>
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer></v-spacer>
+          <v-btn color="primary" variant="text" @click="closeDialog">Close</v-btn>
+          <v-btn color="primary" variant="text" type="submit">Save</v-btn>
+        </v-card-actions>
+      </v-card>
+    </form>
   </v-dialog>
 </template>
 <script setup>
   import { ref } from "vue";
   import { useBanks } from "@/composables/banksComposable";
+  import { useField, useForm } from "vee-validate";
+  import * as yup from "yup";
 
   const { addBank } = useBanks();
-  const bankSubmit = ref(true);
   const dialog = ref(false);
-  const bankForm = ref({
-    bank_name: null,
+
+  const schema = yup.object({
+    bank_name: yup.string().required("Bank name is required."),
   });
-  const checkBank = async () => {
-    if (bankForm.value.bank_name !== "" && bankForm.value.bank_name !== null) {
-      bankSubmit.value = false;
-    } else {
-      bankSubmit.value = true;
-    }
-  };
-  const submitForm = async () => {
-    addBank(bankForm.value);
+
+  const { handleSubmit, resetForm } = useForm({ validationSchema: schema });
+  const bank_name = useField("bank_name");
+
+  const submit = handleSubmit(values => {
+    addBank(values);
+    closeDialog();
+  });
+
+  const closeDialog = () => {
+    resetForm();
     dialog.value = false;
   };
 </script>

--- a/frontend/src/components/AdjustBalanceForm.vue
+++ b/frontend/src/components/AdjustBalanceForm.vue
@@ -1,126 +1,103 @@
 <template>
   <v-dialog width="400">
-    <v-card>
-      <v-card-title>Adjust Balance</v-card-title>
-      <v-card-text>
-        <v-container>
-          <v-row density>
-            <v-col>
-              <v-text-field
-                v-model="currentBalance"
-                variant="outlined"
-                label="Current Balance"
-                prefix="$"
-                disabled
-              ></v-text-field>
-            </v-col>
-          </v-row>
-          <v-row density>
-            <v-col>
-              <v-text-field
-                v-model="new_balance"
-                variant="outlined"
-                label="New Balance*"
-                :rules="required"
-                prefix="$"
-                @update:model-value="checkBalance"
-              ></v-text-field>
-            </v-col>
-          </v-row>
-        </v-container>
-      </v-card-text>
-      <v-card-actions>
-        <v-spacer></v-spacer>
-        <v-btn @click="emit('updateDialog', false)" color="primary">
-          Close
-        </v-btn>
-        <v-btn
-          @click="clickAdjustBalance()"
-          color="primary"
-          :disabled="balanceSubmit"
-        >
-          Adjust
-        </v-btn>
-      </v-card-actions>
-    </v-card>
+    <form @submit.prevent="submit">
+      <v-card>
+        <v-card-title>Adjust Balance</v-card-title>
+        <v-card-text>
+          <v-container>
+            <v-row density>
+              <v-col>
+                <v-text-field
+                  v-model="currentBalance"
+                  variant="outlined"
+                  label="Current Balance"
+                  prefix="$"
+                  disabled
+                ></v-text-field>
+              </v-col>
+            </v-row>
+            <v-row density>
+              <v-col>
+                <v-text-field
+                  v-model="new_balance.value.value"
+                  variant="outlined"
+                  label="New Balance*"
+                  :error-messages="new_balance.errorMessage.value"
+                  prefix="$"
+                ></v-text-field>
+              </v-col>
+            </v-row>
+          </v-container>
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer></v-spacer>
+          <v-btn @click="emit('updateDialog', false)" color="primary">Close</v-btn>
+          <v-btn color="primary" type="submit">Adjust</v-btn>
+        </v-card-actions>
+      </v-card>
+    </form>
   </v-dialog>
 </template>
 <script setup>
   import { defineEmits, defineProps, ref, watch } from "vue";
   import { useTransactions } from "@/composables/transactionsComposable";
+  import { useField, useForm } from "vee-validate";
+  import * as yup from "yup";
 
   const today = new Date();
   const year = today.getFullYear();
   const month = String(today.getMonth() + 1).padStart(2, "0");
   const day = String(today.getDate()).padStart(2, "0");
   const formattedDate = `${year}-${month}-${day}`;
-  const props = defineProps({
-    account: Object,
-  });
 
-  const checkBalance = async () => {
-    if (new_balance.value !== "" && new_balance.value !== null) {
-      balanceSubmit.value = false;
-    } else {
-      balanceSubmit.value = true;
-    }
-  };
+  const props = defineProps({ account: Object });
+  const emit = defineEmits(["updateDialog"]);
+  const { addTransaction } = useTransactions();
 
   const currentBalance = ref(props.account.balance);
-
   watch(
     () => props.account.balance,
     newValue => {
       currentBalance.value = newValue;
     },
   );
-  const required = [
-    value => {
-      if (value) return true;
 
-      return "This field is required.";
-    },
-  ];
-
-  const new_balance = ref("");
-  const balanceForm = ref({
-    id: 0,
-    status_id: 2,
-    transaction_type_id: 1,
-    transaction_date: formattedDate,
-    memo: "",
-    source_account_id: props.account.id,
-    destination_account_id: null,
-    edit_date: formattedDate,
-    add_date: formattedDate,
-    details: [
-      {
-        tag_id: 4,
-        tag_amt: 0,
-        tag_pretty_name: "Balance Adjustment",
-        tag_full_toggle: true,
-      },
-    ],
-    total_amount: "",
-    description: "Balance Adjustment",
+  const schema = yup.object({
+    new_balance: yup
+      .number()
+      .typeError("New balance is required.")
+      .required("New balance is required."),
   });
 
-  const balanceSubmit = ref(true);
+  const { handleSubmit, resetForm } = useForm({ validationSchema: schema });
+  const new_balance = useField("new_balance");
 
-  const emit = defineEmits(["updateDialog"]);
-  const { addTransaction } = useTransactions();
-  const clickAdjustBalance = async () => {
-    if (new_balance.value - currentBalance.value < 0) {
-      balanceForm.value.transaction_type_id = 1;
-    } else {
-      balanceForm.value.transaction_type_id = 2;
-    }
-    balanceForm.value.total_amount = parseFloat(
-      (new_balance.value - currentBalance.value).toFixed(2),
+  const submit = handleSubmit(values => {
+    const diff = parseFloat(
+      (values.new_balance - currentBalance.value).toFixed(2),
     );
-    console.log("adjBal:", balanceForm.value);
-    await addTransaction(balanceForm.value);
+    addTransaction({
+      id: 0,
+      status_id: 2,
+      transaction_type_id: diff < 0 ? 1 : 2,
+      transaction_date: formattedDate,
+      memo: "",
+      source_account_id: props.account.id,
+      destination_account_id: null,
+      edit_date: formattedDate,
+      add_date: formattedDate,
+      details: [
+        {
+          tag_id: 4,
+          tag_amt: 0,
+          tag_pretty_name: "Balance Adjustment",
+          tag_full_toggle: true,
+        },
+      ],
+      total_amount: diff,
+      description: "Balance Adjustment",
+    });
+    resetForm();
     emit("updateDialog", false);
-    new_balance.value = "";
-  };
+  });
 </script>

--- a/frontend/src/components/EditAccountFormMobile.vue
+++ b/frontend/src/components/EditAccountFormMobile.vue
@@ -1,384 +1,398 @@
 <template>
   <v-dialog fullscreen persistent>
-    <v-card min-height="550px">
-      <v-card-text>
-        <v-sheet border rounded>
-          <v-container>
-            <v-row dense>
-              <v-col>
-                <h4 class="text-h6 font-weight-bold mb-2">Account Info</h4>
-              </v-col>
-            </v-row>
-            <v-row dense>
-              <v-col>
-                <v-text-field
-                  v-model="formData.account_name"
-                  :rules="required"
-                  @update:model-value="checkForm"
-                  variant="outlined"
-                  label="Account Name*"
-                  density="comfortable"
-                ></v-text-field>
-              </v-col>
-            </v-row>
-            <v-row dense>
-              <v-col>
-                <v-autocomplete
-                  clearable
-                  label="Bank Name*"
-                  :items="banks"
-                  variant="outlined"
-                  :loading="isLoading"
-                  item-title="bank_name"
-                  item-value="id"
-                  v-model="formData.bank_id"
-                  :rules="required"
-                  @update:model-value="checkForm"
-                  density="comfortable"
-                ></v-autocomplete>
-              </v-col>
-            </v-row>
-            <v-row dense>
-              <v-col>
-                <span class="text-subtitle-2">Open Date</span>
-                <VueDatePicker
-                  v-model="formData.open_date"
-                  timezone="America/New_York"
-                  model-type="yyyy-MM-dd"
-                  :enable-time-picker="false"
-                  auto-apply
-                  format="yyyy-MM-dd"
-                  @update:model-value="checkForm"
-                ></VueDatePicker>
-              </v-col>
-            </v-row>
-            <v-row dense>
-              <v-col>
-                <v-text-field
-                  v-model="formData.opening_balance"
-                  variant="outlined"
-                  label="Opening Balance*"
-                  :rules="required"
-                  prefix="$"
-                  @update:model-value="checkForm"
-                  density="comfortable"
-                ></v-text-field>
-              </v-col>
-              <v-col>
-                <v-spacer></v-spacer>
-              </v-col>
-            </v-row>
-          </v-container>
-        </v-sheet>
-        <v-sheet border rounded v-if="!props.account.is_parent_account">
-          <v-container>
-            <v-row dense>
-              <v-col>
-                <h4 class="text-h6 font-weight-bold mb-2">Parent Account</h4>
-              </v-col>
-            </v-row>
-            <v-row dense>
-              <v-col>
-                <v-autocomplete
-                  clearable
-                  label="Parent Account"
-                  :items="sameTypeAccounts"
-                  variant="outlined"
-                  :loading="accounts_isLoading"
-                  item-title="account_name"
-                  item-value="id"
-                  v-model="formData.parent_account_id"
-                  density="comfortable"
-                  hint="Roll this account up under a parent. Interest is calculated at the parent level."
-                  persistent-hint
-                ></v-autocomplete>
-              </v-col>
-            </v-row>
-          </v-container>
-        </v-sheet>
-        <v-sheet border rounded v-if="props.account.is_parent_account">
-          <v-container>
-            <v-row dense>
-              <v-col>
-                <h4 class="text-h6 font-weight-bold mb-2">Child Accounts</h4>
-              </v-col>
-            </v-row>
-            <v-row dense>
-              <v-col>
-                <v-autocomplete
-                  clearable
-                  label="Interest Child Account"
-                  :items="childAccounts"
-                  variant="outlined"
-                  item-title="account_name"
-                  item-value="id"
-                  v-model="formData.interest_child_account_id"
-                  density="comfortable"
-                  hint="Interest forecast deposits will be posted to this child account."
-                  persistent-hint
-                ></v-autocomplete>
-              </v-col>
-            </v-row>
-          </v-container>
-        </v-sheet>
-        <v-sheet border rounded v-if="props.account.account_type.id == 1">
-          <v-container>
-            <v-row dense>
-              <v-col>
-                <h4 class="text-h6 font-weight-bold mb-2">Credit Card Info</h4>
-              </v-col>
-            </v-row>
-            <v-row dense>
-              <v-col>
-                <v-text-field
-                  v-model="formData.credit_limit"
-                  variant="outlined"
-                  label="Credit Limit*"
-                  :rules="required"
-                  prefix="$"
-                  @update:model-value="checkForm"
-                  density="comfortable"
-                ></v-text-field>
-              </v-col>
-              <v-col>
-                <v-text-field
-                  v-model="formData.annual_rate"
-                  variant="outlined"
-                  label="Annual Rate(APR/APY)*"
-                  :rules="required"
-                  suffix="%"
-                  @update:model-value="checkForm"
-                  density="comfortable"
-                ></v-text-field>
-              </v-col>
-            </v-row>
-            <v-row dense>
-              <v-col>
-                <span class="text-subtitle-2">Next Statment Date</span>
-                <VueDatePicker
-                  v-model="formData.next_cycle_date"
-                  timezone="America/New_York"
-                  model-type="yyyy-MM-dd"
-                  :enable-time-picker="false"
-                  auto-apply
-                  format="yyyy-MM-dd"
-                  @update:model-value="checkForm"
-                ></VueDatePicker>
-              </v-col>
-            </v-row>
-            <v-row dense>
-              <v-col>
-                <v-select
-                  label="Statment Cycle Length"
-                  required
-                  :items="intervals"
-                  v-model="formData.statement_cycle_length"
-                  @update:model-value="checkForm"
-                  density="comfortable"
-                ></v-select>
-              </v-col>
-              <v-col>
-                <v-select
-                  label="Statment Cycle Period"
-                  required
-                  :items="units"
-                  v-model="formData.statement_cycle_period"
-                  item-value="letter"
-                  item-title="name"
-                  @update:model-value="checkForm"
-                  density="comfortable"
-                ></v-select>
-              </v-col>
-            </v-row>
-            <v-row dense>
-              <v-col>
-                <span class="text-subtitle-2">Next Due Date</span>
-                <VueDatePicker
-                  v-model="formData.due_date"
-                  timezone="America/New_York"
-                  model-type="yyyy-MM-dd"
-                  :enable-time-picker="false"
-                  auto-apply
-                  format="yyyy-MM-dd"
-                  @update:model-value="checkForm"
-                ></VueDatePicker>
-              </v-col>
-            </v-row>
-            <v-row dense>
-              <v-col>
-                <v-text-field
-                  v-model="formData.statement_balance"
-                  variant="outlined"
-                  label="Statement Balance"
-                  prefix="$"
-                  @update:model-value="checkForm"
-                  density="comfortable"
-                ></v-text-field>
-              </v-col>
-              <v-col>
-                <v-text-field
-                  v-model="formData.rewards_amount"
-                  variant="outlined"
-                  label="Rewards Earned"
-                  prefix="$"
-                  @update:model-value="checkForm"
-                  density="comfortable"
-                ></v-text-field>
-              </v-col>
-            </v-row>
-          </v-container>
-        </v-sheet>
-        <v-sheet border rounded v-if="['savings', 'investment'].includes(props.account.account_type.slug) && !formData.parent_account_id">
-          <v-container>
-            <v-row dense>
-              <v-col>
-                <h4 class="text-h6 font-weight-bold mb-2">
-                  Savings / Investment Info
-                </h4>
-              </v-col>
-            </v-row>
-            <v-row dense>
-              <v-col>
-                <v-checkbox
-                  v-model="formData.calculate_interest"
-                  label="Calculate Interest"
-                  @update:model-value="checkForm"
-                ></v-checkbox>
-              </v-col>
-            </v-row>
-            <v-row dense v-if="formData.calculate_interest">
-              <v-col>
-                <v-text-field
-                  v-model="formData.annual_rate"
-                  variant="outlined"
-                  label="Annual Rate (APY)"
-                  suffix="%"
-                  @update:model-value="checkForm"
-                  density="comfortable"
-                ></v-text-field>
-              </v-col>
-              <v-col>
-                <v-select
-                  label="Interest Deposit Day"
-                  :items="intervals"
-                  v-model="formData.interest_deposit_day"
-                  density="comfortable"
-                  clearable
-                  @update:model-value="checkForm"
-                ></v-select>
-              </v-col>
-            </v-row>
-          </v-container>
-        </v-sheet>
-      </v-card-text>
-      <v-card-actions>
-        <v-spacer></v-spacer>
-        <v-btn @click="emit('updateDialog', false)" color="primary">
-          Close
-        </v-btn>
-        <v-btn
-          @click="clickEditAccount()"
-          color="primary"
-          :disabled="editSubmit"
-        >
-          Save
-        </v-btn>
-      </v-card-actions>
-    </v-card>
+    <form @submit.prevent="submit">
+      <v-card min-height="550px">
+        <v-card-text>
+          <v-sheet border rounded>
+            <v-container>
+              <v-row dense>
+                <v-col>
+                  <h4 class="text-h6 font-weight-bold mb-2">Account Info</h4>
+                </v-col>
+              </v-row>
+              <v-row dense>
+                <v-col>
+                  <v-text-field
+                    v-model="account_name.value.value"
+                    :error-messages="account_name.errorMessage.value"
+                    variant="outlined"
+                    label="Account Name*"
+                    density="comfortable"
+                  ></v-text-field>
+                </v-col>
+              </v-row>
+              <v-row dense>
+                <v-col>
+                  <v-autocomplete
+                    clearable
+                    label="Bank Name*"
+                    :items="banks"
+                    variant="outlined"
+                    :loading="isLoading"
+                    item-title="bank_name"
+                    item-value="id"
+                    v-model="bank_id.value.value"
+                    :error-messages="bank_id.errorMessage.value"
+                    density="comfortable"
+                  ></v-autocomplete>
+                </v-col>
+              </v-row>
+              <v-row dense>
+                <v-col>
+                  <span class="text-subtitle-2">Open Date</span>
+                  <VueDatePicker
+                    v-model="open_date.value.value"
+                    timezone="America/New_York"
+                    model-type="yyyy-MM-dd"
+                    :enable-time-picker="false"
+                    auto-apply
+                    format="yyyy-MM-dd"
+                  ></VueDatePicker>
+                  <span
+                    class="text-error text-caption"
+                    v-if="open_date.errorMessage.value"
+                  >
+                    {{ open_date.errorMessage.value }}
+                  </span>
+                </v-col>
+              </v-row>
+              <v-row dense>
+                <v-col>
+                  <v-text-field
+                    v-model="opening_balance.value.value"
+                    :error-messages="opening_balance.errorMessage.value"
+                    variant="outlined"
+                    label="Opening Balance*"
+                    prefix="$"
+                    density="comfortable"
+                  ></v-text-field>
+                </v-col>
+                <v-col>
+                  <v-spacer></v-spacer>
+                </v-col>
+              </v-row>
+            </v-container>
+          </v-sheet>
+          <v-sheet border rounded v-if="!props.account.is_parent_account">
+            <v-container>
+              <v-row dense>
+                <v-col>
+                  <h4 class="text-h6 font-weight-bold mb-2">Parent Account</h4>
+                </v-col>
+              </v-row>
+              <v-row dense>
+                <v-col>
+                  <v-autocomplete
+                    clearable
+                    label="Parent Account"
+                    :items="sameTypeAccounts"
+                    variant="outlined"
+                    :loading="accounts_isLoading"
+                    item-title="account_name"
+                    item-value="id"
+                    v-model="parent_account_id.value.value"
+                    density="comfortable"
+                    hint="Roll this account up under a parent. Interest is calculated at the parent level."
+                    persistent-hint
+                  ></v-autocomplete>
+                </v-col>
+              </v-row>
+            </v-container>
+          </v-sheet>
+          <v-sheet border rounded v-if="props.account.is_parent_account">
+            <v-container>
+              <v-row dense>
+                <v-col>
+                  <h4 class="text-h6 font-weight-bold mb-2">Child Accounts</h4>
+                </v-col>
+              </v-row>
+              <v-row dense>
+                <v-col>
+                  <v-autocomplete
+                    clearable
+                    label="Interest Child Account"
+                    :items="childAccounts"
+                    variant="outlined"
+                    item-title="account_name"
+                    item-value="id"
+                    v-model="interest_child_account_id.value.value"
+                    density="comfortable"
+                    hint="Interest forecast deposits will be posted to this child account."
+                    persistent-hint
+                  ></v-autocomplete>
+                </v-col>
+              </v-row>
+            </v-container>
+          </v-sheet>
+          <v-sheet border rounded v-if="props.account.account_type.id == 1">
+            <v-container>
+              <v-row dense>
+                <v-col>
+                  <h4 class="text-h6 font-weight-bold mb-2">Credit Card Info</h4>
+                </v-col>
+              </v-row>
+              <v-row dense>
+                <v-col>
+                  <v-text-field
+                    v-model="credit_limit.value.value"
+                    :error-messages="credit_limit.errorMessage.value"
+                    variant="outlined"
+                    label="Credit Limit*"
+                    prefix="$"
+                    density="comfortable"
+                  ></v-text-field>
+                </v-col>
+                <v-col>
+                  <v-text-field
+                    v-model="annual_rate.value.value"
+                    :error-messages="annual_rate.errorMessage.value"
+                    variant="outlined"
+                    label="Annual Rate(APR/APY)*"
+                    suffix="%"
+                    density="comfortable"
+                  ></v-text-field>
+                </v-col>
+              </v-row>
+              <v-row dense>
+                <v-col>
+                  <span class="text-subtitle-2">Next Statement Date</span>
+                  <VueDatePicker
+                    v-model="next_cycle_date.value.value"
+                    timezone="America/New_York"
+                    model-type="yyyy-MM-dd"
+                    :enable-time-picker="false"
+                    auto-apply
+                    format="yyyy-MM-dd"
+                  ></VueDatePicker>
+                </v-col>
+              </v-row>
+              <v-row dense>
+                <v-col>
+                  <v-select
+                    label="Statement Cycle Length"
+                    :items="intervals"
+                    v-model="statement_cycle_length.value.value"
+                    density="comfortable"
+                  ></v-select>
+                </v-col>
+                <v-col>
+                  <v-select
+                    label="Statement Cycle Period"
+                    :items="units"
+                    v-model="statement_cycle_period.value.value"
+                    item-value="letter"
+                    item-title="name"
+                    density="comfortable"
+                  ></v-select>
+                </v-col>
+              </v-row>
+              <v-row dense>
+                <v-col>
+                  <span class="text-subtitle-2">Next Due Date</span>
+                  <VueDatePicker
+                    v-model="due_date.value.value"
+                    timezone="America/New_York"
+                    model-type="yyyy-MM-dd"
+                    :enable-time-picker="false"
+                    auto-apply
+                    format="yyyy-MM-dd"
+                  ></VueDatePicker>
+                </v-col>
+              </v-row>
+              <v-row dense>
+                <v-col>
+                  <v-text-field
+                    v-model="statement_balance.value.value"
+                    variant="outlined"
+                    label="Statement Balance"
+                    prefix="$"
+                    density="comfortable"
+                  ></v-text-field>
+                </v-col>
+                <v-col>
+                  <v-text-field
+                    v-model="rewards_amount.value.value"
+                    variant="outlined"
+                    label="Rewards Earned"
+                    prefix="$"
+                    density="comfortable"
+                  ></v-text-field>
+                </v-col>
+              </v-row>
+            </v-container>
+          </v-sheet>
+          <v-sheet
+            border
+            rounded
+            v-if="['savings', 'investment'].includes(props.account.account_type.slug) && !parent_account_id.value.value"
+          >
+            <v-container>
+              <v-row dense>
+                <v-col>
+                  <h4 class="text-h6 font-weight-bold mb-2">
+                    Savings / Investment Info
+                  </h4>
+                </v-col>
+              </v-row>
+              <v-row dense>
+                <v-col>
+                  <v-checkbox
+                    v-model="calculate_interest.value.value"
+                    label="Calculate Interest"
+                  ></v-checkbox>
+                </v-col>
+              </v-row>
+              <v-row dense v-if="calculate_interest.value.value">
+                <v-col>
+                  <v-text-field
+                    v-model="annual_rate.value.value"
+                    :error-messages="annual_rate.errorMessage.value"
+                    variant="outlined"
+                    label="Annual Rate (APY)"
+                    suffix="%"
+                    density="comfortable"
+                  ></v-text-field>
+                </v-col>
+                <v-col>
+                  <v-select
+                    label="Interest Deposit Day"
+                    :items="intervals"
+                    v-model="interest_deposit_day.value.value"
+                    density="comfortable"
+                    clearable
+                  ></v-select>
+                </v-col>
+              </v-row>
+            </v-container>
+          </v-sheet>
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer></v-spacer>
+          <v-btn @click="emit('updateDialog', false)" color="primary">
+            Close
+          </v-btn>
+          <v-btn color="primary" type="submit">Save</v-btn>
+        </v-card-actions>
+      </v-card>
+    </form>
   </v-dialog>
 </template>
 <script setup>
-  import { defineEmits, defineProps, ref, computed } from "vue";
+  import { defineEmits, defineProps, onMounted, watchEffect, computed } from "vue";
   import { useBanks } from "@/composables/banksComposable";
   import { useAccountByID, useAccounts } from "@/composables/accountsComposable";
   import VueDatePicker from "@vuepic/vue-datepicker";
   import "@vuepic/vue-datepicker/dist/main.css";
   import { useMainStore } from "@/stores/main";
+  import { useField, useForm } from "vee-validate";
+  import * as yup from "yup";
+
+  const schema = yup.object({
+    account_name: yup.string().required("Must provide an account name."),
+    bank_id: yup.number().required("Must select a bank."),
+    open_date: yup.string().required("Must provide opening date."),
+    opening_balance: yup.number().required("Must provide opening balance."),
+    annual_rate: yup.number().when(["account_type_id", "calculate_interest"], {
+      is: (type, calc) => type === 1 || ((type === 3 || type === 4) && calc === true),
+      then: schema => schema.required("Must provide annual rate (APR/APY)."),
+      otherwise: schema => schema.nullable().notRequired(),
+    }),
+    credit_limit: yup.number().when("account_type_id", {
+      is: 1,
+      then: schema => schema.required("Must provide credit limit."),
+      otherwise: schema => schema.nullable().notRequired(),
+    }),
+    due_date: yup.string().nullable().notRequired(),
+    next_cycle_date: yup.string().nullable().notRequired(),
+    statement_cycle_length: yup.number().nullable().notRequired(),
+    statement_cycle_period: yup.string().nullable().notRequired(),
+    statement_balance: yup.number().nullable().notRequired(),
+    rewards_amount: yup.number().nullable().notRequired(),
+    calculate_interest: yup.boolean().nullable().notRequired(),
+    interest_deposit_day: yup.number().nullable().notRequired(),
+    parent_account_id: yup.number().nullable().notRequired(),
+    interest_child_account_id: yup.number().nullable().notRequired(),
+    account_type_id: yup.number().notRequired(),
+    active: yup.boolean().notRequired(),
+  });
+
+  const { handleSubmit } = useForm({ validationSchema: schema });
+
+  const account_name = useField("account_name");
+  const bank_id = useField("bank_id");
+  const open_date = useField("open_date");
+  const opening_balance = useField("opening_balance");
+  const annual_rate = useField("annual_rate");
+  const credit_limit = useField("credit_limit");
+  const due_date = useField("due_date");
+  const next_cycle_date = useField("next_cycle_date");
+  const statement_cycle_length = useField("statement_cycle_length");
+  const statement_cycle_period = useField("statement_cycle_period");
+  const statement_balance = useField("statement_balance");
+  const rewards_amount = useField("rewards_amount");
+  const calculate_interest = useField("calculate_interest");
+  const interest_deposit_day = useField("interest_deposit_day");
+  const parent_account_id = useField("parent_account_id");
+  const interest_child_account_id = useField("interest_child_account_id");
+  const account_type_id = useField("account_type_id");
+  const active = useField("active");
 
   const { banks, isLoading } = useBanks();
   const { accounts, isLoading: accounts_isLoading } = useAccounts();
-  const editSubmit = ref(true);
   const mainstore = useMainStore();
   const emit = defineEmits(["updateDialog"]);
-  const props = defineProps({
-    account: Object,
-  });
+  const props = defineProps({ account: Object });
   const { editAccount } = useAccountByID(props.account.id);
-  const formData = ref({
-    id: props.account.id,
-    account_name: props.account.account_name,
-    account_type_id: props.account.account_type.id,
-    opening_balance: props.account.opening_balance,
-    annual_rate: props.account.annual_rate,
-    due_date: props.account.due_date,
-    active: props.account.active,
-    open_date: props.account.open_date,
-    next_cycle_date: props.account.next_cycle_date,
-    statement_cycle_length: props.account.statement_cycle_length,
-    statement_cycle_period: props.account.statement_cycle_period,
-    rewards_amount: props.account.rewards_amount,
-    credit_limit: props.account.credit_limit,
-    bank_id: props.account.bank.id,
-    statement_balance: props.account.statement_balance,
-    calculate_interest: props.account.calculate_interest,
-    interest_deposit_day: props.account.interest_deposit_day,
-    parent_account_id: props.account.parent_account_id ?? null,
-    interest_child_account_id: props.account.interest_child_account_id ?? null,
-  });
 
   const sameTypeAccounts = computed(() => {
-    if (!accounts.value) return []
+    if (!accounts.value) return [];
     return accounts.value.filter(
       a =>
         a.id !== props.account.id &&
         a.account_type.id === props.account.account_type.id &&
         a.parent_account_id === null,
-    )
-  })
+    );
+  });
 
   const childAccounts = computed(() => {
-    if (!accounts.value) return []
-    return accounts.value.filter(a => a.parent_account_id === props.account.id)
-  })
-
-  const clickEditAccount = () => {
-    editAccount(formData.value);
-    emit("updateDialog", false);
-  };
-
-  const required = [
-    value => {
-      if (value) return true;
-
-      return "This field is required.";
-    },
-  ];
-
-  const checkForm = async () => {
-    if (
-      formData.value.account_name !== null &&
-      formData.value.account_name !== "" &&
-      formData.value.bank_id !== null &&
-      formData.value.bank_id !== "" &&
-      formData.value.open_date !== null &&
-      formData.value.open_date !== "" &&
-      formData.value.opening_balance !== null &&
-      formData.value.opening_balance !== "" &&
-      formData.value.credit_limit !== null &&
-      formData.value.credit_limit !== "" &&
-      formData.value.annual_rate !== null &&
-      formData.value.annual_rate !== ""
-    ) {
-      editSubmit.value = false;
-    } else {
-      editSubmit.value = true;
-    }
-  };
-
-  const units = computed(() => {
-    return mainstore.units;
+    if (!accounts.value) return [];
+    return accounts.value.filter(a => a.parent_account_id === props.account.id);
   });
-  const intervals = computed(() => {
-    return mainstore.intervals;
+
+  const submit = handleSubmit(values => {
+    editAccount(values);
+    emit("updateDialog", false);
+  });
+
+  const units = computed(() => mainstore.units);
+  const intervals = computed(() => mainstore.intervals);
+
+  const initializeFormData = () => {
+    account_name.value.value = props.account.account_name;
+    bank_id.value.value = props.account.bank.id;
+    open_date.value.value = props.account.open_date;
+    opening_balance.value.value = props.account.opening_balance;
+    annual_rate.value.value = props.account.annual_rate;
+    credit_limit.value.value = props.account.credit_limit;
+    due_date.value.value = props.account.due_date ?? null;
+    next_cycle_date.value.value = props.account.next_cycle_date ?? null;
+    statement_cycle_length.value.value = props.account.statement_cycle_length ?? null;
+    statement_cycle_period.value.value = props.account.statement_cycle_period ?? null;
+    statement_balance.value.value = props.account.statement_balance ?? null;
+    rewards_amount.value.value = props.account.rewards_amount ?? null;
+    calculate_interest.value.value = props.account.calculate_interest ?? false;
+    interest_deposit_day.value.value = props.account.interest_deposit_day ?? null;
+    parent_account_id.value.value = props.account.parent_account_id ?? null;
+    interest_child_account_id.value.value = props.account.interest_child_account_id ?? null;
+    account_type_id.value.value = props.account.account_type.id;
+    active.value.value = props.account.active;
+  };
+
+  onMounted(() => {
+    watchEffect(() => {
+      if (props.account) {
+        initializeFormData();
+      }
+    });
   });
 </script>

--- a/frontend/src/components/ReminderForm.vue
+++ b/frontend/src/components/ReminderForm.vue
@@ -1,229 +1,223 @@
 <template>
   <v-dialog persistent width="1024" min-height="800px">
-    <v-card>
-      <v-card-title>
-        <span class="text-h5" v-if="props.isEdit == false">Add Reminder</span>
-        <span class="text-h5" v-else>Edit Reminder</span>
-      </v-card-title>
-      <v-card-text>
-        <v-container>
-          <v-row>
-            <v-col>
-              <v-text-field
-                v-model="amount"
-                variant="outlined"
-                label="Amount*"
-                :rules="required"
-                prefix="$"
-                @update:model-value="checkFormComplete"
-                type="number"
-                step="1.00"
-                @update:focused="reformatNumberToMoney"
-              ></v-text-field>
-            </v-col>
-            <v-col>
-              <v-text-field
-                v-model="formData.description"
-                variant="outlined"
-                label="Description*"
-                :rules="required"
-                @update:model-value="checkFormComplete"
-              ></v-text-field>
-            </v-col>
-          </v-row>
-          <v-row>
-            <v-col>
-              <v-autocomplete
-                clearable
-                label="Transaction Type*"
-                :items="transaction_types"
-                variant="outlined"
-                :loading="transaction_types_isLoading"
-                item-title="transaction_type"
-                item-value="id"
-                v-model="formData.transaction_type_id"
-                :rules="required"
-                @update:model-value="checkFormComplete"
-              ></v-autocomplete>
-            </v-col>
-            <v-col>
-              <!-- TODO: Enable adding tags here -->
-              <v-autocomplete
-                clearable
-                label="Tag*"
-                :items="tags"
-                variant="outlined"
-                :loading="tags_isLoading"
-                item-title="tag_name"
-                item-value="id"
-                v-model="formData.tag_id"
-                :rules="required"
-                @update:model-value="checkFormComplete"
-              >
-                <template v-slot:item="{ props, item }">
-                  <v-list-item
-                    v-bind="props"
-                    :title="
-                      item.raw.parent
-                        ? item.raw.parent.tag_name
-                        : item.raw.tag_name
-                    "
-                    :subtitle="item.raw.parent ? item.raw.tag_name : null"
-                  >
-                    <template v-slot:prepend>
-                      <v-icon
-                        icon="mdi-tag"
-                        :color="tagColor(item.raw.tag_type.id)"
-                      ></v-icon>
-                    </template>
-                  </v-list-item>
-                </template>
-              </v-autocomplete>
-            </v-col>
-          </v-row>
-          <v-row>
-            <v-col>
-              <v-autocomplete
-                clearable
-                label="Source Account*"
-                :items="accounts"
-                variant="outlined"
-                :loading="accounts_isLoading"
-                item-title="account_name"
-                item-value="id"
-                v-model="formData.reminder_source_account_id"
-                :rules="required"
-                @update:model-value="checkFormComplete"
-              >
-                <template v-slot:item="{ props, item }">
-                  <v-list-item
-                    v-bind="props"
-                    :title="item.raw.account_name"
-                    :subtitle="item.raw.bank.bank_name"
-                  >
-                    <template v-slot:prepend>
-                      <v-icon :icon="item.raw.account_type.icon"></v-icon>
-                    </template>
-                  </v-list-item>
-                </template>
-              </v-autocomplete>
-            </v-col>
-            <v-col>
-              <v-autocomplete
-                clearable
-                label="Destination Account*"
-                :items="accounts"
-                variant="outlined"
-                :loading="accounts_isLoading"
-                item-title="account_name"
-                item-value="id"
-                v-model="formData.reminder_destination_account_id"
-                :rules="required"
-                @update:model-value="checkFormComplete"
-                v-if="formData.transaction_type_id == 3"
-              >
-                <template v-slot:item="{ props, item }">
-                  <v-list-item
-                    v-bind="props"
-                    :title="item.raw.account_name"
-                    :subtitle="item.raw.bank.bank_name"
-                  >
-                    <template v-slot:prepend>
-                      <v-icon :icon="item.raw.account_type.icon"></v-icon>
-                    </template>
-                  </v-list-item>
-                </template>
-              </v-autocomplete>
-            </v-col>
-          </v-row>
-          <v-row>
-            <v-col>
-              <span class="text-subtitle-2">Start Date</span>
-              <VueDatePicker
-                v-model="formData.start_date"
-                timezone="America/New_York"
-                model-type="yyyy-MM-dd"
-                :enable-time-picker="false"
-                auto-apply
-                format="yyyy-MM-dd"
-                @closed="checkFormComplete"
-                :min-date="tomorrow"
-                :teleport="true"
-              ></VueDatePicker>
-            </v-col>
-            <v-col>
-              <span class="text-subtitle-2">End Date</span>
-              <VueDatePicker
-                v-model="formData.end_date"
-                timezone="America/New_York"
-                model-type="yyyy-MM-dd"
-                :enable-time-picker="false"
-                auto-apply
-                format="yyyy-MM-dd"
-                @closed="checkFormComplete"
-                :min-date="getLowerLimit()"
-                :teleport="true"
-                :state="endDateGood"
-              ></VueDatePicker>
-            </v-col>
-          </v-row>
-          <v-row>
-            <v-col>
-              <v-autocomplete
-                clearable
-                label="Repeats*"
-                :items="repeats"
-                variant="outlined"
-                :loading="repeats_isLoading"
-                item-title="repeat_name"
-                item-value="id"
-                v-model="formData.repeat_id"
-                :rules="required"
-                @update:model-value="checkFormComplete"
-              ></v-autocomplete>
-            </v-col>
-            <v-col>
-              <v-switch
-                v-model="formData.auto_add"
-                hide-details
-                label="Auto Add"
-                color="primary"
-                @update:model-value="checkFormComplete"
-              ></v-switch>
-            </v-col>
-          </v-row>
-          <v-row>
-            <v-col>
-              <v-textarea
-                clearable
-                label="Memo"
-                variant="outlined"
-                v-model="formData.memo"
-                :rows="4"
-                no-resize
-                @update:model-value="checkFormComplete"
-              ></v-textarea>
-            </v-col>
-          </v-row>
-        </v-container>
-      </v-card-text>
-      <v-card-actions>
-        <v-spacer></v-spacer>
-        <v-btn color="primary" variant="text" @click="closeDialog">Close</v-btn>
-        <v-btn
-          color="primary"
-          variant="text"
-          @click="submitForm"
-          :disabled="!formComplete"
-        >
-          Save
-        </v-btn>
-      </v-card-actions>
-    </v-card>
+    <form @submit.prevent="submit">
+      <v-card>
+        <v-card-title>
+          <span class="text-h5" v-if="props.isEdit == false">Add Reminder</span>
+          <span class="text-h5" v-else>Edit Reminder</span>
+        </v-card-title>
+        <v-card-text>
+          <v-container>
+            <v-row>
+              <v-col>
+                <v-text-field
+                  v-model="amount.value.value"
+                  variant="outlined"
+                  label="Amount*"
+                  :error-messages="amount.errorMessage.value"
+                  prefix="$"
+                  type="number"
+                  step="1.00"
+                  @blur="reformatNumberToMoney"
+                ></v-text-field>
+              </v-col>
+              <v-col>
+                <v-text-field
+                  v-model="description.value.value"
+                  variant="outlined"
+                  label="Description*"
+                  :error-messages="description.errorMessage.value"
+                ></v-text-field>
+              </v-col>
+            </v-row>
+            <v-row>
+              <v-col>
+                <v-autocomplete
+                  clearable
+                  label="Transaction Type*"
+                  :items="transaction_types"
+                  variant="outlined"
+                  :loading="transaction_types_isLoading"
+                  item-title="transaction_type"
+                  item-value="id"
+                  v-model="transaction_type_id.value.value"
+                  :error-messages="transaction_type_id.errorMessage.value"
+                ></v-autocomplete>
+              </v-col>
+              <v-col>
+                <v-autocomplete
+                  clearable
+                  label="Tag*"
+                  :items="tags"
+                  variant="outlined"
+                  :loading="tags_isLoading"
+                  item-title="tag_name"
+                  item-value="id"
+                  v-model="tag_id.value.value"
+                  :error-messages="tag_id.errorMessage.value"
+                >
+                  <template v-slot:item="{ props, item }">
+                    <v-list-item
+                      v-bind="props"
+                      :title="
+                        item.raw.parent
+                          ? item.raw.parent.tag_name
+                          : item.raw.tag_name
+                      "
+                      :subtitle="item.raw.parent ? item.raw.tag_name : null"
+                    >
+                      <template v-slot:prepend>
+                        <v-icon
+                          icon="mdi-tag"
+                          :color="tagColor(item.raw.tag_type.id)"
+                        ></v-icon>
+                      </template>
+                    </v-list-item>
+                  </template>
+                </v-autocomplete>
+              </v-col>
+            </v-row>
+            <v-row>
+              <v-col>
+                <v-autocomplete
+                  clearable
+                  label="Source Account*"
+                  :items="accounts"
+                  variant="outlined"
+                  :loading="accounts_isLoading"
+                  item-title="account_name"
+                  item-value="id"
+                  v-model="reminder_source_account_id.value.value"
+                  :error-messages="reminder_source_account_id.errorMessage.value"
+                >
+                  <template v-slot:item="{ props, item }">
+                    <v-list-item
+                      v-bind="props"
+                      :title="item.raw.account_name"
+                      :subtitle="item.raw.bank.bank_name"
+                    >
+                      <template v-slot:prepend>
+                        <v-icon :icon="item.raw.account_type.icon"></v-icon>
+                      </template>
+                    </v-list-item>
+                  </template>
+                </v-autocomplete>
+              </v-col>
+              <v-col>
+                <v-autocomplete
+                  clearable
+                  label="Destination Account*"
+                  :items="accounts"
+                  variant="outlined"
+                  :loading="accounts_isLoading"
+                  item-title="account_name"
+                  item-value="id"
+                  v-model="reminder_destination_account_id.value.value"
+                  :error-messages="reminder_destination_account_id.errorMessage.value"
+                  v-if="transaction_type_id.value.value == 3"
+                >
+                  <template v-slot:item="{ props, item }">
+                    <v-list-item
+                      v-bind="props"
+                      :title="item.raw.account_name"
+                      :subtitle="item.raw.bank.bank_name"
+                    >
+                      <template v-slot:prepend>
+                        <v-icon :icon="item.raw.account_type.icon"></v-icon>
+                      </template>
+                    </v-list-item>
+                  </template>
+                </v-autocomplete>
+              </v-col>
+            </v-row>
+            <v-row>
+              <v-col>
+                <span class="text-subtitle-2">Start Date</span>
+                <VueDatePicker
+                  v-model="start_date.value.value"
+                  timezone="America/New_York"
+                  model-type="yyyy-MM-dd"
+                  :enable-time-picker="false"
+                  auto-apply
+                  format="yyyy-MM-dd"
+                  :min-date="tomorrow"
+                  :teleport="true"
+                ></VueDatePicker>
+                <span
+                  class="text-error text-caption"
+                  v-if="start_date.errorMessage.value"
+                >
+                  {{ start_date.errorMessage.value }}
+                </span>
+              </v-col>
+              <v-col>
+                <span class="text-subtitle-2">End Date</span>
+                <VueDatePicker
+                  v-model="end_date.value.value"
+                  timezone="America/New_York"
+                  model-type="yyyy-MM-dd"
+                  :enable-time-picker="false"
+                  auto-apply
+                  format="yyyy-MM-dd"
+                  :min-date="getLowerLimit()"
+                  :teleport="true"
+                ></VueDatePicker>
+                <span
+                  class="text-error text-caption"
+                  v-if="end_date.errorMessage.value"
+                >
+                  {{ end_date.errorMessage.value }}
+                </span>
+              </v-col>
+            </v-row>
+            <v-row>
+              <v-col>
+                <v-autocomplete
+                  clearable
+                  label="Repeats*"
+                  :items="repeats"
+                  variant="outlined"
+                  :loading="repeats_isLoading"
+                  item-title="repeat_name"
+                  item-value="id"
+                  v-model="repeat_id.value.value"
+                  :error-messages="repeat_id.errorMessage.value"
+                ></v-autocomplete>
+              </v-col>
+              <v-col>
+                <v-switch
+                  v-model="auto_add.value.value"
+                  hide-details
+                  label="Auto Add"
+                  color="primary"
+                ></v-switch>
+              </v-col>
+            </v-row>
+            <v-row>
+              <v-col>
+                <v-textarea
+                  clearable
+                  label="Memo"
+                  variant="outlined"
+                  v-model="memo.value.value"
+                  :rows="4"
+                  no-resize
+                ></v-textarea>
+              </v-col>
+            </v-row>
+          </v-container>
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer></v-spacer>
+          <v-btn color="primary" variant="text" @click="closeDialog">Close</v-btn>
+          <v-btn color="primary" variant="text" type="submit">Save</v-btn>
+        </v-card-actions>
+      </v-card>
+    </form>
   </v-dialog>
 </template>
 <script setup>
-  import { ref, defineEmits, defineProps, onMounted, watchEffect } from "vue";
+  import { defineEmits, defineProps, onMounted, watchEffect, watch } from "vue";
   import { useTransactionTypes } from "@/composables/transactionTypesComposable";
   import { useAccounts } from "@/composables/accountsComposable";
   import { useTags } from "@/composables/tagsComposable";
@@ -231,180 +225,169 @@
   import "@vuepic/vue-datepicker/dist/main.css";
   import { useReminders } from "@/composables/remindersComposable";
   import { useRepeats } from "@/composables/repeatsComposable";
+  import { useField, useForm } from "vee-validate";
+  import * as yup from "yup";
+
+  const schema = yup.object({
+    description: yup.string().required("Description is required."),
+    amount: yup
+      .number()
+      .typeError("Amount is required.")
+      .required("Amount is required.")
+      .positive("Amount must be greater than zero."),
+    transaction_type_id: yup
+      .number()
+      .typeError("Transaction type is required.")
+      .required("Transaction type is required."),
+    tag_id: yup
+      .number()
+      .typeError("Tag is required.")
+      .required("Tag is required."),
+    reminder_source_account_id: yup
+      .number()
+      .typeError("Source account is required.")
+      .required("Source account is required."),
+    reminder_destination_account_id: yup.mixed().when("transaction_type_id", {
+      is: 3,
+      then: schema => schema.required("Destination account is required for transfers."),
+      otherwise: schema => schema.nullable().notRequired(),
+    }),
+    start_date: yup.string().nullable().required("Start date is required."),
+    end_date: yup
+      .string()
+      .nullable()
+      .notRequired()
+      .test(
+        "end-after-start",
+        "End date must be on or after start date.",
+        function (value) {
+          const { start_date } = this.parent;
+          if (!value || !start_date) return true;
+          return value >= start_date;
+        },
+      ),
+    repeat_id: yup
+      .number()
+      .typeError("Repeat type is required.")
+      .required("Repeat type is required."),
+    auto_add: yup.boolean().notRequired(),
+    memo: yup.string().nullable().notRequired(),
+  });
+
+  const { handleSubmit } = useForm({ validationSchema: schema });
+
+  const description = useField("description");
+  const amount = useField("amount");
+  const transaction_type_id = useField("transaction_type_id");
+  const tag_id = useField("tag_id");
+  const reminder_source_account_id = useField("reminder_source_account_id");
+  const reminder_destination_account_id = useField(
+    "reminder_destination_account_id",
+  );
+  const start_date = useField("start_date");
+  const end_date = useField("end_date");
+  const repeat_id = useField("repeat_id");
+  const auto_add = useField("auto_add");
+  const memo = useField("memo");
 
   const today = new Date();
   const tomorrow = new Date(today);
   tomorrow.setDate(today.getDate() + 1);
+
   const { addReminder, updateReminder } = useReminders();
   const { accounts, isLoading: accounts_isLoading } = useAccounts();
-  const formComplete = ref(false);
   const { repeats, isLoading: repeats_isLoading } = useRepeats();
   const { transaction_types, isLoading: transaction_types_isLoading } =
     useTransactionTypes();
-  const props = defineProps({
-    isEdit: {
-      type: Boolean,
-      default: false,
-    },
-    passedFormData: {
-      type: Object,
-    },
-  });
-
-  const formData = ref({
-    id: props.passedFormData.id || 0,
-    tag_id: props.passedFormData.tag.id || null,
-    amount: props.passedFormData.amount || null,
-    reminder_source_account_id:
-      props.passedFormData.reminder_source_account.id || null,
-    reminder_destination_account_id:
-      props.passedFormData.reminder_destination_account.id || null,
-    description: props.passedFormData.description || null,
-    transaction_type_id: props.passedFormData.transaction_type.id || 1,
-    start_date: props.passedFormData.start_date || null,
-    end_date: props.passedFormData.end_date || null,
-    repeat_id: props.passedFormData.repeat.id || null,
-    auto_add: props.passedFormData.auto_add || true,
-    memo: props.passedFormData.memo || null,
-  });
-
   const { tags, isLoading: tags_isLoading } = useTags();
+
   const emit = defineEmits(["updateDialog"]);
-  const watchPassedFormData = () => {
-    watchEffect(() => {
-      if (props.passedFormData) {
-        formData.value = {
-          id: props.passedFormData.id,
-          tag_id: props.passedFormData.tag.id,
-          amount: props.passedFormData.amount,
-          reminder_source_account_id:
-            props.passedFormData.reminder_source_account.id,
-          reminder_destination_account_id:
-            props.passedFormData.reminder_destination_account &&
-            props.passedFormData.reminder_destination_account.id
-              ? props.passedFormData.reminder_destination_account.id
-              : null,
-          description: props.passedFormData.description,
-          transaction_type_id: props.passedFormData.transaction_type.id,
-          start_date: props.passedFormData.start_date,
-          end_date: props.passedFormData.end_date,
-          repeat_id: props.passedFormData.repeat.id,
-          auto_add: props.passedFormData.auto_add,
-          memo: props.passedFormData.memo,
-        };
-        amount.value = props.passedFormData.amount
-          ? parseFloat(Math.abs(props.passedFormData.amount)).toFixed(2)
-          : null;
-      }
-    });
-  };
-  const endDateGood = ref(true);
-  const required = [
-    value => {
-      if (value) return true;
-
-      return "This field is required.";
-    },
-  ];
-  const amount = ref(
-    props.passedFormData.amount
-      ? parseFloat(Math.abs(props.passedFormData.amount)).toFixed(2)
-      : null,
-  );
-  const checkFormComplete = async () => {
-    if (formData.value.repeat_id == 6) {
-      formData.value.end_date = formData.value.start_date;
-    }
-    if (formData.value.end_date) {
-      if (formData.value.end_date >= formData.value.start_date) {
-        endDateGood.value = true;
-      } else {
-        endDateGood.value = false;
-      }
-    }
-    if (
-      formData.value.transaction_type_id !== null &&
-      formData.value.transaction_type_id !== "" &&
-      formData.value.description !== "" &&
-      formData.value.description !== null &&
-      formData.value.reminder_source_account_id !== "" &&
-      formData.value.reminder_source_account_id !== null &&
-      formData.value.tag_id !== "" &&
-      formData.value.tag_id !== null &&
-      amount.value !== "" &&
-      amount.value !== null &&
-      formData.value.start_date !== "" &&
-      formData.value.start_date !== null &&
-      formData.value.repeat_id !== "" &&
-      formData.value.repeat_id !== null
-    ) {
-      if (formData.value.transaction_type_id == 3) {
-        if (
-          formData.value.reminder_destination_account_id !== null &&
-          formData.value.reminder_destination_account_id !== ""
-        ) {
-          formComplete.value = true;
-        } else {
-          formComplete.value = false;
-        }
-      } else {
-        formData.value.reminder_destination_account_id = null;
-        formComplete.value = true;
-      }
-      if (formData.value.end_date) {
-        if (formData.value.end_date >= formData.value.start_date) {
-          formComplete.value = true;
-        } else {
-          formComplete.value = false;
-        }
-      }
-    } else {
-      formComplete.value = false;
-    }
-  };
-
-  const reformatNumberToMoney = () => {
-    amount.value = parseFloat(amount.value).toFixed(2);
-  };
-
-  onMounted(() => {
-    watchPassedFormData();
+  const props = defineProps({
+    isEdit: { type: Boolean, default: false },
+    passedFormData: { type: Object },
   });
 
-  const submitForm = async () => {
-    if (formData.value.transaction_type_id == 2) {
-      formData.value.amount = amount.value;
-    } else {
-      formData.value.amount = -amount.value;
-    }
-    formData.value.next_date = formData.value.start_date;
-    if (props.isEdit == false) {
-      await addReminder(formData.value);
-    } else {
-      await updateReminder(formData.value);
-    }
+  // When one-time repeat is selected, lock end_date to start_date
+  watch(
+    () => repeat_id.value.value,
+    newVal => {
+      if (newVal == 6) {
+        end_date.value.value = start_date.value.value;
+      }
+    },
+  );
 
+  const submit = handleSubmit(values => {
+    const payload = { ...values };
+    payload.amount =
+      values.transaction_type_id == 2
+        ? Math.abs(values.amount)
+        : -Math.abs(values.amount);
+    if (values.repeat_id == 6) {
+      payload.end_date = values.start_date;
+    }
+    if (values.transaction_type_id != 3) {
+      payload.reminder_destination_account_id = null;
+    }
+    payload.next_date = values.start_date;
+    payload.id = props.passedFormData.id;
+
+    if (props.isEdit) {
+      updateReminder(payload);
+    } else {
+      addReminder(payload);
+    }
     closeDialog();
-  };
+  });
 
   const closeDialog = () => {
     emit("updateDialog", false);
   };
 
-  const tagColor = typeID => {
-    if (typeID == 1) {
-      return "error";
-    } else if (typeID == 2) {
-      return "success";
-    } else if (typeID == 3) {
-      return "info";
+  const initializeFormData = () => {
+    description.value.value = props.passedFormData.description ?? null;
+    amount.value.value = props.passedFormData.amount
+      ? parseFloat(Math.abs(props.passedFormData.amount)).toFixed(2)
+      : null;
+    transaction_type_id.value.value =
+      props.passedFormData.transaction_type?.id ?? null;
+    tag_id.value.value = props.passedFormData.tag?.id ?? null;
+    reminder_source_account_id.value.value =
+      props.passedFormData.reminder_source_account?.id ?? null;
+    reminder_destination_account_id.value.value =
+      props.passedFormData.reminder_destination_account?.id ?? null;
+    start_date.value.value = props.passedFormData.start_date ?? null;
+    end_date.value.value = props.passedFormData.end_date ?? null;
+    repeat_id.value.value = props.passedFormData.repeat?.id ?? null;
+    auto_add.value.value = props.passedFormData.auto_add ?? true;
+    memo.value.value = props.passedFormData.memo ?? null;
+  };
+
+  onMounted(() => {
+    watchEffect(() => {
+      if (props.passedFormData) {
+        initializeFormData();
+      }
+    });
+  });
+
+  const reformatNumberToMoney = () => {
+    if (amount.value.value) {
+      amount.value.value = parseFloat(amount.value.value).toFixed(2);
     }
   };
 
+  const tagColor = typeID => {
+    if (typeID == 1) return "error";
+    if (typeID == 2) return "success";
+    if (typeID == 3) return "info";
+  };
+
   const getLowerLimit = () => {
-    const lowerLimit = new Date();
-    const start_date = new Date(formData.value.start_date);
-    lowerLimit.setDate(start_date.getDate() + 1);
-    return lowerLimit;
+    const startVal = start_date.value.value;
+    if (!startVal) return new Date();
+    const d = new Date(startVal);
+    d.setDate(d.getDate() + 1);
+    return d;
   };
 </script>

--- a/frontend/src/components/ReminderFormMobile.vue
+++ b/frontend/src/components/ReminderFormMobile.vue
@@ -1,235 +1,229 @@
 <template>
   <v-dialog fullscreen persistent>
-    <v-card>
-      <v-card-title>
-        <span class="text-h5" v-if="props.isEdit == false">Add Reminder</span>
-        <span class="text-h5" v-else>Edit Reminder</span>
-      </v-card-title>
-      <v-card-text>
-        <v-container>
-          <v-row dense>
-            <v-col>
-              <v-text-field
-                v-model="amount"
-                variant="outlined"
-                label="Amount*"
-                :rules="required"
-                prefix="$"
-                @update:model-value="checkFormComplete"
-                type="number"
-                step="1.00"
-                @update:focused="reformatNumberToMoney"
-              ></v-text-field>
-            </v-col>
-          </v-row>
-          <v-row dense>
-            <v-col>
-              <v-text-field
-                v-model="formData.description"
-                variant="outlined"
-                label="Description*"
-                :rules="required"
-                @update:model-value="checkFormComplete"
-              ></v-text-field>
-            </v-col>
-          </v-row>
-          <v-row dense>
-            <v-col>
-              <v-autocomplete
-                clearable
-                label="Transaction Type*"
-                :items="transaction_types"
-                variant="outlined"
-                :loading="transaction_types_isLoading"
-                item-title="transaction_type"
-                item-value="id"
-                v-model="formData.transaction_type_id"
-                :rules="required"
-                @update:model-value="checkFormComplete"
-              ></v-autocomplete>
-            </v-col>
-          </v-row>
-          <v-row dense>
-            <v-col>
-              <!-- TODO: Enable adding tags here -->
-              <v-autocomplete
-                clearable
-                label="Tag*"
-                :items="tags"
-                variant="outlined"
-                :loading="tags_isLoading"
-                item-title="tag_name"
-                item-value="id"
-                v-model="formData.tag_id"
-                :rules="required"
-                @update:model-value="checkFormComplete"
-              >
-                <template v-slot:item="{ props, item }">
-                  <v-list-item
-                    v-bind="props"
-                    :title="
-                      item.raw.parent
-                        ? item.raw.parent.tag_name
-                        : item.raw.tag_name
-                    "
-                    :subtitle="item.raw.parent ? item.raw.tag_name : null"
-                  >
-                    <template v-slot:prepend>
-                      <v-icon
-                        icon="mdi-tag"
-                        :color="tagColor(item.raw.tag_type.id)"
-                      ></v-icon>
-                    </template>
-                  </v-list-item>
-                </template>
-              </v-autocomplete>
-            </v-col>
-          </v-row>
-          <v-row dense>
-            <v-col>
-              <v-autocomplete
-                clearable
-                label="Source Account*"
-                :items="accounts"
-                variant="outlined"
-                :loading="accounts_isLoading"
-                item-title="account_name"
-                item-value="id"
-                v-model="formData.reminder_source_account_id"
-                :rules="required"
-                @update:model-value="checkFormComplete"
-              >
-                <template v-slot:item="{ props, item }">
-                  <v-list-item
-                    v-bind="props"
-                    :title="item.raw.account_name"
-                    :subtitle="item.raw.bank.bank_name"
-                  >
-                    <template v-slot:prepend>
-                      <v-icon :icon="item.raw.account_type.icon"></v-icon>
-                    </template>
-                  </v-list-item>
-                </template>
-              </v-autocomplete>
-            </v-col>
-          </v-row>
-          <v-row dense>
-            <v-col>
-              <v-autocomplete
-                clearable
-                label="Destination Account*"
-                :items="accounts"
-                variant="outlined"
-                :loading="accounts_isLoading"
-                item-title="account_name"
-                item-value="id"
-                v-model="formData.reminder_destination_account_id"
-                :rules="required"
-                @update:model-value="checkFormComplete"
-                v-if="formData.transaction_type_id == 3"
-              >
-                <template v-slot:item="{ props, item }">
-                  <v-list-item
-                    v-bind="props"
-                    :title="item.raw.account_name"
-                    :subtitle="item.raw.bank.bank_name"
-                  >
-                    <template v-slot:prepend>
-                      <v-icon :icon="item.raw.account_type.icon"></v-icon>
-                    </template>
-                  </v-list-item>
-                </template>
-              </v-autocomplete>
-            </v-col>
-          </v-row>
-          <v-row dense>
-            <v-col>
-              <span class="text-subtitle-2">Start Date</span>
-              <VueDatePicker
-                v-model="formData.start_date"
-                timezone="America/New_York"
-                model-type="yyyy-MM-dd"
-                :enable-time-picker="false"
-                auto-apply
-                format="yyyy-MM-dd"
-                @closed="checkFormComplete"
-                :min-date="tomorrow"
-                :teleport="true"
-              ></VueDatePicker>
-            </v-col>
-            <v-col>
-              <span class="text-subtitle-2">End Date</span>
-              <VueDatePicker
-                v-model="formData.end_date"
-                timezone="America/New_York"
-                model-type="yyyy-MM-dd"
-                :enable-time-picker="false"
-                auto-apply
-                format="yyyy-MM-dd"
-                @closed="checkFormComplete"
-                :min-date="getLowerLimit()"
-                :teleport="true"
-                :state="endDateGood"
-              ></VueDatePicker>
-            </v-col>
-          </v-row>
-          <v-row dense>
-            <v-col>
-              <v-autocomplete
-                clearable
-                label="Repeats*"
-                :items="repeats"
-                variant="outlined"
-                :loading="repeats_isLoading"
-                item-title="repeat_name"
-                item-value="id"
-                v-model="formData.repeat_id"
-                :rules="required"
-                @update:model-value="checkFormComplete"
-              ></v-autocomplete>
-            </v-col>
-            <v-col>
-              <v-switch
-                v-model="formData.auto_add"
-                hide-details
-                label="Auto Add"
-                color="primary"
-                @update:model-value="checkFormComplete"
-              ></v-switch>
-            </v-col>
-          </v-row>
-          <v-row dense>
-            <v-col>
-              <v-textarea
-                clearable
-                label="Memo"
-                variant="outlined"
-                v-model="formData.memo"
-                :rows="4"
-                no-resize
-                @update:model-value="checkFormComplete"
-              ></v-textarea>
-            </v-col>
-          </v-row>
-        </v-container>
-      </v-card-text>
-      <v-card-actions>
-        <v-spacer></v-spacer>
-        <v-btn color="primary" variant="text" @click="closeDialog">Close</v-btn>
-        <v-btn
-          color="primary"
-          variant="text"
-          @click="submitForm"
-          :disabled="!formComplete"
-        >
-          Save
-        </v-btn>
-      </v-card-actions>
-    </v-card>
+    <form @submit.prevent="submit">
+      <v-card>
+        <v-card-title>
+          <span class="text-h5" v-if="props.isEdit == false">Add Reminder</span>
+          <span class="text-h5" v-else>Edit Reminder</span>
+        </v-card-title>
+        <v-card-text>
+          <v-container>
+            <v-row dense>
+              <v-col>
+                <v-text-field
+                  v-model="amount.value.value"
+                  variant="outlined"
+                  label="Amount*"
+                  :error-messages="amount.errorMessage.value"
+                  prefix="$"
+                  type="number"
+                  step="1.00"
+                  @blur="reformatNumberToMoney"
+                ></v-text-field>
+              </v-col>
+            </v-row>
+            <v-row dense>
+              <v-col>
+                <v-text-field
+                  v-model="description.value.value"
+                  variant="outlined"
+                  label="Description*"
+                  :error-messages="description.errorMessage.value"
+                ></v-text-field>
+              </v-col>
+            </v-row>
+            <v-row dense>
+              <v-col>
+                <v-autocomplete
+                  clearable
+                  label="Transaction Type*"
+                  :items="transaction_types"
+                  variant="outlined"
+                  :loading="transaction_types_isLoading"
+                  item-title="transaction_type"
+                  item-value="id"
+                  v-model="transaction_type_id.value.value"
+                  :error-messages="transaction_type_id.errorMessage.value"
+                ></v-autocomplete>
+              </v-col>
+            </v-row>
+            <v-row dense>
+              <v-col>
+                <v-autocomplete
+                  clearable
+                  label="Tag*"
+                  :items="tags"
+                  variant="outlined"
+                  :loading="tags_isLoading"
+                  item-title="tag_name"
+                  item-value="id"
+                  v-model="tag_id.value.value"
+                  :error-messages="tag_id.errorMessage.value"
+                >
+                  <template v-slot:item="{ props, item }">
+                    <v-list-item
+                      v-bind="props"
+                      :title="
+                        item.raw.parent
+                          ? item.raw.parent.tag_name
+                          : item.raw.tag_name
+                      "
+                      :subtitle="item.raw.parent ? item.raw.tag_name : null"
+                    >
+                      <template v-slot:prepend>
+                        <v-icon
+                          icon="mdi-tag"
+                          :color="tagColor(item.raw.tag_type.id)"
+                        ></v-icon>
+                      </template>
+                    </v-list-item>
+                  </template>
+                </v-autocomplete>
+              </v-col>
+            </v-row>
+            <v-row dense>
+              <v-col>
+                <v-autocomplete
+                  clearable
+                  label="Source Account*"
+                  :items="accounts"
+                  variant="outlined"
+                  :loading="accounts_isLoading"
+                  item-title="account_name"
+                  item-value="id"
+                  v-model="reminder_source_account_id.value.value"
+                  :error-messages="reminder_source_account_id.errorMessage.value"
+                >
+                  <template v-slot:item="{ props, item }">
+                    <v-list-item
+                      v-bind="props"
+                      :title="item.raw.account_name"
+                      :subtitle="item.raw.bank.bank_name"
+                    >
+                      <template v-slot:prepend>
+                        <v-icon :icon="item.raw.account_type.icon"></v-icon>
+                      </template>
+                    </v-list-item>
+                  </template>
+                </v-autocomplete>
+              </v-col>
+            </v-row>
+            <v-row dense>
+              <v-col>
+                <v-autocomplete
+                  clearable
+                  label="Destination Account*"
+                  :items="accounts"
+                  variant="outlined"
+                  :loading="accounts_isLoading"
+                  item-title="account_name"
+                  item-value="id"
+                  v-model="reminder_destination_account_id.value.value"
+                  :error-messages="reminder_destination_account_id.errorMessage.value"
+                  v-if="transaction_type_id.value.value == 3"
+                >
+                  <template v-slot:item="{ props, item }">
+                    <v-list-item
+                      v-bind="props"
+                      :title="item.raw.account_name"
+                      :subtitle="item.raw.bank.bank_name"
+                    >
+                      <template v-slot:prepend>
+                        <v-icon :icon="item.raw.account_type.icon"></v-icon>
+                      </template>
+                    </v-list-item>
+                  </template>
+                </v-autocomplete>
+              </v-col>
+            </v-row>
+            <v-row dense>
+              <v-col>
+                <span class="text-subtitle-2">Start Date</span>
+                <VueDatePicker
+                  v-model="start_date.value.value"
+                  timezone="America/New_York"
+                  model-type="yyyy-MM-dd"
+                  :enable-time-picker="false"
+                  auto-apply
+                  format="yyyy-MM-dd"
+                  :min-date="tomorrow"
+                  :teleport="true"
+                ></VueDatePicker>
+                <span
+                  class="text-error text-caption"
+                  v-if="start_date.errorMessage.value"
+                >
+                  {{ start_date.errorMessage.value }}
+                </span>
+              </v-col>
+              <v-col>
+                <span class="text-subtitle-2">End Date</span>
+                <VueDatePicker
+                  v-model="end_date.value.value"
+                  timezone="America/New_York"
+                  model-type="yyyy-MM-dd"
+                  :enable-time-picker="false"
+                  auto-apply
+                  format="yyyy-MM-dd"
+                  :min-date="getLowerLimit()"
+                  :teleport="true"
+                ></VueDatePicker>
+                <span
+                  class="text-error text-caption"
+                  v-if="end_date.errorMessage.value"
+                >
+                  {{ end_date.errorMessage.value }}
+                </span>
+              </v-col>
+            </v-row>
+            <v-row dense>
+              <v-col>
+                <v-autocomplete
+                  clearable
+                  label="Repeats*"
+                  :items="repeats"
+                  variant="outlined"
+                  :loading="repeats_isLoading"
+                  item-title="repeat_name"
+                  item-value="id"
+                  v-model="repeat_id.value.value"
+                  :error-messages="repeat_id.errorMessage.value"
+                ></v-autocomplete>
+              </v-col>
+              <v-col>
+                <v-switch
+                  v-model="auto_add.value.value"
+                  hide-details
+                  label="Auto Add"
+                  color="primary"
+                ></v-switch>
+              </v-col>
+            </v-row>
+            <v-row dense>
+              <v-col>
+                <v-textarea
+                  clearable
+                  label="Memo"
+                  variant="outlined"
+                  v-model="memo.value.value"
+                  :rows="4"
+                  no-resize
+                ></v-textarea>
+              </v-col>
+            </v-row>
+          </v-container>
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer></v-spacer>
+          <v-btn color="primary" variant="text" @click="closeDialog">Close</v-btn>
+          <v-btn color="primary" variant="text" type="submit">Save</v-btn>
+        </v-card-actions>
+      </v-card>
+    </form>
   </v-dialog>
 </template>
 <script setup>
-  import { ref, defineEmits, defineProps, onMounted, watchEffect } from "vue";
+  import { defineEmits, defineProps, onMounted, watchEffect, watch } from "vue";
   import { useTransactionTypes } from "@/composables/transactionTypesComposable";
   import { useAccounts } from "@/composables/accountsComposable";
   import { useTags } from "@/composables/tagsComposable";
@@ -237,180 +231,170 @@
   import "@vuepic/vue-datepicker/dist/main.css";
   import { useReminders } from "@/composables/remindersComposable";
   import { useRepeats } from "@/composables/repeatsComposable";
+  import { useField, useForm } from "vee-validate";
+  import * as yup from "yup";
+
+  const schema = yup.object({
+    description: yup.string().required("Description is required."),
+    amount: yup
+      .number()
+      .typeError("Amount is required.")
+      .required("Amount is required.")
+      .positive("Amount must be greater than zero."),
+    transaction_type_id: yup
+      .number()
+      .typeError("Transaction type is required.")
+      .required("Transaction type is required."),
+    tag_id: yup
+      .number()
+      .typeError("Tag is required.")
+      .required("Tag is required."),
+    reminder_source_account_id: yup
+      .number()
+      .typeError("Source account is required.")
+      .required("Source account is required."),
+    reminder_destination_account_id: yup.mixed().when("transaction_type_id", {
+      is: 3,
+      then: schema =>
+        schema.required("Destination account is required for transfers."),
+      otherwise: schema => schema.nullable().notRequired(),
+    }),
+    start_date: yup.string().nullable().required("Start date is required."),
+    end_date: yup
+      .string()
+      .nullable()
+      .notRequired()
+      .test(
+        "end-after-start",
+        "End date must be on or after start date.",
+        function (value) {
+          const { start_date } = this.parent;
+          if (!value || !start_date) return true;
+          return value >= start_date;
+        },
+      ),
+    repeat_id: yup
+      .number()
+      .typeError("Repeat type is required.")
+      .required("Repeat type is required."),
+    auto_add: yup.boolean().notRequired(),
+    memo: yup.string().nullable().notRequired(),
+  });
+
+  const { handleSubmit } = useForm({ validationSchema: schema });
+
+  const description = useField("description");
+  const amount = useField("amount");
+  const transaction_type_id = useField("transaction_type_id");
+  const tag_id = useField("tag_id");
+  const reminder_source_account_id = useField("reminder_source_account_id");
+  const reminder_destination_account_id = useField(
+    "reminder_destination_account_id",
+  );
+  const start_date = useField("start_date");
+  const end_date = useField("end_date");
+  const repeat_id = useField("repeat_id");
+  const auto_add = useField("auto_add");
+  const memo = useField("memo");
 
   const today = new Date();
   const tomorrow = new Date(today);
   tomorrow.setDate(today.getDate() + 1);
+
   const { addReminder, updateReminder } = useReminders();
   const { accounts, isLoading: accounts_isLoading } = useAccounts();
-  const formComplete = ref(false);
   const { repeats, isLoading: repeats_isLoading } = useRepeats();
   const { transaction_types, isLoading: transaction_types_isLoading } =
     useTransactionTypes();
-  const props = defineProps({
-    isEdit: {
-      type: Boolean,
-      default: false,
-    },
-    passedFormData: {
-      type: Object,
-    },
-  });
-
-  const formData = ref({
-    id: props.passedFormData.id || 0,
-    tag_id: props.passedFormData.tag.id || null,
-    amount: props.passedFormData.amount || null,
-    reminder_source_account_id:
-      props.passedFormData.reminder_source_account.id || null,
-    reminder_destination_account_id:
-      props.passedFormData.reminder_destination_account.id || null,
-    description: props.passedFormData.description || null,
-    transaction_type_id: props.passedFormData.transaction_type.id || 1,
-    start_date: props.passedFormData.start_date || null,
-    end_date: props.passedFormData.end_date || null,
-    repeat_id: props.passedFormData.repeat.id || null,
-    auto_add: props.passedFormData.auto_add || true,
-    memo: props.passedFormData.memo || null,
-  });
-
   const { tags, isLoading: tags_isLoading } = useTags();
+
   const emit = defineEmits(["updateDialog"]);
-  const watchPassedFormData = () => {
-    watchEffect(() => {
-      if (props.passedFormData) {
-        formData.value = {
-          id: props.passedFormData.id,
-          tag_id: props.passedFormData.tag.id,
-          amount: props.passedFormData.amount,
-          reminder_source_account_id:
-            props.passedFormData.reminder_source_account.id,
-          reminder_destination_account_id:
-            props.passedFormData.reminder_destination_account &&
-            props.passedFormData.reminder_destination_account.id
-              ? props.passedFormData.reminder_destination_account.id
-              : null,
-          description: props.passedFormData.description,
-          transaction_type_id: props.passedFormData.transaction_type.id,
-          start_date: props.passedFormData.start_date,
-          end_date: props.passedFormData.end_date,
-          repeat_id: props.passedFormData.repeat.id,
-          auto_add: props.passedFormData.auto_add,
-          memo: props.passedFormData.memo,
-        };
-        amount.value = props.passedFormData.amount
-          ? parseFloat(Math.abs(props.passedFormData.amount)).toFixed(2)
-          : null;
-      }
-    });
-  };
-  const endDateGood = ref(true);
-  const required = [
-    value => {
-      if (value) return true;
-
-      return "This field is required.";
-    },
-  ];
-  const amount = ref(
-    props.passedFormData.amount
-      ? parseFloat(Math.abs(props.passedFormData.amount)).toFixed(2)
-      : null,
-  );
-  const checkFormComplete = async () => {
-    if (formData.value.repeat_id == 6) {
-      formData.value.end_date = formData.value.start_date;
-    }
-    if (formData.value.end_date) {
-      if (formData.value.end_date >= formData.value.start_date) {
-        endDateGood.value = true;
-      } else {
-        endDateGood.value = false;
-      }
-    }
-    if (
-      formData.value.transaction_type_id !== null &&
-      formData.value.transaction_type_id !== "" &&
-      formData.value.description !== "" &&
-      formData.value.description !== null &&
-      formData.value.reminder_source_account_id !== "" &&
-      formData.value.reminder_source_account_id !== null &&
-      formData.value.tag_id !== "" &&
-      formData.value.tag_id !== null &&
-      amount.value !== "" &&
-      amount.value !== null &&
-      formData.value.start_date !== "" &&
-      formData.value.start_date !== null &&
-      formData.value.repeat_id !== "" &&
-      formData.value.repeat_id !== null
-    ) {
-      if (formData.value.transaction_type_id == 3) {
-        if (
-          formData.value.reminder_destination_account_id !== null &&
-          formData.value.reminder_destination_account_id !== ""
-        ) {
-          formComplete.value = true;
-        } else {
-          formComplete.value = false;
-        }
-      } else {
-        formData.value.reminder_destination_account_id = null;
-        formComplete.value = true;
-      }
-      if (formData.value.end_date) {
-        if (formData.value.end_date >= formData.value.start_date) {
-          formComplete.value = true;
-        } else {
-          formComplete.value = false;
-        }
-      }
-    } else {
-      formComplete.value = false;
-    }
-  };
-
-  const reformatNumberToMoney = () => {
-    amount.value = parseFloat(amount.value).toFixed(2);
-  };
-
-  onMounted(() => {
-    watchPassedFormData();
+  const props = defineProps({
+    isEdit: { type: Boolean, default: false },
+    passedFormData: { type: Object },
   });
 
-  const submitForm = async () => {
-    if (formData.value.transaction_type_id == 2) {
-      formData.value.amount = amount.value;
-    } else {
-      formData.value.amount = -amount.value;
-    }
-    formData.value.next_date = formData.value.start_date;
-    if (props.isEdit == false) {
-      await addReminder(formData.value);
-    } else {
-      await updateReminder(formData.value);
-    }
+  // When one-time repeat is selected, lock end_date to start_date
+  watch(
+    () => repeat_id.value.value,
+    newVal => {
+      if (newVal == 6) {
+        end_date.value.value = start_date.value.value;
+      }
+    },
+  );
 
+  const submit = handleSubmit(values => {
+    const payload = { ...values };
+    payload.amount =
+      values.transaction_type_id == 2
+        ? Math.abs(values.amount)
+        : -Math.abs(values.amount);
+    if (values.repeat_id == 6) {
+      payload.end_date = values.start_date;
+    }
+    if (values.transaction_type_id != 3) {
+      payload.reminder_destination_account_id = null;
+    }
+    payload.next_date = values.start_date;
+    payload.id = props.passedFormData.id;
+
+    if (props.isEdit) {
+      updateReminder(payload);
+    } else {
+      addReminder(payload);
+    }
     closeDialog();
-  };
+  });
 
   const closeDialog = () => {
     emit("updateDialog", false);
   };
 
-  const tagColor = typeID => {
-    if (typeID == 1) {
-      return "error";
-    } else if (typeID == 2) {
-      return "success";
-    } else if (typeID == 3) {
-      return "info";
+  const initializeFormData = () => {
+    description.value.value = props.passedFormData.description ?? null;
+    amount.value.value = props.passedFormData.amount
+      ? parseFloat(Math.abs(props.passedFormData.amount)).toFixed(2)
+      : null;
+    transaction_type_id.value.value =
+      props.passedFormData.transaction_type?.id ?? null;
+    tag_id.value.value = props.passedFormData.tag?.id ?? null;
+    reminder_source_account_id.value.value =
+      props.passedFormData.reminder_source_account?.id ?? null;
+    reminder_destination_account_id.value.value =
+      props.passedFormData.reminder_destination_account?.id ?? null;
+    start_date.value.value = props.passedFormData.start_date ?? null;
+    end_date.value.value = props.passedFormData.end_date ?? null;
+    repeat_id.value.value = props.passedFormData.repeat?.id ?? null;
+    auto_add.value.value = props.passedFormData.auto_add ?? true;
+    memo.value.value = props.passedFormData.memo ?? null;
+  };
+
+  onMounted(() => {
+    watchEffect(() => {
+      if (props.passedFormData) {
+        initializeFormData();
+      }
+    });
+  });
+
+  const reformatNumberToMoney = () => {
+    if (amount.value.value) {
+      amount.value.value = parseFloat(amount.value.value).toFixed(2);
     }
   };
 
+  const tagColor = typeID => {
+    if (typeID == 1) return "error";
+    if (typeID == 2) return "success";
+    if (typeID == 3) return "info";
+  };
+
   const getLowerLimit = () => {
-    const lowerLimit = new Date();
-    const start_date = new Date(formData.value.start_date);
-    lowerLimit.setDate(start_date.getDate() + 1);
-    return lowerLimit;
+    const startVal = start_date.value.value;
+    if (!startVal) return new Date();
+    const d = new Date(startVal);
+    d.setDate(d.getDate() + 1);
+    return d;
   };
 </script>

--- a/frontend/src/components/TagForm.vue
+++ b/frontend/src/components/TagForm.vue
@@ -1,110 +1,95 @@
 <template>
   <v-dialog persistent width="1024">
-    <v-card>
-      <v-card-title>
-        <span class="text-h5">Add Tag</span>
-      </v-card-title>
-      <v-card-text>
-        <v-container>
-          <v-row>
-            <v-col>
-              <v-text-field
-                v-model="formData.tag_name"
-                variant="outlined"
-                label="Tag Name*"
-                :rules="required"
-                @update:model-value="checkFormComplete"
-              ></v-text-field>
-            </v-col>
-          </v-row>
-          <v-row>
-            <v-col>
-              <v-autocomplete
-                clearable
-                label="Tag Type*"
-                :items="tag_types"
-                variant="outlined"
-                :loading="tag_types_isLoading"
-                item-title="tag_type"
-                item-value="id"
-                v-model="formData.tag_type_id"
-                :rules="required"
-                @update:model-value="checkFormComplete"
-              ></v-autocomplete>
-            </v-col>
-            <v-col>
-              <v-autocomplete
-                clearable
-                label="Parent"
-                :items="parent_tags"
-                variant="outlined"
-                :loading="parent_tags_isLoading"
-                item-title="tag_name"
-                item-value="id"
-                v-model="formData.parent_id"
-              ></v-autocomplete>
-            </v-col>
-          </v-row>
-        </v-container>
-      </v-card-text>
-      <v-card-actions>
-        <v-spacer></v-spacer>
-        <v-btn color="primary" variant="text" @click="closeDialog">Close</v-btn>
-        <v-btn
-          color="primary"
-          variant="text"
-          @click="submitForm"
-          :disabled="!formComplete"
-        >
-          Save
-        </v-btn>
-      </v-card-actions>
-    </v-card>
+    <form @submit.prevent="submit">
+      <v-card>
+        <v-card-title>
+          <span class="text-h5">Add Tag</span>
+        </v-card-title>
+        <v-card-text>
+          <v-container>
+            <v-row>
+              <v-col>
+                <v-text-field
+                  v-model="tag_name.value.value"
+                  variant="outlined"
+                  label="Tag Name*"
+                  :error-messages="tag_name.errorMessage.value"
+                ></v-text-field>
+              </v-col>
+            </v-row>
+            <v-row>
+              <v-col>
+                <v-autocomplete
+                  clearable
+                  label="Tag Type*"
+                  :items="tag_types"
+                  variant="outlined"
+                  :loading="tag_types_isLoading"
+                  item-title="tag_type"
+                  item-value="id"
+                  v-model="tag_type_id.value.value"
+                  :error-messages="tag_type_id.errorMessage.value"
+                ></v-autocomplete>
+              </v-col>
+              <v-col>
+                <v-autocomplete
+                  clearable
+                  label="Parent"
+                  :items="parent_tags"
+                  variant="outlined"
+                  :loading="parent_tags_isLoading"
+                  item-title="tag_name"
+                  item-value="id"
+                  v-model="parent_id.value.value"
+                ></v-autocomplete>
+              </v-col>
+            </v-row>
+          </v-container>
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer></v-spacer>
+          <v-btn color="primary" variant="text" @click="closeDialog">Close</v-btn>
+          <v-btn color="primary" variant="text" type="submit">Save</v-btn>
+        </v-card-actions>
+      </v-card>
+    </form>
   </v-dialog>
 </template>
 <script setup>
-  import { ref, defineEmits } from "vue";
-  import { useTags } from "@/composables/tagsComposable";
-  import { useParentTags } from "@/composables/tagsComposable";
+  import { defineEmits } from "vue";
+  import { useTags, useParentTags } from "@/composables/tagsComposable";
   import { useTagTypes } from "@/composables/tagtypesComposable";
+  import { useField, useForm } from "vee-validate";
+  import * as yup from "yup";
+
+  const schema = yup.object({
+    tag_name: yup.string().required("Tag name is required."),
+    tag_type_id: yup
+      .number()
+      .typeError("Tag type is required.")
+      .required("Tag type is required."),
+    parent_id: yup.number().nullable().notRequired(),
+  });
+
+  const { handleSubmit, resetForm } = useForm({ validationSchema: schema });
+
+  const tag_name = useField("tag_name");
+  const tag_type_id = useField("tag_type_id");
+  const parent_id = useField("parent_id");
 
   const { tag_types, isLoading: tag_types_isLoading } = useTagTypes();
   const { addTag } = useTags();
   const { parent_tags, isLoading: parent_tags_isLoading } = useParentTags();
-  const formComplete = ref(false);
-  const formData = ref({
-    tag_name: "",
-    parent_id: null,
-    tag_type_id: 1,
+
+  const emit = defineEmits(["updateDialog"]);
+
+  const submit = handleSubmit(values => {
+    addTag(values);
+    closeDialog();
   });
 
-  const required = [
-    value => {
-      if (value) return true;
-
-      return "This field is required.";
-    },
-  ];
-  const emit = defineEmits(["updateDialog"]);
-  const checkFormComplete = async () => {
-    if (
-      formData.value.tag_name !== null &&
-      formData.value.tag_name !== "" &&
-      formData.value.tag_type_id !== null &&
-      formData.value.tag_type_id !== ""
-    ) {
-      formComplete.value = true;
-    } else {
-      formComplete.value = false;
-    }
-  };
-
-  const submitForm = async () => {
-    addTag(formData.value);
-    closeDialog();
-  };
-
   const closeDialog = () => {
+    resetForm();
     emit("updateDialog", false);
   };
 </script>

--- a/frontend/src/views/AddAccount.vue
+++ b/frontend/src/views/AddAccount.vue
@@ -1,7 +1,6 @@
 <template>
-  <v-form @submit.prevent>
+  <form @submit.prevent="submit">
     <v-card v-if="page1">
-      <!--TODO: use v-stepper here-->
       <v-card-title>What bank is this account with?</v-card-title>
       <v-card-text>
         <v-row dense>
@@ -14,9 +13,8 @@
               :loading="isLoading"
               item-title="bank_name"
               item-value="id"
-              v-model="formData.bank_id"
-              :rules="required"
-              @update:model-value="checkNext"
+              v-model="bank_id.value.value"
+              :error-messages="bank_id.errorMessage.value"
             ></v-autocomplete>
           </v-col>
         </v-row>
@@ -35,18 +33,16 @@
               :loading="account_types_isLoading"
               item-title="account_type"
               item-value="id"
-              v-model="formData.account_type_id"
-              :rules="required"
-              @update:model-value="checkNext"
+              v-model="account_type_id.value.value"
+              :error-messages="account_type_id.errorMessage.value"
             ></v-autocomplete>
           </v-col>
         </v-row>
         <v-row dense>
           <v-col>
             <v-text-field
-              v-model="formData.account_name"
-              :rules="required"
-              @update:model-value="checkNext"
+              v-model="account_name.value.value"
+              :error-messages="account_name.errorMessage.value"
               variant="outlined"
               label="Name Your Account*"
             ></v-text-field>
@@ -57,16 +53,7 @@
         </v-row>
       </v-card-text>
       <v-card-actions>
-        <v-btn
-          @click="
-            page1
-              ? ((page1 = false), (page2 = true))
-              : ((page1 = true), (page2 = false))
-          "
-          :disabled="next1"
-        >
-          Next
-        </v-btn>
+        <v-btn @click="goToPage2" :disabled="!page1Valid">Next</v-btn>
       </v-card-actions>
     </v-card>
     <v-card v-if="page2" min-height="500">
@@ -76,55 +63,57 @@
           <v-col>
             When did you open this account?*
             <VueDatePicker
-              v-model="formData.open_date"
+              v-model="open_date.value.value"
               timezone="America/New_York"
               model-type="yyyy-MM-dd"
               :enable-time-picker="false"
               auto-apply
               format="yyyy-MM-dd"
-              @update:model-value="checkNext"
             ></VueDatePicker>
+            <span
+              class="text-error text-caption"
+              v-if="open_date.errorMessage.value"
+            >
+              {{ open_date.errorMessage.value }}
+            </span>
           </v-col>
         </v-row>
         <v-row dense>
           <v-col>
             <v-text-field
-              v-model="formData.opening_balance"
+              v-model="opening_balance.value.value"
               variant="outlined"
               label="Opening Balance*"
-              :rules="required"
+              :error-messages="opening_balance.errorMessage.value"
               prefix="$"
-              @update:model-value="checkNext"
             ></v-text-field>
           </v-col>
         </v-row>
-        <v-row dense v-if="formData.account_type_id == 1">
+        <v-row dense v-if="account_type_id.value.value == 1">
           <v-col>
             <v-text-field
-              v-model="formData.annual_rate"
+              v-model="annual_rate.value.value"
               variant="outlined"
               label="Annual Rate (APR/APY)*"
-              :rules="required"
+              :error-messages="annual_rate.errorMessage.value"
               suffix="%"
-              @update:model-value="checkNext"
             ></v-text-field>
           </v-col>
           <v-col>
             <v-text-field
-              v-model="formData.credit_limit"
+              v-model="credit_limit.value.value"
               variant="outlined"
               label="Credit Limit*"
-              :rules="required"
+              :error-messages="credit_limit.errorMessage.value"
               prefix="$"
-              @update:model-value="checkNext"
             ></v-text-field>
           </v-col>
         </v-row>
-        <v-row dense v-if="formData.account_type_id == 1">
+        <v-row dense v-if="account_type_id.value.value == 1">
           <v-col>
             When is your next due date?
             <VueDatePicker
-              v-model="formData.due_date"
+              v-model="due_date.value.value"
               timezone="America/New_York"
               model-type="yyyy-MM-dd"
               :enable-time-picker="false"
@@ -133,9 +122,9 @@
             ></VueDatePicker>
           </v-col>
           <v-col>
-            When does this statment period end?
+            When does this statement period end?
             <VueDatePicker
-              v-model="formData.next_cycle_date"
+              v-model="next_cycle_date.value.value"
               timezone="America/New_York"
               model-type="yyyy-MM-dd"
               :enable-time-picker="false"
@@ -144,21 +133,19 @@
             ></VueDatePicker>
           </v-col>
         </v-row>
-        <v-row dense v-if="formData.account_type_id == 1">
+        <v-row dense v-if="account_type_id.value.value == 1">
           <v-col>
             <v-select
-              label="Statment Cycle Length"
-              required
+              label="Statement Cycle Length"
               :items="intervals"
-              v-model="formData.statement_cycle_length"
+              v-model="statement_cycle_length.value.value"
             ></v-select>
           </v-col>
           <v-col>
             <v-select
-              label="Statment Cycle Period"
-              required
+              label="Statement Cycle Period"
               :items="units"
-              v-model="formData.statement_cycle_period"
+              v-model="statement_cycle_period.value.value"
               item-value="letter"
               item-title="name"
             ></v-select>
@@ -168,10 +155,10 @@
       </v-card-text>
       <v-card-actions>
         <v-btn @click="goBack">Back</v-btn>
-        <v-btn @click="submitForm" :disabled="submitDisabled">Submit</v-btn>
+        <v-btn type="submit">Submit</v-btn>
       </v-card-actions>
     </v-card>
-  </v-form>
+  </form>
 </template>
 <script setup>
   import { useBanks } from "@/composables/banksComposable";
@@ -183,90 +170,108 @@
   import { useMainStore } from "@/stores/main";
   import { useRouter } from "vue-router";
   import AddBankForm from "@/components/AddBankForm.vue";
+  import { useField, useForm } from "vee-validate";
+  import * as yup from "yup";
 
   const router = useRouter();
   const today = new Date();
-  const year = today.getFullYear();
-  const month = String(today.getMonth() + 1).padStart(2, "0");
-  const day = String(today.getDate()).padStart(2, "0");
+  const formattedDate = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, "0")}-${String(today.getDate()).padStart(2, "0")}`;
 
-  const formattedDate = `${year}-${month}-${day}`;
   const mainstore = useMainStore();
-  const required = [
-    value => {
-      if (value) return true;
 
-      return "This field is required.";
-    },
-  ];
-  const formData = ref({
-    account_name: null,
-    account_type_id: null,
-    opening_balance: 0,
-    annual_rate: 0.0,
-    due_date: null,
-    active: true,
-    open_date: formattedDate,
-    next_cycle_date: null,
-    statement_cycle_length: null,
-    statement_cycle_period: null,
-    credit_limit: 0,
-    bank_id: null,
+  const schema = yup.object({
+    bank_id: yup
+      .number()
+      .typeError("Bank is required.")
+      .required("Bank is required."),
+    account_type_id: yup
+      .number()
+      .typeError("Account type is required.")
+      .required("Account type is required."),
+    account_name: yup.string().required("Account name is required."),
+    open_date: yup.string().nullable().required("Open date is required."),
+    opening_balance: yup
+      .number()
+      .typeError("Opening balance is required.")
+      .required("Opening balance is required."),
+    annual_rate: yup.number().when("account_type_id", {
+      is: 1,
+      then: schema =>
+        schema
+          .typeError("Annual rate is required.")
+          .required("Annual rate is required."),
+      otherwise: schema => schema.notRequired(),
+    }),
+    credit_limit: yup.number().when("account_type_id", {
+      is: 1,
+      then: schema =>
+        schema
+          .typeError("Credit limit is required.")
+          .required("Credit limit is required."),
+      otherwise: schema => schema.notRequired(),
+    }),
+    due_date: yup.string().nullable().notRequired(),
+    next_cycle_date: yup.string().nullable().notRequired(),
+    statement_cycle_length: yup.number().nullable().notRequired(),
+    statement_cycle_period: yup.string().nullable().notRequired(),
   });
 
-  const submitDisabled = ref(true);
+  const { handleSubmit } = useForm({ validationSchema: schema });
+
+  const bank_id = useField("bank_id");
+  const account_type_id = useField("account_type_id");
+  const account_name = useField("account_name");
+  const open_date = useField("open_date");
+  const opening_balance = useField("opening_balance");
+  const annual_rate = useField("annual_rate");
+  const credit_limit = useField("credit_limit");
+  const due_date = useField("due_date");
+  const next_cycle_date = useField("next_cycle_date");
+  const statement_cycle_length = useField("statement_cycle_length");
+  const statement_cycle_period = useField("statement_cycle_period");
+
+  // Initialise defaults
+  open_date.value.value = formattedDate;
+  opening_balance.value.value = 0;
+  annual_rate.value.value = 0.0;
+  credit_limit.value.value = 0;
+
   const page1 = ref(true);
-  const next1 = ref(true);
   const page2 = ref(false);
+
+  const page1Valid = computed(
+    () =>
+      !!bank_id.value.value &&
+      !!account_type_id.value.value &&
+      !!account_name.value.value,
+  );
+
   const { banks, isLoading } = useBanks();
   const { account_types, isLoading: account_types_isLoading } =
     useAccountTypes();
   const { addAccount } = useAccounts();
-  const goBack = async () => {
-    page2.value = false;
-    page1.value = true;
-    formData.value.annual_rate = 0.0;
-    formData.value.due_date = null;
-    formData.value.next_cycle_date = null;
-    formData.value.statement_cycle_length = null;
-    formData.value.statement_cycle_period = null;
-    formData.value.credit_limit = 0;
+
+  const goToPage2 = () => {
+    page1.value = false;
+    page2.value = true;
   };
 
-  const checkNext = async () => {
-    if (
-      formData.value.account_name !== null &&
-      formData.value.bank_id !== null &&
-      formData.value.account_name !== "" &&
-      formData.value.account_type_id !== null
-    ) {
-      next1.value = false;
-    } else {
-      next1.value = true;
-    }
-    if (
-      formData.value.annual_rate !== null &&
-      formData.value.annual_rate !== "" &&
-      formData.value.credit_limit !== null &&
-      formData.value.credit_limit !== "" &&
-      formData.value.open_date !== null &&
-      formData.value.open_date !== "" &&
-      formData.value.opening_balance !== null &&
-      formData.value.opening_balance !== ""
-    ) {
-      submitDisabled.value = false;
-    } else {
-      submitDisabled.value = true;
-    }
+  const goBack = () => {
+    page2.value = false;
+    page1.value = true;
+    annual_rate.value.value = 0.0;
+    due_date.value.value = null;
+    next_cycle_date.value.value = null;
+    statement_cycle_length.value.value = null;
+    statement_cycle_period.value.value = null;
+    credit_limit.value.value = 0;
   };
-  const units = computed(() => {
-    return mainstore.units;
-  });
-  const intervals = computed(() => {
-    return mainstore.intervals;
-  });
-  const submitForm = () => {
-    addAccount(formData.value);
+
+  const submit = handleSubmit(values => {
+    addAccount({ ...values, active: true });
     router.push("/");
-  };
+  });
+
+  const units = computed(() => mainstore.units);
+  const intervals = computed(() => mainstore.intervals);
 </script>


### PR DESCRIPTION
## Summary
- Replaces manual `formData` ref + `checkFormComplete` pattern with `useForm` / `useField` / `handleSubmit` from vee-validate v4 across 7 forms
- Migrated: `ReminderForm`, `ReminderFormMobile`, `EditAccountFormMobile`, `TagForm`, `AdjustBalanceForm`, `AddBankForm`, `AddAccount`
- Adds Yup schema validation with conditional required fields (`.when()`), cross-field validation (end date ≥ start date via `.test()`), and consistent `errorMessage` display throughout
- Fixed "Statment" → "Statement" typo in `AddAccount` and `EditAccountFormMobile`

## Test plan
- [ ] Add/edit a reminder (desktop and mobile) — required field errors, destination account shows only for transfers, end date locked when one-time repeat
- [ ] Add a tag — name and type required, parent optional
- [ ] Adjust account balance — new balance required, diff calculation correct
- [ ] Add a bank via the "Don't see your bank?" dialog — name required, form resets on close
- [ ] Add an account — Next button disabled until page 1 fields complete, CC fields shown conditionally for credit card type
- [ ] Edit account (mobile) — required fields validate, CC and savings/investment sections conditional

🤖 Generated with [Claude Code](https://claude.com/claude-code)