### PR TITLE
feat: add VITE_OPT_FEATURES flag to gate optional planning menu items

### DIFF
--- a/example.env
+++ b/example.env
@@ -13,4 +13,5 @@ DJANGO_SUPERUSER_PASSWORD=somepassword
 DJANGO_SUPERUSER_EMAIL=someone@somewhere.com
 DJANGO_SUPERUSER_USERNAME=superuser
 VITE_API_KEY=secretkey
+VITE_OPT_FEATURES=false
 TIMEZONE=America/New_York

--- a/frontend/src/components/PlanningMenu.vue
+++ b/frontend/src/components/PlanningMenu.vue
@@ -43,50 +43,50 @@
   const transactions_store = useTransactionsStore();
   const authStore = useAuthStore();
   const router = useRouter();
-  const app_personal = computed(() => process.env.VUE_APP_PERSONAL === "true");
+  const optFeatures = import.meta.env.VITE_OPT_FEATURES === "true";
 
   const planning_menu = ref([
     {
       title: "Pay",
       link: "/planning/pay",
       icon: "mdi-checkbook",
-      personal: false,
+      optional: false,
     },
     {
       title: "Expenses",
       link: "/planning/expenses",
       icon: "mdi-cash",
-      personal: false,
+      optional: false,
     },
     {
       title: "Budgets",
       link: "/planning/budgets",
       icon: "mdi-pail",
-      personal: false,
+      optional: false,
     },
     {
       title: "Contributions",
       link: "/planning/contributions",
       icon: "mdi-pail",
-      personal: true,
+      optional: true,
     },
     {
       title: "Retirement",
       link: "/planning/retirement",
       icon: "mdi-piggy-bank",
-      personal: false,
+      optional: false,
     },
     {
       title: "Notes",
       link: "/planning/notes",
       icon: "mdi-note",
-      personal: true,
+      optional: true,
     },
     {
       title: "Calculator",
       link: "/planning/calculator",
       icon: "mdi-calculator",
-      personal: true,
+      optional: true,
     },
   ]);
 
@@ -105,7 +105,8 @@
   const filteredPlanningMenu = computed(() =>
     planning_menu.value.filter(item => {
       if (item.link === "/planning/calculator" && !authStore.isFullAccess) return false;
-      return (item.personal && app_personal) || !item.personal;
+      if (item.optional && !optFeatures) return false;
+      return true;
     }),
   );
 </script>


### PR DESCRIPTION
## Summary
- Adds `VITE_OPT_FEATURES=false` to `example.env` for documentation
- When set to `true` in `frontend/.env`, the planning menu shows **Contributions**, **Notes**, and **Calculator**; when `false` or unset those items are hidden
- Replaces the old `VUE_APP_PERSONAL` / `process.env` pattern which was broken in Vite (those vars are never exposed — must use `import.meta.env.VITE_*`)
- Renamed `personal` → `optional` on menu item objects for clarity
- Filter logic simplified: one guard per condition, no computed ref bug

## Setup
Add to `frontend/.env` before building:
```
VITE_OPT_FEATURES=true   # show optional planning items
VITE_OPT_FEATURES=false  # hide them (default)
```

## Test plan
- [ ] With `VITE_OPT_FEATURES=false` — Contributions, Notes, Calculator absent from planning menu
- [ ] With `VITE_OPT_FEATURES=true` — all three items appear
- [ ] Pay, Expenses, Budgets, Retirement always visible regardless of flag
- [ ] Calculator still hidden for readonly users even when flag is true

🤖 Generated with [Claude Code](https://claude.com/claude-code)