### PR TITLE
feat: add file attachments to transactions

### DIFF
--- a/backend/backend/api.py
+++ b/backend/backend/api.py
@@ -29,6 +29,7 @@ from administration.api.routers.message import message_router
 from transactions.api.routers.transaction_detail import (
     transaction_detail_router,
 )
+from transactions.api.routers.transaction_image import router as transaction_image_router
 from tags.api.routers.tag_graph import tag_graph_router
 from tags.api.routers.graph_by_tags import graph_by_tags_router
 from imports.api.routers.import_file import import_file_router
@@ -70,6 +71,7 @@ api.add_router("/transactions/paychecks", paycheck_router)
 api.add_router("/transactions", transaction_router)
 api.add_router("/administration/messages", message_router)
 api.add_router("/transactions/transaction-details", transaction_detail_router)
+api.add_router("/transactions/attachments", transaction_image_router)
 api.add_router("/tags/tag-graphs", tag_graph_router)
 api.add_router("/tags/graph-by-tags", graph_by_tags_router)
 api.add_router("/file-imports", import_file_router)

--- a/backend/transactions/api/routers/transaction_image.py
+++ b/backend/transactions/api/routers/transaction_image.py
@@ -1,0 +1,5 @@
+from ninja import Router
+from transactions.api.views.transaction_image import transaction_image_router
+
+router = Router()
+router.add_router("/", transaction_image_router)

--- a/backend/transactions/api/schemas/transaction_image.py
+++ b/backend/transactions/api/schemas/transaction_image.py
@@ -1,0 +1,11 @@
+from ninja import Schema
+from pydantic import ConfigDict
+from typing import Optional
+
+
+class TransactionImageOut(Schema):
+    id: int
+    url: Optional[str] = None
+    filename: Optional[str] = None
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/transactions/api/views/transaction_image.py
+++ b/backend/transactions/api/views/transaction_image.py
@@ -1,0 +1,69 @@
+from ninja import Router, File
+from ninja.files import UploadedFile
+from ninja.errors import HttpError
+from django.shortcuts import get_object_or_404
+from django.http import Http404
+from typing import List
+import logging
+
+from administration.api.dependencies.auth import FullAccessAuth
+from transactions.models import Transaction, TransactionImage
+from transactions.api.schemas.transaction_image import TransactionImageOut
+
+api_logger = logging.getLogger("api")
+error_logger = logging.getLogger("error")
+
+transaction_image_router = Router(tags=["Transaction Attachments"])
+
+
+@transaction_image_router.get(
+    "/list/{transaction_id}",
+    response=List[TransactionImageOut],
+)
+def list_transaction_images(request, transaction_id: int):
+    try:
+        images = TransactionImage.objects.filter(transaction_id=transaction_id)
+        api_logger.debug(f"Attachments listed for transaction #{transaction_id}")
+        return images
+    except Exception as e:
+        error_logger.error(str(e))
+        raise HttpError(500, "Record retrieval error")
+
+
+@transaction_image_router.post(
+    "/upload/{transaction_id}",
+    response=TransactionImageOut,
+    auth=FullAccessAuth(),
+)
+def upload_transaction_image(
+    request,
+    transaction_id: int,
+    file: UploadedFile = File(...),
+):
+    try:
+        transaction = get_object_or_404(Transaction, id=transaction_id)
+        image = TransactionImage.objects.create(transaction=transaction, image=file)
+        api_logger.info(f"Attachment uploaded for transaction #{transaction_id}")
+        return image
+    except Http404:
+        raise HttpError(404, "Transaction not found")
+    except Exception as e:
+        error_logger.error(str(e))
+        raise HttpError(500, "Upload error")
+
+
+@transaction_image_router.delete(
+    "/delete/{image_id}",
+    auth=FullAccessAuth(),
+)
+def delete_transaction_image(request, image_id: int):
+    try:
+        image = get_object_or_404(TransactionImage, id=image_id)
+        image.delete()
+        api_logger.info(f"Attachment deleted #{image_id}")
+        return {"success": True}
+    except Http404:
+        raise HttpError(404, "Attachment not found")
+    except Exception as e:
+        error_logger.error(str(e))
+        raise HttpError(500, "Delete error")

--- a/backend/transactions/models.py
+++ b/backend/transactions/models.py
@@ -183,18 +183,20 @@ class TransactionImage(models.Model):
     Model representing a transaction image.
 
     Fields:
-    - image (ImageField): The image.
-    - transaction (ForeignKey): A reference to the Transaction model, associating the
-    transaction with this image.
+    - image (FileField): The uploaded file.
+    - transaction (ForeignKey): A reference to the Transaction model.
     """
 
     image = models.FileField(upload_to=transaction_image_name)
     transaction = models.ForeignKey(Transaction, on_delete=models.CASCADE)
 
-    def delete(self, *args, **kwargs):
-        # Delete the associated file when the instance is deleted
-        self.image.delete()
-        super().delete(*args, **kwargs)
+    @property
+    def url(self):
+        return self.image.url if self.image else None
+
+    @property
+    def filename(self):
+        return os.path.basename(self.image.name) if self.image else None
 
 
 class TransactionDetail(models.Model):

--- a/backend/transactions/signals.py
+++ b/backend/transactions/signals.py
@@ -1,6 +1,6 @@
 from django.db.models.signals import post_save, post_delete
 from django.dispatch import receiver
-from transactions.models import Transaction
+from transactions.models import Transaction, TransactionImage
 from django_q.tasks import async_task
 from core.cache.helpers import delete_pattern
 from core.cache.keys import account_all
@@ -24,3 +24,9 @@ def update_forecast_cache_on_delete(sender, instance, **kwargs):
     _refresh_account(instance.source_account_id)
     if instance.destination_account_id is not None:
         _refresh_account(instance.destination_account_id)
+
+
+@receiver(post_delete, sender=TransactionImage)
+def delete_transaction_image_file(sender, instance, **kwargs):
+    if instance.image:
+        instance.image.delete(save=False)

--- a/backend/transactions/tests/api/test_transaction_image_api.py
+++ b/backend/transactions/tests/api/test_transaction_image_api.py
@@ -1,0 +1,138 @@
+import pytest
+from django.core.files.uploadedfile import SimpleUploadedFile
+from transactions.models import TransactionImage
+
+AUTH = {"Authorization": "Bearer test-api-key"}
+
+
+@pytest.mark.django_db
+@pytest.mark.api
+def test_list_transaction_images_empty(api_client, test_transaction):
+    response = api_client.get(
+        f"/transactions/attachments/list/{test_transaction.id}",
+        headers=AUTH,
+    )
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+@pytest.mark.django_db
+@pytest.mark.api
+def test_list_transaction_images(api_client, settings, tmp_path, test_transaction):
+    settings.MEDIA_ROOT = tmp_path
+
+    file = SimpleUploadedFile("receipt.jpg", b"fake image bytes", content_type="image/jpeg")
+    obj = TransactionImage.objects.create(image=file, transaction=test_transaction)
+
+    response = api_client.get(
+        f"/transactions/attachments/list/{test_transaction.id}",
+        headers=AUTH,
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["id"] == obj.id
+    assert data[0]["url"].startswith("/media/tran_images/")
+    assert data[0]["filename"].endswith("-receipt.jpg")
+
+
+@pytest.mark.django_db
+@pytest.mark.api
+def test_upload_transaction_image(api_client, settings, tmp_path, test_transaction):
+    settings.MEDIA_ROOT = tmp_path
+
+    file = SimpleUploadedFile("receipt.jpg", b"fake image bytes", content_type="image/jpeg")
+
+    response = api_client.post(
+        f"/transactions/attachments/upload/{test_transaction.id}",
+        FILES={"file": file},
+        headers=AUTH,
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert "id" in data
+    assert data["url"].startswith("/media/tran_images/")
+    assert data["filename"].endswith("-receipt.jpg")
+
+    assert TransactionImage.objects.filter(id=data["id"]).exists()
+    assert (tmp_path / TransactionImage.objects.get(id=data["id"]).image.name).exists()
+
+
+@pytest.mark.django_db
+@pytest.mark.api
+def test_upload_transaction_image_transaction_not_found(api_client):
+    file = SimpleUploadedFile("receipt.jpg", b"fake image bytes", content_type="image/jpeg")
+
+    response = api_client.post(
+        "/transactions/attachments/upload/9999",
+        FILES={"file": file},
+        headers=AUTH,
+    )
+
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+@pytest.mark.api
+def test_delete_transaction_image(api_client, settings, tmp_path, test_transaction):
+    settings.MEDIA_ROOT = tmp_path
+
+    file = SimpleUploadedFile("receipt.jpg", b"fake image bytes", content_type="image/jpeg")
+    obj = TransactionImage.objects.create(image=file, transaction=test_transaction)
+    path = tmp_path / obj.image.name
+    assert path.exists()
+
+    response = api_client.delete(
+        f"/transactions/attachments/delete/{obj.id}",
+        headers=AUTH,
+    )
+
+    assert response.status_code == 200
+    assert response.json()["success"] is True
+    assert not TransactionImage.objects.filter(id=obj.id).exists()
+    assert not path.exists()
+
+
+@pytest.mark.django_db
+@pytest.mark.api
+def test_delete_transaction_image_not_found(api_client):
+    response = api_client.delete(
+        "/transactions/attachments/delete/9999",
+        headers=AUTH,
+    )
+
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+@pytest.mark.api
+def test_delete_transaction_removes_attachment_files(
+    api_client, settings, tmp_path, test_transaction
+):
+    """Deleting a transaction via the API cleans up all its attachment files."""
+    settings.MEDIA_ROOT = tmp_path
+
+    file1 = SimpleUploadedFile("receipt1.jpg", b"bytes1", content_type="image/jpeg")
+    file2 = SimpleUploadedFile("receipt2.jpg", b"bytes2", content_type="image/jpeg")
+    obj1 = TransactionImage.objects.create(image=file1, transaction=test_transaction)
+    obj2 = TransactionImage.objects.create(image=file2, transaction=test_transaction)
+
+    path1 = tmp_path / obj1.image.name
+    path2 = tmp_path / obj2.image.name
+    assert path1.exists()
+    assert path2.exists()
+
+    api_client.patch(
+        "/transactions/delete",
+        json={"transactions": [test_transaction.id]},
+        headers=AUTH,
+    )
+
+    assert not TransactionImage.objects.filter(
+        transaction_id=test_transaction.id
+    ).exists()
+    assert not path1.exists()
+    assert not path2.exists()

--- a/backend/transactions/tests/unit/test_transaction_image_model.py
+++ b/backend/transactions/tests/unit/test_transaction_image_model.py
@@ -71,3 +71,53 @@ def test_transaction_image_deleted_on_transaction_delete(
     assert TransactionImage.objects.count() == 1
     test_transaction.delete()
     assert TransactionImage.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_transaction_image_file_deleted_on_transaction_delete(
+    settings, tmp_path, test_transaction
+):
+    """File is removed from disk when parent transaction is cascade-deleted."""
+    settings.MEDIA_ROOT = tmp_path
+
+    file = SimpleUploadedFile("receipt.jpg", b"fake image")
+    obj = TransactionImage.objects.create(
+        image=file,
+        transaction=test_transaction,
+    )
+
+    path = tmp_path / obj.image.name
+    assert path.exists()
+
+    test_transaction.delete()
+
+    assert not path.exists()
+
+
+@pytest.mark.django_db
+def test_transaction_image_url_property(settings, tmp_path, test_transaction):
+    settings.MEDIA_ROOT = tmp_path
+
+    file = SimpleUploadedFile("receipt.jpg", b"fake image bytes")
+    obj = TransactionImage.objects.create(
+        image=file,
+        transaction=test_transaction,
+    )
+
+    assert obj.url is not None
+    assert obj.url.startswith("/media/tran_images/")
+    assert obj.url.endswith("-receipt.jpg")
+
+
+@pytest.mark.django_db
+def test_transaction_image_filename_property(settings, tmp_path, test_transaction):
+    settings.MEDIA_ROOT = tmp_path
+
+    file = SimpleUploadedFile("my-receipt.jpg", b"fake image bytes")
+    obj = TransactionImage.objects.create(
+        image=file,
+        transaction=test_transaction,
+    )
+
+    assert obj.filename is not None
+    assert obj.filename.endswith("-my-receipt.jpg")

--- a/backend/transactions/tests/unit/test_transaction_signals.py
+++ b/backend/transactions/tests/unit/test_transaction_signals.py
@@ -84,4 +84,35 @@ def test_transaction_image_file_is_deleted_on_model_delete(test_transaction, tmp
         transaction=test_transaction,
     )
 
+    path = tmp_path / image.image.name
+    assert path.exists()
+
     image.delete()
+
+    assert not path.exists()
+
+
+@pytest.mark.django_db
+def test_transaction_image_file_is_deleted_on_transaction_cascade(
+    test_transaction, tmp_path, settings
+):
+    """post_delete signal fires during CASCADE, cleaning up the file on disk."""
+    settings.MEDIA_ROOT = tmp_path
+    image_file = SimpleUploadedFile(
+        name="cascade.jpg",
+        content=b"fake image data",
+        content_type="image/jpeg",
+    )
+
+    image = TransactionImage.objects.create(
+        image=image_file,
+        transaction=test_transaction,
+    )
+
+    path = tmp_path / image.image.name
+    assert path.exists()
+
+    # Deleting the transaction triggers CASCADE which fires the post_delete signal
+    test_transaction.delete()
+
+    assert not path.exists()

--- a/frontend/src/components/TransactionForm.vue
+++ b/frontend/src/components/TransactionForm.vue
@@ -402,22 +402,85 @@
             </v-window-item>
             <v-window-item value="attachments">
               <v-container>
-                <v-carousel>
-                  <v-carousel-item
-                    src="https://cdn.vuetifyjs.com/images/cards/docks.jpg"
-                    cover
-                  ></v-carousel-item>
-
-                  <v-carousel-item
-                    src="https://cdn.vuetifyjs.com/images/cards/hotel.jpg"
-                    cover
-                  ></v-carousel-item>
-
-                  <v-carousel-item
-                    src="https://cdn.vuetifyjs.com/images/cards/sunshine.jpg"
-                    cover
-                  ></v-carousel-item>
-                </v-carousel>
+                <div
+                  v-if="!props.isEdit"
+                  class="text-center pa-6 text-medium-emphasis"
+                >
+                  Save the transaction first to add attachments.
+                </div>
+                <div v-else>
+                  <v-row dense class="mb-3">
+                    <v-col>
+                      <v-btn
+                        prepend-icon="mdi-paperclip"
+                        variant="outlined"
+                        size="small"
+                        @click="triggerFileInput"
+                      >
+                        Add Attachment
+                      </v-btn>
+                      <input
+                        ref="fileInput"
+                        type="file"
+                        style="display: none"
+                        @change="handleFileUpload"
+                      />
+                    </v-col>
+                  </v-row>
+                  <v-row v-if="attachments_isLoading">
+                    <v-col class="text-center">
+                      <v-progress-circular indeterminate></v-progress-circular>
+                    </v-col>
+                  </v-row>
+                  <v-row v-else-if="images && images.length > 0" dense>
+                    <v-col
+                      v-for="img in images"
+                      :key="img.id"
+                      cols="6"
+                      sm="4"
+                      md="3"
+                    >
+                      <v-card variant="outlined">
+                        <v-img
+                          :src="img.url"
+                          height="120"
+                          cover
+                          class="bg-grey-lighten-3"
+                        >
+                          <template v-slot:error>
+                            <div
+                              class="d-flex align-center justify-center fill-height"
+                            >
+                              <v-icon
+                                icon="mdi-file-document-outline"
+                                size="48"
+                                color="grey"
+                              ></v-icon>
+                            </div>
+                          </template>
+                        </v-img>
+                        <v-card-subtitle class="text-truncate px-2 py-1">
+                          {{ img.filename }}
+                        </v-card-subtitle>
+                        <v-card-actions class="pa-1">
+                          <v-spacer></v-spacer>
+                          <v-btn
+                            icon="mdi-delete"
+                            size="x-small"
+                            color="error"
+                            variant="text"
+                            @click="deleteImage(img.id)"
+                          ></v-btn>
+                        </v-card-actions>
+                      </v-card>
+                    </v-col>
+                  </v-row>
+                  <v-row v-else>
+                    <v-col class="text-center text-medium-emphasis">
+                      No attachments yet.
+                    </v-col>
+                  </v-row>
+                </div>
               </v-container>
             </v-window-item>
           </v-window>
@@ -438,6 +501,7 @@
 <script setup>
   import {
     ref,
+    computed,
     defineEmits,
     defineProps,
     onMounted,
@@ -450,6 +514,7 @@
   import { useAccounts } from "@/composables/accountsComposable";
   import { useTransactions } from "@/composables/transactionsComposable";
   import { usePayees } from "@/composables/payeesComposable";
+  import { useTransactionImages } from "@/composables/transactionImagesComposable";
   import VueDatePicker from "@vuepic/vue-datepicker";
   import "@vuepic/vue-datepicker/dist/main.css";
   import TagTable from "@/components/TagTable.vue";
@@ -617,6 +682,22 @@
     passedFormData: Object,
     account_id: { type: Number, default: 1 },
   });
+
+  const transactionIdRef = computed(() => props.passedFormData?.id ?? null);
+  const { images, attachments_isLoading, uploadImage, deleteImage } =
+    useTransactionImages(transactionIdRef);
+
+  const fileInput = ref(null);
+  function triggerFileInput() {
+    fileInput.value?.click();
+  }
+  function handleFileUpload(event) {
+    const file = event.target.files[0];
+    if (file) {
+      uploadImage(file);
+      event.target.value = "";
+    }
+  }
 
   // Re-validate gross when any paycheck amount changes so the total error updates live
   watch(

--- a/frontend/src/composables/transactionImagesComposable.js
+++ b/frontend/src/composables/transactionImagesComposable.js
@@ -1,0 +1,96 @@
+import { useQuery, useQueryClient, useMutation } from "@tanstack/vue-query";
+import { computed } from "vue";
+import apiClient from "./apiClient";
+import { useMainStore } from "@/stores/main";
+
+function handleApiError(error, message) {
+  if (error.response?.status === 401) throw error;
+  const mainstore = useMainStore();
+  mainstore.showSnackbar(
+    message + " : " + (error.response?.data?.detail ?? "Unknown error"),
+    "error",
+  );
+  throw error;
+}
+
+async function getTransactionImagesFunction(transactionId) {
+  try {
+    const response = await apiClient.get(
+      `/transactions/attachments/list/${transactionId}`,
+    );
+    return response.data;
+  } catch (error) {
+    return handleApiError(error, "Attachments not fetched");
+  }
+}
+
+async function uploadTransactionImageFunction({ transactionId, file }) {
+  const mainstore = useMainStore();
+  try {
+    const formData = new FormData();
+    formData.append("file", file);
+    const response = await apiClient.post(
+      `/transactions/attachments/upload/${transactionId}`,
+      formData,
+      { headers: { "Content-Type": "multipart/form-data" } },
+    );
+    mainstore.showSnackbar("Attachment uploaded!", "success");
+    return response.data;
+  } catch (error) {
+    return handleApiError(error, "Attachment not uploaded");
+  }
+}
+
+async function deleteTransactionImageFunction(imageId) {
+  const mainstore = useMainStore();
+  try {
+    const response = await apiClient.delete(
+      `/transactions/attachments/delete/${imageId}`,
+    );
+    mainstore.showSnackbar("Attachment deleted!", "success");
+    return response.data;
+  } catch (error) {
+    return handleApiError(error, "Attachment not deleted");
+  }
+}
+
+export function useTransactionImages(transactionId) {
+  const queryClient = useQueryClient();
+  const id = computed(() =>
+    transactionId?.value !== undefined ? transactionId.value : transactionId,
+  );
+
+  const { data: images, isLoading: attachments_isLoading } = useQuery({
+    queryKey: computed(() => ["transaction_images", id.value]),
+    queryFn: () => getTransactionImagesFunction(id.value),
+    enabled: computed(() => !!id.value),
+  });
+
+  const uploadMutation = useMutation({
+    mutationFn: uploadTransactionImageFunction,
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["transaction_images", id.value],
+      });
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: deleteTransactionImageFunction,
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["transaction_images", id.value],
+      });
+    },
+  });
+
+  function uploadImage(file) {
+    uploadMutation.mutate({ transactionId: id.value, file });
+  }
+
+  function deleteImage(imageId) {
+    deleteMutation.mutate(imageId);
+  }
+
+  return { images, attachments_isLoading, uploadImage, deleteImage };
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -26,6 +26,10 @@ export default defineConfig({
         changeOrigin: true,
         rewrite: path => path.replace(/^\/api/, ""),
       },
+      "/media": {
+        target: "https://back-dev.danielleandjohn.love", // Serve media files from backend in dev
+        changeOrigin: true,
+      },
     },
   },
   define: {


### PR DESCRIPTION
## Summary
- Any file type can be uploaded and attached to a transaction (receipts, statements, etc.)
- **File cleanup on delete is guaranteed**: replaced the model's custom `delete()` (which Django's CASCADE bulk-delete bypasses) with a `post_delete` signal on `TransactionImage` — fires for both direct and cascade deletes
- Attachments tab in TransactionForm is now functional; shows a "save first" message when adding a new transaction

## Backend
- `TransactionImage` model: removed custom `delete()`, added `url` and `filename` properties, `post_delete` signal in `signals.py` handles file removal
- New endpoints at `/api/v1/transactions/attachments/`:
  - `GET /list/{transaction_id}` — list attachments (all auth)
  - `POST /upload/{transaction_id}` — upload file (FullAccess)
  - `DELETE /delete/{image_id}` — delete attachment + file (FullAccess)

## Frontend
- `transactionImagesComposable.js` — TanStack Query fetch + upload/delete mutations with snackbar feedback
- `TransactionForm.vue` attachments tab — upload button, thumbnail grid with delete per file, file icon fallback for non-images
- `vite.config.js` — `/media` proxied to dev backend so uploaded files resolve in dev

## Test plan
- [ ] Open an existing transaction → Attachments tab → upload an image → thumbnail appears
- [ ] Upload a non-image file → file icon placeholder shows, filename shown
- [ ] Delete an attachment → removed from list, file cleaned up on server
- [ ] Delete a transaction that has attachments → verify files are removed from `mediafiles/tran_images/`
- [ ] Open "Add Transaction" → Attachments tab shows "Save the transaction first" message

🤖 Generated with [Claude Code](https://claude.com/claude-code)