### PR TITLE
fix: surface attachment_count on TransactionOut to show paperclip icon

### DIFF
--- a/backend/transactions/api/dependencies/transaction_utilities.py
+++ b/backend/transactions/api/dependencies/transaction_utilities.py
@@ -18,6 +18,7 @@ from django.db.models import (
     Window,
     Sum,
     ExpressionWrapper,
+    Count,
 )
 from django.db.models.functions import Concat, Coalesce
 from accounts.models import Account
@@ -76,6 +77,9 @@ def annotate_transaction_display_info(
             default=F("source_name"),
             output_field=CharField(),
         )
+    )
+    all_transactions = all_transactions.annotate(
+        attachment_count=Count("transactionimage", distinct=True)
     )
     return all_transactions
 

--- a/backend/transactions/api/schemas/transaction.py
+++ b/backend/transactions/api/schemas/transaction.py
@@ -71,6 +71,7 @@ class TransactionOut(Schema):
     reminder_id: Optional[int] = None
     tag_total: Optional[AmountDecimal] = None
     simulated: Optional[bool] = False
+    attachment_count: Optional[int] = 0
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/backend/transactions/api/views/transaction.py
+++ b/backend/transactions/api/views/transaction.py
@@ -21,6 +21,7 @@ from django.db.models import (
     Subquery,
     OuterRef,
     DecimalField,
+    Count,
 )
 from django.db.models.functions import Concat, Coalesce, Abs
 from transactions.services.transaction import (
@@ -215,7 +216,13 @@ def get_transaction(request, transaction_id: int):
     """
 
     try:
-        transaction = get_object_or_404(Transaction, id=transaction_id)
+        transaction = (
+            Transaction.objects.annotate(
+                attachment_count=Count("transactionimage", distinct=True)
+            ).filter(id=transaction_id).first()
+        )
+        if transaction is None:
+            raise Http404
         api_logger.debug(f"Transaction retrieved : #{transaction.id}")
         return transaction
     except Http404:

--- a/backend/transactions/tests/api/test_transaction_image_api.py
+++ b/backend/transactions/tests/api/test_transaction_image_api.py
@@ -7,6 +7,40 @@ AUTH = {"Authorization": "Bearer test-api-key"}
 
 @pytest.mark.django_db
 @pytest.mark.api
+def test_transaction_list_attachment_count_zero(api_client, test_transaction):
+    response = api_client.get(
+        f"/transactions/get/{test_transaction.id}",
+        headers=AUTH,
+    )
+
+    assert response.status_code == 200
+    assert response.json()["attachment_count"] == 0
+
+
+@pytest.mark.django_db
+@pytest.mark.api
+def test_transaction_list_attachment_count_reflects_uploads(
+    api_client, settings, tmp_path, test_transaction
+):
+    settings.MEDIA_ROOT = tmp_path
+
+    for name in ("receipt1.jpg", "receipt2.jpg"):
+        TransactionImage.objects.create(
+            image=SimpleUploadedFile(name, b"bytes", content_type="image/jpeg"),
+            transaction=test_transaction,
+        )
+
+    response = api_client.get(
+        f"/transactions/get/{test_transaction.id}",
+        headers=AUTH,
+    )
+
+    assert response.status_code == 200
+    assert response.json()["attachment_count"] == 2
+
+
+@pytest.mark.django_db
+@pytest.mark.api
 def test_list_transaction_images_empty(api_client, test_transaction):
     response = api_client.get(
         f"/transactions/attachments/list/{test_transaction.id}",

--- a/frontend/src/components/TransactionTableWidget.vue
+++ b/frontend/src/components/TransactionTableWidget.vue
@@ -183,7 +183,7 @@
               <template v-slot:activator="{ props }">
                 <v-icon
                   icon="mdi-paperclip"
-                  v-if="item.attachments"
+                  v-if="item.attachment_count"
                   color="textPending"
                   v-bind="props"
                 ></v-icon>
@@ -392,7 +392,7 @@
                     {{ item.pretty_account }}
                   </span>
                 </v-col>
-                <v-col class="ma-0 pa-0 ga-0" cols="1" v-if="item.attachments">
+                <v-col class="ma-0 pa-0 ga-0" cols="1" v-if="item.attachment_count">
                   <v-icon
                     icon="mdi-paperclip"
                     color="textPending"


### PR DESCRIPTION
## Summary
- `TransactionOut` schema now includes `attachment_count: int = 0`
- `annotate_transaction_display_info` (used by all list queries) annotates with `Count("transactionimage", distinct=True)`
- Single `get_transaction` endpoint annotated the same way
- `TransactionTableWidget.vue` — both desktop and mobile icon conditions updated from `item.attachments` → `item.attachment_count`

## Root cause
The frontend template already had `v-if="item.attachments"` in both desktop and mobile views, but the field was never included in the API response, so the icon was always hidden.

## Test plan
- [ ] Upload an attachment to a transaction → paperclip icon appears in both desktop and mobile list views
- [ ] Delete the attachment → icon disappears after refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)