### PR TITLE
feat: wire up widget edit form for dashboard pie chart widgets

### DIFF
--- a/frontend/src/components/GraphAreaWidget.vue
+++ b/frontend/src/components/GraphAreaWidget.vue
@@ -12,7 +12,7 @@
               {{ getGraphTitle(i) }}
             </span>
 
-            <WidgetForm v-if="authStore.isFullAccess" :widget="i" class="ms-auto" />
+            <WidgetForm v-if="authStore.isFullAccess" :widget="i" />
           </v-card-title>
           <v-card-text
             class="d-flex justify-center align-center pa-0 ga-0 ma-0 w-100"
@@ -37,7 +37,7 @@
             <span class="text-subtitle-2 text-primary">
               {{ getGraphTitle(page) }}
             </span>
-            <WidgetForm v-if="authStore.isFullAccess" :widget="page" class="ms-auto" />
+            <WidgetForm v-if="authStore.isFullAccess" :widget="page" />
           </v-card-title>
           <v-card-text
             class="d-flex justify-center align-center pa-0 ga-0 ma-0 w-100"

--- a/frontend/src/components/GraphAreaWidget.vue
+++ b/frontend/src/components/GraphAreaWidget.vue
@@ -12,7 +12,7 @@
               {{ getGraphTitle(i) }}
             </span>
 
-            <v-btn icon="mdi-cog" variant="text" size="small" class="ms-auto" v-if="authStore.isFullAccess" />
+            <WidgetForm v-if="authStore.isFullAccess" :widget="i" class="ms-auto" />
           </v-card-title>
           <v-card-text
             class="d-flex justify-center align-center pa-0 ga-0 ma-0 w-100"
@@ -37,7 +37,7 @@
             <span class="text-subtitle-2 text-primary">
               {{ getGraphTitle(page) }}
             </span>
-            <v-btn icon="mdi-cog" variant="text" size="small" class="ms-auto" v-if="authStore.isFullAccess" />
+            <WidgetForm v-if="authStore.isFullAccess" :widget="page" class="ms-auto" />
           </v-card-title>
           <v-card-text
             class="d-flex justify-center align-center pa-0 ga-0 ma-0 w-100"
@@ -56,6 +56,7 @@
 </template>
 <script setup>
   import PieGraphWidget from "@/components/PieGraphWidget.vue";
+  import WidgetForm from "@/components/WidgetForm.vue";
   import { useDisplay } from "vuetify";
   import { useGraphsNew } from "@/composables/tagsComposable";
   import { useOptions } from "@/composables/optionsComposable";
@@ -75,10 +76,6 @@
     useGraphsNew(3);
 
   function getGraphTitle(widget) {
-    if (!lgAndUp) {
-      return "Graph Unknown";
-    }
-
     return appOptions.value
       ? appOptions.value[`widget${widget}_graph_name`]
       : `Graph ${widget}`;

--- a/frontend/src/components/WidgetForm.vue
+++ b/frontend/src/components/WidgetForm.vue
@@ -131,9 +131,11 @@
     formData.graph_type = options.value[`widget${w}_type`]?.id ?? 1;
     formData.tag_id = options.value[`widget${w}_tag_id`] ?? null;
     const excludeStr = options.value[`widget${w}_exclude`];
-    formData.exclude = excludeStr
-      ? excludeStr.split(",").map(id => parseInt(id)).filter(Boolean)
-      : [];
+    try {
+      formData.exclude = excludeStr ? JSON.parse(excludeStr).filter(Boolean) : [];
+    } catch {
+      formData.exclude = [];
+    }
   };
 
   const submitForm = () => {
@@ -142,9 +144,7 @@
       [`widget${w}_graph_name`]: formData.graph_name,
       [`widget${w}_tag_id`]: formData.tag_id ?? null,
       [`widget${w}_type_id`]: formData.graph_type,
-      [`widget${w}_exclude`]: formData.exclude?.length
-        ? formData.exclude.join(",")
-        : "",
+      [`widget${w}_exclude`]: JSON.stringify(formData.exclude ?? []),
     });
     menu.value = false;
   };

--- a/frontend/src/components/WidgetForm.vue
+++ b/frontend/src/components/WidgetForm.vue
@@ -5,18 +5,18 @@
     v-model="menu"
     @update:model-value="onMenuStateChange"
   >
-    <template v-slot:activator="{ props }">
+    <template v-slot:activator="{ props: menuProps }">
       <v-btn
         icon="mdi-cog"
         flat
         size="xs"
-        v-bind="props"
+        v-bind="menuProps"
         :disabled="isLoading"
       ></v-btn>
     </template>
     <v-form v-model="formValid" ref="form">
       <v-card :width="isMobile ? '400' : '350'">
-        <v-card-title>Widget {{ props.widget }}</v-card-title>
+        <v-card-title>Widget {{ widget }}</v-card-title>
         <v-card-subtitle>Settings</v-card-subtitle>
         <v-card-text>
           <v-container>
@@ -27,7 +27,6 @@
                   variant="outlined"
                   label="Graph Name*"
                   :rules="required"
-                  @update:model-value="checkFormComplete"
                 ></v-text-field>
               </v-col>
             </v-row>
@@ -36,7 +35,6 @@
                 <v-radio-group
                   title="Graph Type"
                   v-model="formData.graph_type"
-                  @update:model-value="checkFormComplete"
                 >
                   <v-radio label="All Expenses" :value="1"></v-radio>
                   <v-radio label="All Income" :value="2"></v-radio>
@@ -57,7 +55,6 @@
                   :loading="parent_tags_isLoading"
                   v-model="formData.tag_id"
                   :rules="required"
-                  @update:model-value="checkFormComplete"
                   density="compact"
                 ></v-autocomplete>
               </v-col>
@@ -75,7 +72,6 @@
                   variant="outlined"
                   :loading="tags_isLoading"
                   v-model="formData.exclude"
-                  @update:model-value="checkFormComplete"
                   density="compact"
                 ></v-autocomplete>
               </v-col>
@@ -83,12 +79,71 @@
           </v-container>
         </v-card-text>
         <v-card-actions>
-          <!--<v-btn @click="resetForm">Reset</v-btn>-->
-          <v-btn :disabled="!formComplete" @click="submitForm()" type="submit">
-            Save
-          </v-btn>
+          <v-btn :disabled="!formComplete" @click="submitForm">Save</v-btn>
         </v-card-actions>
       </v-card>
     </v-form>
   </v-menu>
 </template>
+<script setup>
+  import { ref, reactive, computed } from "vue";
+  import { useOptions } from "@/composables/optionsComposable";
+  import { useTags, useParentTags } from "@/composables/tagsComposable";
+  import { useDisplay } from "vuetify";
+
+  const props = defineProps({
+    widget: {
+      type: Number,
+      required: true,
+    },
+  });
+
+  const { smAndDown } = useDisplay();
+  const isMobile = smAndDown;
+
+  const { options, isLoading, editOptions } = useOptions();
+  const { tags, isLoading: tags_isLoading } = useTags();
+  const { parent_tags, isLoading: parent_tags_isLoading } = useParentTags();
+
+  const menu = ref(false);
+  const formValid = ref(false);
+  const formData = reactive({
+    graph_name: "",
+    graph_type: 1,
+    tag_id: null,
+    exclude: [],
+  });
+
+  const required = [v => !!v || "This field is required."];
+
+  const formComplete = computed(() => {
+    if (!formData.graph_name) return false;
+    if (formData.graph_type === 4 && !formData.tag_id) return false;
+    return true;
+  });
+
+  const onMenuStateChange = val => {
+    if (!val || !options.value) return;
+    const w = props.widget;
+    formData.graph_name = options.value[`widget${w}_graph_name`] ?? "";
+    formData.graph_type = options.value[`widget${w}_type`]?.id ?? 1;
+    formData.tag_id = options.value[`widget${w}_tag_id`] ?? null;
+    const excludeStr = options.value[`widget${w}_exclude`];
+    formData.exclude = excludeStr
+      ? excludeStr.split(",").map(id => parseInt(id)).filter(Boolean)
+      : [];
+  };
+
+  const submitForm = () => {
+    const w = props.widget;
+    editOptions({
+      [`widget${w}_graph_name`]: formData.graph_name,
+      [`widget${w}_tag_id`]: formData.tag_id ?? null,
+      [`widget${w}_type_id`]: formData.graph_type,
+      [`widget${w}_exclude`]: formData.exclude?.length
+        ? formData.exclude.join(",")
+        : null,
+    });
+    menu.value = false;
+  };
+</script>

--- a/frontend/src/components/WidgetForm.vue
+++ b/frontend/src/components/WidgetForm.vue
@@ -9,7 +9,9 @@
       <v-btn
         icon="mdi-cog"
         flat
-        size="xs"
+        size="x-small"
+        variant="text"
+        class="ms-auto"
         v-bind="menuProps"
         :disabled="isLoading"
       ></v-btn>
@@ -142,7 +144,7 @@
       [`widget${w}_type_id`]: formData.graph_type,
       [`widget${w}_exclude`]: formData.exclude?.length
         ? formData.exclude.join(",")
-        : null,
+        : "",
     });
     menu.value = false;
   };

--- a/frontend/src/composables/optionsComposable.js
+++ b/frontend/src/composables/optionsComposable.js
@@ -35,7 +35,6 @@ async function getOptionsFunction() {
 
 async function updateOptionsFunction(updatedOptions) {
   try {
-    console.log("update_options:", updatedOptions);
     const response = await apiClient.patch(
       "/administration/options/update/1",
       updatedOptions,
@@ -69,9 +68,9 @@ export function useOptions() {
   const updateOptionsMutation = useMutation({
     mutationFn: updateOptionsFunction,
     onSuccess: () => {
-      console.log("Success updating options");
       queryClient.invalidateQueries({ queryKey: ["options"] });
       queryClient.invalidateQueries({ queryKey: ["tag_graph"] });
+      queryClient.invalidateQueries({ queryKey: ["tag_graph_items"] });
       queryClient.invalidateQueries({ queryKey: ["retirement_forecast"] });
       queryClient.invalidateQueries({ queryKey: ["expense_graph"] });
     },


### PR DESCRIPTION
## Summary
- **WidgetForm.vue** now has a `<script setup>` — the cog button opens a settings menu that pre-fills the current widget's graph name, type, tag, and excluded tags from the options store, then saves via `editOptions()`
- **GraphAreaWidget.vue** replaces the two inert `v-btn` cog buttons with `<WidgetForm :widget="i" />` (desktop, per-card) and `<WidgetForm :widget="page" />` (mobile, tracks pagination)
- **optionsComposable.js** adds `tag_graph_items` to the invalidation list — without this the pie charts never refreshed after a save; also removes stale `console.log` calls
- Fixes a dead code branch in `getGraphTitle` where `!lgAndUp` was checking the ref object (always falsy) instead of its value

## Test plan
- [ ] Desktop: click cog on each of the 3 widgets — form opens pre-filled with current name/type
- [ ] Change graph name and save — card title updates
- [ ] Change graph type (e.g. All Expenses → Custom), select a tag, save — pie chart refreshes with new data
- [ ] Set excluded tags, save — exclusions applied to graph
- [ ] Mobile: paginate to widget 2, open cog — form pre-fills widget 2 settings
- [ ] Readonly user — cog button not shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)