### PR TITLE
fix: use plain global constant for opt features flag

### DIFF
--- a/example.env
+++ b/example.env
@@ -13,5 +13,7 @@ DJANGO_SUPERUSER_PASSWORD=somepassword
 DJANGO_SUPERUSER_EMAIL=someone@somewhere.com
 DJANGO_SUPERUSER_USERNAME=superuser
 VITE_API_KEY=secretkey
+# Optional planning features (Contributions, Notes, Calculator). Set to true to enable.
+# Requires rebuilding the frontend image to take effect: docker compose up -d --build frontend
 VITE_OPT_FEATURES=false
 TIMEZONE=America/New_York

--- a/example.env
+++ b/example.env
@@ -14,6 +14,6 @@ DJANGO_SUPERUSER_EMAIL=someone@somewhere.com
 DJANGO_SUPERUSER_USERNAME=superuser
 VITE_API_KEY=secretkey
 # Optional planning features (Contributions, Notes, Calculator). Set to true to enable.
-# Requires rebuilding the frontend image to take effect: docker compose up -d --build frontend
+# Takes effect on container restart (no rebuild required).
 VITE_OPT_FEATURES=false
 TIMEZONE=America/New_York

--- a/frontend/entrypoint.sh
+++ b/frontend/entrypoint.sh
@@ -3,7 +3,7 @@
 # Set timezone
 if [ -n "$TZ" ]; then
     echo "Setting timezone to $TZ"
-    ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ >/etc/timezone
+    ln -snf "/usr/share/zoneinfo/$TZ" /etc/localtime && echo "$TZ" >/etc/timezone
 else
     echo "Timezone not set, defaulting to UTC"
     ln -snf /usr/share/zoneinfo/UTC /etc/localtime && echo "UTC" >/etc/timezone
@@ -12,7 +12,8 @@ fi
 # Load environment variables from .env file
 cat <<EOF > /usr/share/nginx/html/config.js
 window.__APP_CONFIG__ = {
-  VITE_API_KEY: "${VITE_API_KEY}"
+  VITE_API_KEY: "${VITE_API_KEY}",
+  VITE_OPT_FEATURES: "${VITE_OPT_FEATURES:-false}"
 };
 EOF
 

--- a/frontend/public/config.js
+++ b/frontend/public/config.js
@@ -1,3 +1,4 @@
 window.__APP_CONFIG__ = {
   VITE_API_KEY: "__VITE_API_KEY__",
+  VITE_OPT_FEATURES: "__VITE_OPT_FEATURES__",
 };

--- a/frontend/src/components/PlanningMenu.vue
+++ b/frontend/src/components/PlanningMenu.vue
@@ -43,7 +43,7 @@
   const transactions_store = useTransactionsStore();
   const authStore = useAuthStore();
   const router = useRouter();
-  const optFeatures = import.meta.env.VITE_OPT_FEATURES === "true";
+  const optFeatures = __OPT_FEATURES__;
 
   const planning_menu = ref([
     {

--- a/frontend/src/components/PlanningMenu.vue
+++ b/frontend/src/components/PlanningMenu.vue
@@ -43,7 +43,10 @@
   const transactions_store = useTransactionsStore();
   const authStore = useAuthStore();
   const router = useRouter();
-  const optFeatures = __OPT_FEATURES__;
+  const runtimeOpt = window.__APP_CONFIG__?.VITE_OPT_FEATURES;
+  const optFeatures = (runtimeOpt && runtimeOpt !== "__VITE_OPT_FEATURES__")
+    ? runtimeOpt === "true"
+    : __OPT_FEATURES__;
 
   const planning_menu = ref([
     {

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -37,7 +37,7 @@ export default defineConfig({
     __VUE_PROD_DEVTOOLS__: false,
     __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: false,
     "import.meta.env.VITE_APP_VERSION": JSON.stringify(pkg.version),
-    "import.meta.env.VITE_OPT_FEATURES": JSON.stringify(process.env.VITE_OPT_FEATURES || "false"),
+    __OPT_FEATURES__: process.env.VITE_OPT_FEATURES === "true",
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- PR #109 didn't fully fix the issue — Vite has special internal handling for the `import.meta.env` namespace that runs before the `define` plugin, so `import.meta.env.VITE_OPT_FEATURES` was still resolving to `undefined`
- Replace with a plain `__OPT_FEATURES__` global in `vite.config.js` which Vite replaces as a simple literal substitution with no namespace conflicts
- `vite.config.js`: `__OPT_FEATURES__: process.env.VITE_OPT_FEATURES === "true"` (boolean, evaluated at server startup)
- `PlanningMenu.vue`: `const optFeatures = __OPT_FEATURES__`

## Test plan
- [ ] Set `VITE_OPT_FEATURES=true` in `.env.dev`, restart container — Contributions, Notes, Calculator should appear in planning menu
- [ ] Remove or set `=false` — those items should be hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)