### PR TITLE
fix: guard attachment_count annotation to Transaction queryset only

### DIFF
--- a/backend/transactions/api/dependencies/transaction_utilities.py
+++ b/backend/transactions/api/dependencies/transaction_utilities.py
@@ -78,9 +78,14 @@ def annotate_transaction_display_info(
             output_field=CharField(),
         )
     )
-    all_transactions = all_transactions.annotate(
-        attachment_count=Count("transactionimage", distinct=True)
-    )
+    if transactions.model is Transaction:
+        all_transactions = all_transactions.annotate(
+            attachment_count=Count("transactionimage", distinct=True)
+        )
+    else:
+        all_transactions = all_transactions.annotate(
+            attachment_count=Value(0, output_field=IntegerField())
+        )
     return all_transactions
 
 

--- a/backend/transactions/api/dependencies/transaction_utilities.py
+++ b/backend/transactions/api/dependencies/transaction_utilities.py
@@ -1,6 +1,7 @@
 from transactions.models import (
     Transaction,
     TransactionDetail,
+    TransactionImage,
     ReminderCacheTransactionDetail,
     ForecastCacheTransactionDetail,
 )
@@ -79,8 +80,16 @@ def annotate_transaction_display_info(
         )
     )
     if transactions.model is Transaction:
+        image_subquery = (
+            TransactionImage.objects.filter(transaction=OuterRef("pk"))
+            .values("transaction")
+            .annotate(c=Count("id"))
+            .values("c")
+        )
         all_transactions = all_transactions.annotate(
-            attachment_count=Count("transactionimage", distinct=True)
+            attachment_count=Coalesce(
+                Subquery(image_subquery), Value(0, output_field=IntegerField())
+            )
         )
     else:
         all_transactions = all_transactions.annotate(

--- a/frontend/src/components/TransactionTableWidget.vue
+++ b/frontend/src/components/TransactionTableWidget.vue
@@ -184,7 +184,7 @@
                 <v-icon
                   icon="mdi-paperclip"
                   v-if="item.attachment_count"
-                  color="textPending"
+                  color="warning"
                   v-bind="props"
                 ></v-icon>
               </template>
@@ -395,7 +395,7 @@
                 <v-col class="ma-0 pa-0 ga-0" cols="1" v-if="item.attachment_count">
                   <v-icon
                     icon="mdi-paperclip"
-                    color="textPending"
+                    color="warning"
                     v-bind="props"
                   ></v-icon>
                 </v-col>


### PR DESCRIPTION
## Summary
- `annotate_transaction_display_info` is called on three queryset types: `Transaction`, `ReminderCacheTransaction`, and `ForecastCacheTransaction`
- The `Count("transactionimage", distinct=True)` annotation only works on `Transaction` (which has the reverse FK); the other two models don't, causing `FieldError: Cannot resolve keyword 'transactionimage' into field`
- Fixed by checking `transactions.model is Transaction` before applying the Count annotation; non-Transaction querysets get `attachment_count=Value(0)`

## Test plan
- [ ] All 9 attachment API tests pass (`pytest transactions/tests/api/test_transaction_image_api.py`)
- [ ] Transaction list loads without error in production (reminder/forecast cache views no longer throw FieldError)

🤖 Generated with [Claude Code](https://claude.com/claude-code)