### PR TITLE
fix: missing closing bracket on v-dialog tag in ReminderForm

### DIFF
--- a/frontend/src/components/ReminderForm.vue
+++ b/frontend/src/components/ReminderForm.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-dialog persistent :fullscreen="smAndDown" :width="smAndDown ? undefined : '1024'"
+  <v-dialog persistent :fullscreen="smAndDown" :width="smAndDown ? undefined : '1024'">
     <form @submit.prevent="submit">
       <v-card>
         <v-card-title>


### PR DESCRIPTION
## Summary
- Fixes Vite build failure introduced in #104
- `<v-dialog>` opening tag was missing its closing `>`, causing the Vue compiler to treat `</form>` as an orphaned end tag

## Root cause
```html
<!-- broken -->
<v-dialog persistent :fullscreen="smAndDown" :width="smAndDown ? undefined : '1024'"
  <form ...>

<!-- fixed -->
<v-dialog persistent :fullscreen="smAndDown" :width="smAndDown ? undefined : '1024'">
  <form ...>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)