### PR TITLE
feat: add edit/delete for tags, blocking is_system tags

### DIFF
--- a/backend/tags/api/schemas/tag.py
+++ b/backend/tags/api/schemas/tag.py
@@ -21,6 +21,7 @@ class TagIn(Schema):
 class TagOut(Schema):
     id: int
     tag_name: str
+    is_system: bool
     parent: MainTagOut
     child: Optional[SubTagOut] = None
     tag_type: Optional[TagTypeOut] = None

--- a/frontend/src/components/TagForm.vue
+++ b/frontend/src/components/TagForm.vue
@@ -3,7 +3,7 @@
     <form @submit.prevent="submit">
       <v-card>
         <v-card-title>
-          <span class="text-h5">Add Tag</span>
+          <span class="text-h5">{{ isEdit ? "Edit Tag" : "Add Tag" }}</span>
         </v-card-title>
         <v-card-text>
           <v-container>
@@ -56,11 +56,22 @@
   </v-dialog>
 </template>
 <script setup>
-  import { defineEmits } from "vue";
+  import { defineEmits, defineProps, watchEffect } from "vue";
   import { useTags, useParentTags } from "@/composables/tagsComposable";
   import { useTagTypes } from "@/composables/tagtypesComposable";
   import { useField, useForm } from "vee-validate";
   import * as yup from "yup";
+
+  const props = defineProps({
+    isEdit: {
+      type: Boolean,
+      default: false,
+    },
+    tagData: {
+      type: Object,
+      default: null,
+    },
+  });
 
   const schema = yup.object({
     tag_name: yup.string().required("Tag name is required."),
@@ -78,13 +89,31 @@
   const parent_id = useField("parent_id");
 
   const { tag_types, isLoading: tag_types_isLoading } = useTagTypes();
-  const { addTag } = useTags();
+  const { addTag, editTag } = useTags();
   const { parent_tags, isLoading: parent_tags_isLoading } = useParentTags();
 
   const emit = defineEmits(["updateDialog"]);
 
+  watchEffect(() => {
+    if (props.isEdit && props.tagData) {
+      const tag = props.tagData;
+      tag_type_id.value.value = tag.tag_type?.id ?? null;
+      if (tag.child) {
+        tag_name.value.value = tag.child.tag_name;
+        parent_id.value.value = tag.parent?.id ?? null;
+      } else {
+        tag_name.value.value = tag.parent?.tag_name ?? "";
+        parent_id.value.value = null;
+      }
+    }
+  });
+
   const submit = handleSubmit(values => {
-    addTag(values);
+    if (props.isEdit && props.tagData) {
+      editTag(props.tagData.id, values);
+    } else {
+      addTag(values);
+    }
     closeDialog();
   });
 

--- a/frontend/src/components/TagsHeaderWidget.vue
+++ b/frontend/src/components/TagsHeaderWidget.vue
@@ -19,9 +19,30 @@
               >
                 Add Tag
               </v-btn>
+              <v-btn
+                icon="mdi-pencil"
+                size="small"
+                variant="text"
+                @click="openEditDialog"
+                v-if="authStore.isFullAccess && selectedTag && !selectedTag.is_system"
+              ></v-btn>
+              <v-btn
+                icon="mdi-delete"
+                size="small"
+                variant="text"
+                color="error"
+                @click="deleteDialog = true"
+                v-if="authStore.isFullAccess && selectedTag && !selectedTag.is_system"
+              ></v-btn>
               <TagForm
                 v-model="tagAddFormDialog"
                 @update-dialog="updateAddDialog"
+              />
+              <TagForm
+                v-model="tagEditFormDialog"
+                :is-edit="true"
+                :tag-data="selectedTag"
+                @update-dialog="updateEditDialog"
               />
             </div>
             <v-slide-group
@@ -109,27 +130,67 @@
       </template>
     </v-card>
     <v-skeleton-loader type="card" v-if="isLoading"></v-skeleton-loader>
+
+    <v-dialog v-model="deleteDialog" max-width="400" persistent>
+      <v-card>
+        <v-card-title class="text-h6">Delete Tag</v-card-title>
+        <v-card-text>
+          Are you sure you want to delete
+          <strong>{{ selectedTag ? selectedTag.tag_name : "" }}</strong>?
+          This cannot be undone.
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer></v-spacer>
+          <v-btn variant="text" @click="deleteDialog = false">Cancel</v-btn>
+          <v-btn color="error" variant="text" @click="confirmDelete">Delete</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
   </div>
 </template>
 <script setup>
-  import { ref, defineEmits } from "vue";
+  import { ref, computed, defineEmits } from "vue";
   import { useTags } from "@/composables/tagsComposable";
   import TagForm from "@/components/TagForm.vue";
   import { useDisplay } from "vuetify";
   import { useAuthStore } from "@/stores/auth";
 
   const tagAddFormDialog = ref(false);
+  const tagEditFormDialog = ref(false);
+  const deleteDialog = ref(false);
   const emit = defineEmits(["tagSelected"]);
   const authStore = useAuthStore();
   const tag_selected = ref(null);
-  const { tags, isLoading } = useTags();
+  const { tags, isLoading, removeTag } = useTags();
   const { smAndDown } = useDisplay();
+
+  const selectedTag = computed(() =>
+    tags.value ? tags.value.find(t => t.id === tag_selected.value) ?? null : null,
+  );
+
   const clickSelectTag = () => {
     emit("tagSelected", tag_selected.value);
   };
 
   const updateAddDialog = () => {
     tagAddFormDialog.value = false;
+  };
+
+  const updateEditDialog = () => {
+    tagEditFormDialog.value = false;
+  };
+
+  const openEditDialog = () => {
+    tagEditFormDialog.value = true;
+  };
+
+  const confirmDelete = () => {
+    if (selectedTag.value) {
+      removeTag(selectedTag.value.id);
+      tag_selected.value = null;
+      emit("tagSelected", null);
+    }
+    deleteDialog.value = false;
   };
 
   const tagColor = typeID => {

--- a/frontend/src/composables/tagsComposable.js
+++ b/frontend/src/composables/tagsComposable.js
@@ -108,6 +108,41 @@ async function createTagFunction(newTag) {
   }
 }
 
+async function updateTagFunction({ tagId, tag }) {
+  const mainstore = useMainStore();
+  try {
+    let data = {};
+    if (tag.parent_id == null) {
+      data = {
+        parent_name: tag.tag_name,
+        tag_type_id: tag.tag_type_id,
+      };
+    } else {
+      data = {
+        child_name: tag.tag_name,
+        tag_type_id: tag.tag_type_id,
+        parent_id: tag.parent_id,
+      };
+    }
+    const response = await apiClient.put(`/tags/update/${tagId}`, data);
+    mainstore.showSnackbar("Tag updated successfully!", "success");
+    return response.data;
+  } catch (error) {
+    handleApiError(error, "Tag not updated: ");
+  }
+}
+
+async function deleteTagFunction(tagId) {
+  const mainstore = useMainStore();
+  try {
+    const response = await apiClient.delete(`/tags/delete/${tagId}`);
+    mainstore.showSnackbar("Tag deleted successfully!", "success");
+    return response.data;
+  } catch (error) {
+    handleApiError(error, "Tag not deleted: ");
+  }
+}
+
 export function useTags(tag_type) {
   const queryClient = useQueryClient();
   const {
@@ -124,7 +159,20 @@ export function useTags(tag_type) {
   const createTagMutation = useMutation({
     mutationFn: createTagFunction,
     onSuccess: () => {
-      console.log("Success adding tag");
+      queryClient.invalidateQueries({ queryKey: ["tags"] });
+    },
+  });
+
+  const updateTagMutation = useMutation({
+    mutationFn: updateTagFunction,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["tags"] });
+    },
+  });
+
+  const deleteTagMutation = useMutation({
+    mutationFn: deleteTagFunction,
+    onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["tags"] });
     },
   });
@@ -133,10 +181,20 @@ export function useTags(tag_type) {
     createTagMutation.mutate(newTag);
   }
 
+  async function editTag(tagId, tag) {
+    updateTagMutation.mutate({ tagId, tag });
+  }
+
+  async function removeTag(tagId) {
+    deleteTagMutation.mutate(tagId);
+  }
+
   return {
     isLoading,
     tags,
     addTag,
+    editTag,
+    removeTag,
     isFetching,
   };
 }


### PR DESCRIPTION
## Summary
- Added `is_system` to `TagOut` schema so the frontend can conditionally show edit/delete buttons
- Added `updateTagMutation` and `deleteTagMutation` (+ `editTag`/`removeTag` functions) to `tagsComposable.js`
- `TagForm.vue` now supports edit mode via `isEdit` + `tagData` props; pre-fills tag name, type, and parent on open, calls `editTag` on submit
- `TagsHeaderWidget.vue` shows pencil and delete icon buttons when a non-system tag is selected and the user has full-access; delete requires confirmation dialog
- Backend already had the `is_system` guard on the delete endpoint (returns 403); this PR just exposes it cleanly in the UI

## Test plan
- [ ] Add a new tag — existing create flow unchanged
- [ ] Select a user-created tag — pencil and delete icons appear
- [ ] Select a system tag — pencil and delete icons are hidden
- [ ] Edit a parent-only tag — form opens pre-filled, rename saves correctly
- [ ] Edit a child tag — form pre-fills with child name + parent selected
- [ ] Delete a tag — confirmation dialog appears, tag removed after confirm
- [ ] Cancel delete — tag not removed
- [ ] Readonly user — edit/delete buttons not shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)