### PR TITLE
fix: declare __OPT_FEATURES__ as ESLint global to fix production build

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -14,6 +14,9 @@ module.exports = {
     ecmaVersion: 2021, // Support for ES2021 features
     sourceType: "module", // Use ECMAScript modules
   },
+  globals: {
+    __OPT_FEATURES__: "readonly",
+  },
   rules: {
     "no-console": process.env.NODE_ENV === "production" ? "warn" : "off", // Warn on console in production
     "no-debugger": process.env.NODE_ENV === "production" ? "warn" : "off", // Warn on debugger in production


### PR DESCRIPTION
## Summary
- Production build failed with `'__OPT_FEATURES__' is not defined  no-undef` because ESLint doesn't know about Vite `define` globals
- Added `__OPT_FEATURES__: "readonly"` to the `globals` block in `.eslintrc.js`

## Test plan
- [ ] Build action passes
- [ ] `VITE_OPT_FEATURES=true` in `.env` shows optional planning menu items after container restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)