### PR TITLE
feat: logging improvements — traceback capture, log viewer, bundle download

### DIFF
--- a/backend/accounts/api/views/account.py
+++ b/backend/accounts/api/views/account.py
@@ -53,19 +53,19 @@ def create_account(request, payload: AccountIn):
             api_logger.error(
                 f"Account not created : name exists ({payload.account_name})"
             )
-            error_logger.error(
+            error_logger.exception(
                 f"Account not created : name exists ({payload.account_name})"
             )
             raise HttpError(400, "Account name already exists")
         else:
             # Log other types of integry errors
             api_logger.error("Account not created : db integrity error")
-            error_logger.error("Account not created : db integrity error")
+            error_logger.exception("Account not created : db integrity error")
             raise HttpError(400, "DB integrity error")
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Account not created")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, f"Record creation error: {str(e)}")
 
 
@@ -125,7 +125,7 @@ def list_accounts(request, query: AccountQuery = Query(...)):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Account list retrieved")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, f"Record retrieval error : {str(e)}")
 
 
@@ -179,19 +179,19 @@ def update_account(request, account_id: int, payload: AccountUpdate):
             api_logger.error(
                 f"Account not updated : account exists ({payload.account_name})"
             )
-            error_logger.error(
+            error_logger.exception(
                 f"Account not updated : account exists ({payload.account_name})"
             )
             raise HttpError(400, "Account already exists")
         else:
             # Log other types of integry errors
             api_logger.error("Account not updated : db integrity error")
-            error_logger.error("Account not updated : db integrity error")
+            error_logger.exception("Account not updated : db integrity error")
             raise HttpError(400, "DB integrity error")
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Account not updated")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, f"Record update error: {str(e)}")
 
 
@@ -233,5 +233,5 @@ def delete_account(request, account_id: int):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Account not deleted")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, f"Record retrieval error: {str(e)}")

--- a/backend/accounts/api/views/account_type.py
+++ b/backend/accounts/api/views/account_type.py
@@ -40,19 +40,19 @@ def create_account_type(request, payload: AccountTypeIn):
             api_logger.error(
                 f"Account type not created : type exists ({payload.account_type})"
             )
-            error_logger.error(
+            error_logger.exception(
                 f"Account type not created : type exists ({payload.account_type})"
             )
             raise HttpError(400, "Account type already exists")
         else:
             # Log other types of integry errors
             api_logger.error("Account type not created : db integrity error")
-            error_logger.error("Account type not created : db integrity error")
+            error_logger.exception("Account type not created : db integrity error")
             raise HttpError(400, "DB integrity error")
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Account type not created")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record creation error")
 
 
@@ -81,7 +81,7 @@ def get_account_type(request, accounttype_id: int):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Record retrieval error")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, f"Record retrieval error: {str(e)}")
 
 
@@ -105,7 +105,7 @@ def list_account_types(request):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Account type list not retrieved")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record retrieval error")
 
 
@@ -140,19 +140,19 @@ def update_account_type(request, accounttype_id: int, payload: AccountTypeIn):
             api_logger.error(
                 f"Account type not updated : account type exists ({payload.account_type})"
             )
-            error_logger.error(
+            error_logger.exception(
                 f"Account type not updated : account type exists ({payload.account_type})"
             )
             raise HttpError(400, "Account type already exists")
         else:
             # Log other types of integry errors
             api_logger.error("Account type not updated : db integrity error")
-            error_logger.error("Account type not updated : db integrity error")
+            error_logger.exception("Account type not updated : db integrity error")
             raise HttpError(400, "DB integrity error")
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Account type not updated")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record update error")
 
 
@@ -185,5 +185,5 @@ def delete_account_type(request, accounttype_id: int):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Account type not deleted")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record retrieval error")

--- a/backend/accounts/api/views/bank.py
+++ b/backend/accounts/api/views/bank.py
@@ -40,19 +40,19 @@ def create_bank(request, payload: BankIn):
             api_logger.error(
                 f"Bank not created : bank exists ({payload.bank_name})"
             )
-            error_logger.error(
+            error_logger.exception(
                 f"Bank not created : bank exists ({payload.bank_name})"
             )
             raise HttpError(400, "Bank already exists")
         else:
             # Log other types of integry errors
             api_logger.error("Bank not created : db integrity error")
-            error_logger.error("Bank not created : db integrity error")
+            error_logger.exception("Bank not created : db integrity error")
             raise HttpError(400, "DB integrity error")
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Bank not created")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record creation error")
 
 
@@ -85,19 +85,19 @@ def update_bank(request, bank_id: int, payload: BankIn):
             api_logger.error(
                 f"Bank not updated : bank exists ({payload.bank_name})"
             )
-            error_logger.error(
+            error_logger.exception(
                 f"Bank not updated : bank exists ({payload.bank_name})"
             )
             raise HttpError(400, "Bank already exists")
         else:
             # Log other types of integry errors
             api_logger.error("Bank not updated : db integrity error")
-            error_logger.error("Bank not updated : db integrity error")
+            error_logger.exception("Bank not updated : db integrity error")
             raise HttpError(400, "DB integrity error")
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Bank not updated")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record update error")
 
 
@@ -126,7 +126,7 @@ def get_bank(request, bank_id: int):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Bank not retrieved")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record retrieval error")
 
 
@@ -150,7 +150,7 @@ def list_banks(request):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Bank list not retrieved")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record retrieval error")
 
 
@@ -179,5 +179,5 @@ def delete_bank(request, bank_id: int):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Bank not deleted")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record retrieval error")

--- a/backend/accounts/api/views/forecast.py
+++ b/backend/accounts/api/views/forecast.py
@@ -38,5 +38,5 @@ def get_forecast(
         return domain_forecast_to_schema(domain_forecast)
     except Exception as e:
         api_logger.error("Forecast not retrieved")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, f"Record retrieval error : {str(e)}")

--- a/backend/administration/api/routers/logs.py
+++ b/backend/administration/api/routers/logs.py
@@ -1,0 +1,5 @@
+from ninja import Router
+from administration.api.views.logs import logs_router
+
+router = Router()
+router.add_router("/", logs_router)

--- a/backend/administration/api/schemas/logs.py
+++ b/backend/administration/api/schemas/logs.py
@@ -1,0 +1,16 @@
+from ninja import Schema
+from typing import List
+
+
+class LogEntryOut(Schema):
+    timestamp: str
+    level: str
+    message: str
+
+
+class LogPageOut(Schema):
+    entries: List[LogEntryOut]
+    total: int
+    page: int
+    pages: int
+    log_type: str

--- a/backend/administration/api/views/description_history.py
+++ b/backend/administration/api/views/description_history.py
@@ -34,5 +34,5 @@ def list_description_histories(request):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Description Histories not retrieved")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record retrieval error")

--- a/backend/administration/api/views/logs.py
+++ b/backend/administration/api/views/logs.py
@@ -65,16 +65,21 @@ def get_logs(
 ):
     if log_type not in VALID_LOG_TYPES:
         raise HttpError(400, f"Invalid log_type. Choose from: {', '.join(sorted(VALID_LOG_TYPES))}")
-    if level and level.upper() not in VALID_LEVELS:
-        raise HttpError(400, f"Invalid level. Choose from: {', '.join(sorted(VALID_LEVELS))}")
+
+    selected_levels = set()
+    if level:
+        selected_levels = {l.strip().upper() for l in level.split(",")}
+        invalid = selected_levels - VALID_LEVELS
+        if invalid:
+            raise HttpError(400, f"Invalid level(s): {', '.join(sorted(invalid))}. Choose from: {', '.join(sorted(VALID_LEVELS))}")
 
     try:
         entries = _parse_log_file(log_type)
         # Newest first
         entries = list(reversed(entries))
 
-        if level:
-            entries = [e for e in entries if e["level"] == level.upper()]
+        if selected_levels:
+            entries = [e for e in entries if e["level"] in selected_levels]
         if search:
             search_lower = search.lower()
             entries = [e for e in entries if search_lower in e["message"].lower()]
@@ -111,7 +116,7 @@ def download_log_bundle(request):
 
         buffer.seek(0)
         response = HttpResponse(buffer.read(), content_type="application/zip")
-        response["Content-Disposition"] = 'attachment; filename="lenore_logs.zip"'
+        response["Content-Disposition"] = 'attachment; filename="lenorefin_logs.zip"'
         api_logger.info("Log bundle downloaded")
         return response
     except Exception as e:

--- a/backend/administration/api/views/logs.py
+++ b/backend/administration/api/views/logs.py
@@ -1,0 +1,119 @@
+import io
+import math
+import re
+import zipfile
+from typing import Optional
+
+import logging
+from django.conf import settings
+from django.http import HttpResponse
+from ninja import Router
+from ninja.errors import HttpError
+
+from administration.api.dependencies.auth import FullAccessAuth
+from administration.api.schemas.logs import LogPageOut
+
+error_logger = logging.getLogger("error")
+api_logger = logging.getLogger("api")
+
+logs_router = Router(tags=["Logs"])
+
+VALID_LOG_TYPES = {"api", "error", "task"}
+VALID_LEVELS = {"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"}
+
+# Matches the start of a new log entry: [timestamp] LEVEL ...
+_LOG_LINE_RE = re.compile(r"^\[(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d+)\] (\w+) (.*)")
+
+
+def _parse_log_file(log_type: str) -> list:
+    log_path = settings.LOG_DIR / f"{log_type}.log"
+    if not log_path.exists():
+        return []
+
+    entries = []
+    current = None
+
+    with open(log_path, "r", errors="replace") as f:
+        for line in f:
+            m = _LOG_LINE_RE.match(line)
+            if m:
+                if current:
+                    entries.append(current)
+                current = {
+                    "timestamp": m.group(1),
+                    "level": m.group(2),
+                    "message": m.group(3).rstrip(),
+                }
+            elif current:
+                # Continuation line (e.g. traceback)
+                current["message"] += "\n" + line.rstrip()
+
+    if current:
+        entries.append(current)
+
+    return entries
+
+
+@logs_router.get("", response=LogPageOut, auth=FullAccessAuth())
+def get_logs(
+    request,
+    log_type: str = "error",
+    page: int = 1,
+    page_size: int = 100,
+    level: Optional[str] = None,
+    search: Optional[str] = None,
+):
+    if log_type not in VALID_LOG_TYPES:
+        raise HttpError(400, f"Invalid log_type. Choose from: {', '.join(sorted(VALID_LOG_TYPES))}")
+    if level and level.upper() not in VALID_LEVELS:
+        raise HttpError(400, f"Invalid level. Choose from: {', '.join(sorted(VALID_LEVELS))}")
+
+    try:
+        entries = _parse_log_file(log_type)
+        # Newest first
+        entries = list(reversed(entries))
+
+        if level:
+            entries = [e for e in entries if e["level"] == level.upper()]
+        if search:
+            search_lower = search.lower()
+            entries = [e for e in entries if search_lower in e["message"].lower()]
+
+        total = len(entries)
+        pages = max(1, math.ceil(total / page_size))
+        page = max(1, min(page, pages))
+        start = (page - 1) * page_size
+        page_entries = entries[start : start + page_size]
+
+        api_logger.info(f"Logs retrieved : type={log_type} page={page} total={total}")
+        return {
+            "entries": page_entries,
+            "total": total,
+            "page": page,
+            "pages": pages,
+            "log_type": log_type,
+        }
+    except Exception as e:
+        error_logger.exception(f"Error reading logs: {e}")
+        raise HttpError(500, "Error reading log file")
+
+
+@logs_router.get("/bundle", auth=FullAccessAuth())
+def download_log_bundle(request):
+    try:
+        log_dir = settings.LOG_DIR
+        buffer = io.BytesIO()
+
+        with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as zf:
+            for log_file in sorted(log_dir.glob("*.log*")):
+                if log_file.is_file():
+                    zf.write(log_file, log_file.name)
+
+        buffer.seek(0)
+        response = HttpResponse(buffer.read(), content_type="application/zip")
+        response["Content-Disposition"] = 'attachment; filename="lenore_logs.zip"'
+        api_logger.info("Log bundle downloaded")
+        return response
+    except Exception as e:
+        error_logger.exception(f"Error creating log bundle: {e}")
+        raise HttpError(500, "Error creating log bundle")

--- a/backend/administration/api/views/message.py
+++ b/backend/administration/api/views/message.py
@@ -41,7 +41,7 @@ def create_message(request, payload: MessageIn):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Message not created")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record creation error")
 
 
@@ -75,7 +75,7 @@ def update_message(request, message_id: int, payload: MessageIn):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Message not updated")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record update error")
 
 
@@ -103,7 +103,7 @@ def update_messages(request, message_id: int, payload: AllMessage):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Messages not marked as read")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Messages not marked read error")
 
 
@@ -132,7 +132,7 @@ def get_message(request, message_id: int):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Message not retrieved")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record retrieval error")
 
 
@@ -162,7 +162,7 @@ def delete_message(request, message_id: int):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Message not deleted")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record retrieval error")
 
 
@@ -188,7 +188,7 @@ def delete_messages(request, message_id: int):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("All messages not deleted")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record retrieval error")
 
 
@@ -212,5 +212,5 @@ def list_messages(request):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Message list not retrieved")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record retrieval error")

--- a/backend/administration/api/views/option.py
+++ b/backend/administration/api/views/option.py
@@ -47,7 +47,7 @@ def update_option(request, option_id: int, payload: OptionIn):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Option not updated")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record update error")
 
 
@@ -76,7 +76,7 @@ def get_option(request, option_id: int):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Option not retrieved")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record retrieval error")
 
 
@@ -100,7 +100,7 @@ def list_options(request):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Option list not retrieved")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record retrieval error")
 
 
@@ -130,5 +130,5 @@ def delete_option(request, option_id: int):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Option not deleted")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record retrieval error")

--- a/backend/administration/api/views/payee.py
+++ b/backend/administration/api/views/payee.py
@@ -40,19 +40,19 @@ def create_payee(request, payload: PayeeIn):
             api_logger.error(
                 f"Payee not created : payee exists ({payload.payee_name})"
             )
-            error_logger.error(
+            error_logger.exception(
                 f"Payee not created : payee exists ({payload.payee_name})"
             )
             raise HttpError(400, "Payee already exists")
         else:
             # Log other types of integry errors
             api_logger.error("Payee not created : db integrity error")
-            error_logger.error("Payee not created : db integrity error")
+            error_logger.exception("Payee not created : db integrity error")
             raise HttpError(400, "DB integrity error")
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Payee not created")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record creation error")
 
 
@@ -87,19 +87,19 @@ def update_payee(request, payee_id: int, payload: PayeeIn):
             api_logger.error(
                 f"Payee not updated : payee exists ({payload.payee_name})"
             )
-            error_logger.error(
+            error_logger.exception(
                 f"Payee not updated : payee exists ({payload.payee_name})"
             )
             raise HttpError(400, "Payee already exists")
         else:
             # Log other types of integry errors
             api_logger.error("Payee not updated : db integrity error")
-            error_logger.error("Payee not updated : db integrity error")
+            error_logger.exception("Payee not updated : db integrity error")
             raise HttpError(400, "DB integrity error")
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Payee not updated")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record update error")
 
 
@@ -128,7 +128,7 @@ def get_payee(request, payee_id: int):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Payee not retrieved")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record retrieval error")
 
 
@@ -152,7 +152,7 @@ def list_payees(request):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Payee list not retrieved")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record retrieval error")
 
 
@@ -190,5 +190,5 @@ def delete_payee(request, payee_id: int):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Payee not deleted")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record retrieval error")

--- a/backend/administration/api/views/version.py
+++ b/backend/administration/api/views/version.py
@@ -36,5 +36,5 @@ def list_version(request):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Version not retrieved")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record retrieval error")

--- a/backend/backend/api.py
+++ b/backend/backend/api.py
@@ -43,6 +43,7 @@ from planning.api.routers.budget import budget_router
 from planning.api.routers.retirement import retirement_router
 from administration.api.routers.health import health_router
 from administration.api.routers.backup import backup_router
+from administration.api.routers.logs import router as logs_router
 
 api = NinjaAPI(auth=SessionAuth())
 api.title = "LenoreFin API"
@@ -85,4 +86,5 @@ api.add_router("/planning/budget", budget_router)
 api.add_router("/planning/retirement", retirement_router)
 api.add_router("/administration/health", health_router)
 api.add_router("/administration/backups", backup_router)
+api.add_router("/administration/logs", logs_router)
 api.add_router("/auth", auth_router)

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -191,31 +191,32 @@ LOGGING = {
             "class": "logging.handlers.RotatingFileHandler",
             "filename": str(LOG_DIR / "db.log"),
             "maxBytes": 1024 * 1024 * 5,  # 5MB
-            "backupCount": 5,
+            "backupCount": 2,
             "formatter": "standard",
             "level": DB_LOG_LEVEL,
         },
         "api_file_handler": {
             "class": "logging.handlers.RotatingFileHandler",
             "filename": str(LOG_DIR / "api.log"),
-            "maxBytes": 1024 * 1024 * 5,
-            "backupCount": 5,
+            "maxBytes": 1024 * 1024 * 5,  # 5MB, 2 backups (~10MB max)
+            "backupCount": 2,
             "formatter": "standard",
             "level": DB_LOG_LEVEL,
         },
         "error_file_handler": {
-            "class": "logging.handlers.RotatingFileHandler",
+            "class": "logging.handlers.TimedRotatingFileHandler",
             "filename": str(LOG_DIR / "error.log"),
-            "maxBytes": 1024 * 1024 * 5,
-            "backupCount": 5,
+            "when": "midnight",
+            "interval": 1,
+            "backupCount": 30,  # 30 days of error history
             "formatter": "detailed",
             "level": DB_LOG_LEVEL,
         },
         "task_file_handler": {
             "class": "logging.handlers.RotatingFileHandler",
             "filename": str(LOG_DIR / "task.log"),
-            "maxBytes": 1024 * 1024 * 5,
-            "backupCount": 5,
+            "maxBytes": 1024 * 1024 * 5,  # 5MB, 2 backups (~10MB max)
+            "backupCount": 2,
             "formatter": "standard",
             "level": DB_LOG_LEVEL,
         },

--- a/backend/imports/api/views/import_file.py
+++ b/backend/imports/api/views/import_file.py
@@ -36,5 +36,5 @@ def import_file(
         return {"id": file_import_id}
     except Exception as e:
         task_logger.error("File import failed")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "File import error")

--- a/backend/planning/api/views/budget.py
+++ b/backend/planning/api/views/budget.py
@@ -55,12 +55,12 @@ def create_budget(request, payload: BudgetIn):
         else:
             # Log other types of integry errors
             api_logger.error("Budget not created : db integrity error")
-            error_logger.error("Budget not created : db integrity error")
+            error_logger.exception("Budget not created : db integrity error")
             raise HttpError(400, "DB integrity error")
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Budget not created")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record creation error")
 
 
@@ -105,19 +105,19 @@ def update_budget(request, budget_id: int, payload: BudgetIn):
             api_logger.error(
                 f"Budget not updated : budget exists ({payload.budget})"
             )
-            error_logger.error(
+            error_logger.exception(
                 f"Budget not updated : budget exists ({payload.budget})"
             )
             raise HttpError(400, "Budget already exists")
         else:
             # Log other types of integry errors
             api_logger.error("Budget not updated : db integrity error")
-            error_logger.error("Budget not updated : db integrity error")
+            error_logger.exception("Budget not updated : db integrity error")
             raise HttpError(400, "DB integrity error")
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Budget not updated")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record update error")
 
 
@@ -146,7 +146,7 @@ def get_budget(request, budget_id: int):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Budget not retrieved")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, f"Record retrieval error: {str(e)}")
 
 
@@ -216,7 +216,7 @@ def list_budgets(
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Budget list not retrieved")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, f"Record retrieval error: {str(e)}")
 
 
@@ -247,7 +247,7 @@ def delete_budget(request, budget_id: int):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Budget not deleted")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record retrieval error")
 
 

--- a/backend/planning/api/views/calculator.py
+++ b/backend/planning/api/views/calculator.py
@@ -50,7 +50,7 @@ def create_calculation_rule(request, payload: CalculationRuleIn):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Calculation rule not created")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record creation error")
 
 
@@ -89,7 +89,7 @@ def update_calculation_rule(
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Calculation rule not updated")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record update error")
 
 
@@ -115,7 +115,7 @@ def list_calculation_rules(request):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Calculation rule list not retrieved")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record retrieval error")
 
 
@@ -148,7 +148,7 @@ def delete_calculation_rule(request, calculation_rule_id: int):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Calculation rule not deleted")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record retrieval error")
 
 
@@ -210,5 +210,5 @@ def get_calculator(request, calculation_rule_id: int, timeframe: int):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Calculator not retrieved")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, f"Record retrieval error: {str(e)}")

--- a/backend/planning/api/views/contrib_rule.py
+++ b/backend/planning/api/views/contrib_rule.py
@@ -40,7 +40,7 @@ def create_contrib_rule(request, payload: ContribRuleIn):
             api_logger.error(
                 f"Contribution rule not created : rule exists ({payload.rule})"
             )
-            error_logger.error(
+            error_logger.exception(
                 f"Contribution rule not created : rule exists ({payload.rule})"
             )
             raise HttpError(400, "Conitribution rule already exists")
@@ -49,14 +49,14 @@ def create_contrib_rule(request, payload: ContribRuleIn):
             api_logger.error(
                 "Contribution rule not created : db integrity error"
             )
-            error_logger.error(
+            error_logger.exception(
                 "Contribution rule not created : db integrity error"
             )
             raise HttpError(400, "DB integrity error")
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Contribution rule not created")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, f"Record creation error: {str(e)}")
 
 
@@ -93,7 +93,7 @@ def update_contrib_rule(request, contribrule_id: int, payload: ContribRuleIn):
             api_logger.error(
                 f"Contribution rule not updated : contribution rule exists ({payload.rule})"
             )
-            error_logger.error(
+            error_logger.exception(
                 f"Contribution rule not updated : contribution rule exists ({payload.rule})"
             )
             raise HttpError(400, "Contribution rule already exists")
@@ -102,7 +102,7 @@ def update_contrib_rule(request, contribrule_id: int, payload: ContribRuleIn):
             api_logger.error(
                 "Contribution rule not updated : db integrity error"
             )
-            error_logger.error(
+            error_logger.exception(
                 "Contribution rule not updated : db integrity error"
             )
             raise HttpError(400, "DB integrity error")
@@ -138,7 +138,7 @@ def get_contribrule(request, contribrule_id: int):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Contribution rule not retrieved")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record retrieval error")
 
 
@@ -162,7 +162,7 @@ def list_contrib_rules(request):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Contribution rule list not retrieved")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record retrieval error")
 
 
@@ -193,5 +193,5 @@ def delete_contrib_rule(request, contribrule_id: int):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Contribution rule not deleted")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record retrieval error")

--- a/backend/planning/api/views/contribution.py
+++ b/backend/planning/api/views/contribution.py
@@ -43,19 +43,19 @@ def create_contribution(request, payload: ContributionIn):
             api_logger.error(
                 f"Contribution not created : contribution exists ({payload.contribution})"
             )
-            error_logger.error(
+            error_logger.exception(
                 f"Contribution not created : contribution exists ({payload.contribution})"
             )
             raise HttpError(400, "Conitribution already exists")
         else:
             # Log other types of integry errors
             api_logger.error("Contribution not created : db integrity error")
-            error_logger.error("Contribution not created : db integrity error")
+            error_logger.exception("Contribution not created : db integrity error")
             raise HttpError(400, "DB integrity error")
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Contribution not created")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record creation error")
 
 
@@ -95,19 +95,19 @@ def update_contribution(request, contribution_id: int, payload: ContributionIn):
             api_logger.error(
                 f"Contribution not updated : contribution exists ({payload.contribution})"
             )
-            error_logger.error(
+            error_logger.exception(
                 f"Contribution not updated : contribution exists ({payload.contribution})"
             )
             raise HttpError(400, "Contribution already exists")
         else:
             # Log other types of integry errors
             api_logger.error("Contribution not updated : db integrity error")
-            error_logger.error("Contribution not updated : db integrity error")
+            error_logger.exception("Contribution not updated : db integrity error")
             raise HttpError(400, "DB integrity error")
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Contribution not updated")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record update error")
 
 
@@ -138,7 +138,7 @@ def get_contribution(request, contribution_id: int):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Contribution not retrieved")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, f"Record retrieval error: {str(e)}")
 
 
@@ -182,7 +182,7 @@ def list_contributions(request):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Contribution list not retrieved")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, f"Record retrieval error: {str(e)}")
 
 
@@ -213,5 +213,5 @@ def delete_contribution(request, contribution_id: int):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Contribution not deleted")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record retrieval error")

--- a/backend/planning/api/views/note.py
+++ b/backend/planning/api/views/note.py
@@ -36,7 +36,7 @@ def create_note(request, payload: NoteIn):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Note not created")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record creation error")
 
 
@@ -69,7 +69,7 @@ def update_note(request, note_id: int, payload: NoteIn):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Note not updated")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record update error")
 
 
@@ -98,7 +98,7 @@ def get_note(request, note_id: int):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Note not retrieved")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record retrieval error")
 
 
@@ -122,7 +122,7 @@ def list_notes(request):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Note list not retrieved")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record retrieval error")
 
 
@@ -153,5 +153,5 @@ def delete_note(request, note_id: int):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Note not deleted")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record retrieval error")

--- a/backend/planning/api/views/planning_graph.py
+++ b/backend/planning/api/views/planning_graph.py
@@ -1056,7 +1056,7 @@ def list_graph_totals(request, graph_type: str):
             except Exception as e:
                 # Log other types of exceptions
                 api_logger.error(f"{graph_type} graph details not retrieved")
-                error_logger.error(f"{str(e)}")
+                error_logger.exception(f"{str(e)}")
                 raise HttpError(
                     500, f"{graph_type} graph details retrieval error: {str(e)}"
                 )
@@ -1489,7 +1489,7 @@ def list_graph_totals(request, graph_type: str):
                 api_logger.error(
                     f"{graph_type} graph details not retrieved(Pay)"
                 )
-                error_logger.error(f"{str(e)}")
+                error_logger.exception(f"{str(e)}")
                 raise HttpError(
                     500,
                     f"{graph_type} graph details retrieval error(Pay): {str(e)}",
@@ -1499,7 +1499,7 @@ def list_graph_totals(request, graph_type: str):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error(f"{graph_type} planning graph not retrieved")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(
             500, f"{graph_type} planning graph retrieval error: {str(e)}"
         )
@@ -1583,5 +1583,5 @@ def prepare_planning_graph(
     except Exception as e:
         # Log other types of exceptions
         api_logger.error(f"Planning graph not prepared({pretty_name})")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, f"Planning graph preperation error: {str(e)}")

--- a/backend/planning/api/views/retirement.py
+++ b/backend/planning/api/views/retirement.py
@@ -35,7 +35,7 @@ def get_forecast(request):
         return ForecastOut(labels=domain.labels, datasets=datasets)
     except Exception as e:
         api_logger.error("Forecast not retrieved")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, f"Record retrieval error : {str(e)}")
 
 
@@ -47,5 +47,5 @@ def get_transactions(request):
         return transactions
     except Exception as e:
         api_logger.error("Retirement transactions not retrieved")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, f"Record retrieval error : {str(e)}")

--- a/backend/reminders/api/views/reminder.py
+++ b/backend/reminders/api/views/reminder.py
@@ -46,7 +46,7 @@ def create_reminder(request, payload: ReminderIn):
         raise
     except Exception as e:
         api_logger.error("Reminder not created")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record creation error")
 
 
@@ -74,7 +74,7 @@ def update_reminder(request, reminder_id: int, payload: ReminderIn):
         return {"success": True}
     except Exception as e:
         api_logger.error("Reminder not updated")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record update error")
 
 
@@ -88,7 +88,7 @@ def get_reminder(request, reminder_id: int):
         raise HttpError(404, "Reminder not found")
     except Exception as e:
         api_logger.error("Reminder not retrieved")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record retrieval error")
 
 
@@ -100,7 +100,7 @@ def list_reminders(request):
         return qs
     except Exception as e:
         api_logger.error("Reminder list not retrieved")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record retrieval error")
 
 
@@ -114,7 +114,7 @@ def delete_reminder(request, reminder_id: int):
         return {"success": True}
     except Exception as e:
         api_logger.error("Reminder not deleted")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, f"Record retrieval error: {str(e)}")
 
 
@@ -129,5 +129,5 @@ def add_reminder_trans(request, reminder_id: int, payload: ReminderTransIn):
         raise HttpError(404, "Reminder not found")
     except Exception as e:
         api_logger.error("Reminder transaction not added")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, f"Record update error : {str(e)}")

--- a/backend/reminders/api/views/repeat.py
+++ b/backend/reminders/api/views/repeat.py
@@ -39,19 +39,19 @@ def create_repeat(request, payload: RepeatIn):
             api_logger.error(
                 f"Repeat not created : repeat exists ({payload.repeat_name})"
             )
-            error_logger.error(
+            error_logger.exception(
                 f"Repeat not created : repeat exists ({payload.repeat_name})"
             )
             raise HttpError(400, "Repeat already exists")
         else:
             # Log other types of integry errors
             api_logger.error("Repeat not created : db integrity error")
-            error_logger.error("Repeat not created : db integrity error")
+            error_logger.exception("Repeat not created : db integrity error")
             raise HttpError(400, "DB integrity error")
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Repeat not created")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record creation error")
 
 
@@ -88,19 +88,19 @@ def update_repeat(request, repeat_id: int, payload: RepeatIn):
             api_logger.error(
                 f"Repeat not updated : repeat exists ({payload.repeat_name})"
             )
-            error_logger.error(
+            error_logger.exception(
                 f"Repeat not updated : repeat exists ({payload.repeat_name})"
             )
             raise HttpError(400, "Repeat already exists")
         else:
             # Log other types of integry errors
             api_logger.error("Repeat not updated : db integrity error")
-            error_logger.error("Repeat not updated : db integrity error")
+            error_logger.exception("Repeat not updated : db integrity error")
             raise HttpError(400, "DB integrity error")
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Repeat not updated")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record update error")
 
 
@@ -127,7 +127,7 @@ def get_repeat(request, repeat_id: int):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Repeat not retrieved")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record retrieval error")
 
 
@@ -151,7 +151,7 @@ def list_repeats(request):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Repeat list not retrieved")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record retrieval error")
 
 
@@ -184,5 +184,5 @@ def delete_repeat(request, repeat_id: int):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Repeat not deleted")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record retrieval error")

--- a/backend/tags/api/views/graph_by_tags.py
+++ b/backend/tags/api/views/graph_by_tags.py
@@ -29,7 +29,7 @@ def get_graph_new(request, widget_id: int):
         return result
     except Exception as e:
         api_logger.error("Graph data not retrieved")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, f"Record retrieval error: {str(e)}")
 
 
@@ -51,5 +51,5 @@ def get_graph(request, widget_id: int):
         return result
     except Exception as e:
         api_logger.error("Graph data not retrieved")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, f"Record retrieval error: {str(e)}")

--- a/backend/tags/api/views/main_tag.py
+++ b/backend/tags/api/views/main_tag.py
@@ -40,7 +40,7 @@ def get_maintag(request, maintag_id: int):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Main Tag not retrieved")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record retrieval error")
 
 
@@ -75,5 +75,5 @@ def list_maintags(
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Main Tag list not retrieved")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, f"Record retrieval error: {str(e)}")

--- a/backend/tags/api/views/sub_tag.py
+++ b/backend/tags/api/views/sub_tag.py
@@ -40,7 +40,7 @@ def get_subtag(request, subtag_id: int):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Sub Tag not retrieved")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record retrieval error")
 
 
@@ -77,5 +77,5 @@ def list_subtags(request, query: SubTagQuery = Query(...)):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Sub Tag list not retrieved")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, f"Record retrieval error: {str(e)}")

--- a/backend/tags/api/views/tag.py
+++ b/backend/tags/api/views/tag.py
@@ -36,15 +36,15 @@ def create_tag_view(request, payload: TagIn):
         return {"id": tag_id}
     except TagAlreadyExists as e:
         api_logger.error(f"Tag not created : {e}")
-        error_logger.error(str(e))
+        error_logger.exception(str(e))
         raise HttpError(400, "Tag already exists")
     except InvalidTagData as e:
         api_logger.error(f"Tag not created : {e}")
-        error_logger.error(str(e))
+        error_logger.exception(str(e))
         raise HttpError(500, "Invalid tag data")
     except Exception as e:
         api_logger.error("Tag not created")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, f"Record creation error : {str(e)}")
 
 
@@ -65,11 +65,11 @@ def update_tag_view(request, tag_id: int, payload: TagIn):
         raise HttpError(404, "Tag not found")
     except TagAlreadyExists as e:
         api_logger.error(f"Tag not updated : {e}")
-        error_logger.error(str(e))
+        error_logger.exception(str(e))
         raise HttpError(400, "Tag already exists")
     except Exception as e:
         api_logger.error("Tag not updated")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, f"Record update error: {str(e)}")
 
 
@@ -81,7 +81,7 @@ def get_tag(request, tag_id: int):
         return tag
     except Exception as e:
         api_logger.error("Tag not retrieved")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record retrieval error")
 
 
@@ -113,7 +113,7 @@ def list_tags(request, query: TagQuery = Query(...)):
         return qs
     except Exception as e:
         api_logger.error("Tag list not retrieved")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, f"Record retrieval error: {str(e)}")
 
 
@@ -131,5 +131,5 @@ def delete_tag(request, tag_id: int):
         raise
     except Exception as e:
         api_logger.error("Tag not deleted")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record retrieval error")

--- a/backend/tags/api/views/tag_graph.py
+++ b/backend/tags/api/views/tag_graph.py
@@ -136,5 +136,5 @@ def list_transactions_bytag(request, tag: int):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Tag details not retrieved")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, f"Record retrieval error: {str(e)}")

--- a/backend/tags/api/views/tag_type.py
+++ b/backend/tags/api/views/tag_type.py
@@ -34,5 +34,5 @@ def list_tag_types(request):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Tag type list not retrieved")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record retrieval error")

--- a/backend/transactions/api/dependencies/create_transactions.py
+++ b/backend/transactions/api/dependencies/create_transactions.py
@@ -139,10 +139,10 @@ def create_transactions(
                             api_logger.error(
                                 "Transaction detail creation error"
                             )
-                            error_logger.error(f"{str(e)}")
+                            error_logger.exception(f"{str(e)}")
                     except Exception as e:
                         api_logger.error("Transaction creation error")
-                        error_logger.error(f"{str(e)}")
+                        error_logger.exception(f"{str(e)}")
                 api_logger.debug("Transaction(s) created successfully")
                 return True
             except Exception as e:
@@ -250,7 +250,7 @@ def create_transactions(
                 api_logger.info("Transaction chunks created successfully")
             except Exception as e:
                 api_logger.error("Transaction chunks not created")
-                error_logger.error(f"{str(e)}")
+                error_logger.exception(f"{str(e)}")
             # Create transaction details
             for trans_detail in transaction_details:
                 transaction_index = trans_detail["transaction_index"]
@@ -306,11 +306,11 @@ def create_transactions(
                 )
             except Exception as e:
                 api_logger.error("Transaction detail chunks not created")
-                error_logger.error(f"{str(e)}")
+                error_logger.exception(f"{str(e)}")
             api_logger.info("Transaction(s) created successfully")
             # update_running_totals()
             return True
         except Exception as e:
             api_logger.error("Transaction(s) not created")
-            error_logger.error(f"{str(e)}")
+            error_logger.exception(f"{str(e)}")
             return False

--- a/backend/transactions/api/views/paycheck.py
+++ b/backend/transactions/api/views/paycheck.py
@@ -36,7 +36,7 @@ def create_paycheck(request, payload: PaycheckIn):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Paycheck not created")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record creation error")
 
 
@@ -77,7 +77,7 @@ def update_paycheck(request, paycheck_id: int, payload: PaycheckIn):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Paycheck not updated")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record update error")
 
 
@@ -106,7 +106,7 @@ def get_paycheck(request, paycheck_id: int):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Paycheck not retrieved")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record retrieval error")
 
 
@@ -130,7 +130,7 @@ def list_paychecks(request):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Paycheck list not retrieved")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record retrieval error")
 
 
@@ -160,5 +160,5 @@ def delete_paycheck(request, paycheck_id: int):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Paycheck not deleted")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record retrieval error")

--- a/backend/transactions/api/views/transaction.py
+++ b/backend/transactions/api/views/transaction.py
@@ -99,7 +99,7 @@ def create_transaction(request, payload: TransactionIn):
         raise
     except Exception as e:
         api_logger.error("Transaction not created")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, f"Record creation error : {str(e)}")
 
 
@@ -139,7 +139,7 @@ def multiedit_transactions(request, payload: MultiTranscationDate):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Tranasction dates not updated")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, f"Transaction dates error: {str(e)}")
 
 
@@ -195,7 +195,7 @@ def clear_transaction(request, payload: TransactionList):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Transaction clear error")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, f"Transaction clear error: {str(e)}")
 
 
@@ -230,7 +230,7 @@ def get_transaction(request, transaction_id: int):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Transaction not retrieved")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record retrieval error")
 
 
@@ -260,7 +260,7 @@ def delete_transaction(request, payload: TransactionList):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Transaction not deleted")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, f"Record retrieval error: {str(e)}")
 
 
@@ -300,7 +300,7 @@ def update_transaction(request, transaction_id: int, payload: TransactionIn):
         raise HttpError(404, "Transaction not found")
     except Exception as e:
         api_logger.error("Transaction not updated")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, f"Record update error: {str(e)}")
 
 
@@ -495,5 +495,5 @@ def list_transactions(request, query: TransactionQuery = Query(...)):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Transaction list not retrieved")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, f"Record retrieval error: {str(e)}")

--- a/backend/transactions/api/views/transaction_detail.py
+++ b/backend/transactions/api/views/transaction_detail.py
@@ -51,7 +51,7 @@ def get_transaction_detail(request, transactiondetail_id: int):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Transaction detail not retrieved")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record retrieval error")
 
 
@@ -75,7 +75,7 @@ def list_transactiondetails(request):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Transaction detail list not retrieved")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record retrieval error")
 
 
@@ -107,7 +107,7 @@ def delete_transaction_detail(request, transactiondetail_id: int):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Transaction detail not deleted")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record retrieval error")
 
 
@@ -135,7 +135,7 @@ def create_transaction_detail(request, payload: TransactionDetailIn):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Transaction detail not created")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record creation error")
 
 
@@ -175,5 +175,5 @@ def update_transaction_detail(
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Transaction detail not updated")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record update error")

--- a/backend/transactions/api/views/transaction_image.py
+++ b/backend/transactions/api/views/transaction_image.py
@@ -26,7 +26,7 @@ def list_transaction_images(request, transaction_id: int):
         api_logger.debug(f"Attachments listed for transaction #{transaction_id}")
         return images
     except Exception as e:
-        error_logger.error(str(e))
+        error_logger.exception(str(e))
         raise HttpError(500, "Record retrieval error")
 
 
@@ -48,7 +48,7 @@ def upload_transaction_image(
     except Http404:
         raise HttpError(404, "Transaction not found")
     except Exception as e:
-        error_logger.error(str(e))
+        error_logger.exception(str(e))
         raise HttpError(500, "Upload error")
 
 
@@ -65,5 +65,5 @@ def delete_transaction_image(request, image_id: int):
     except Http404:
         raise HttpError(404, "Attachment not found")
     except Exception as e:
-        error_logger.error(str(e))
+        error_logger.exception(str(e))
         raise HttpError(500, "Delete error")

--- a/backend/transactions/api/views/transaction_status.py
+++ b/backend/transactions/api/views/transaction_status.py
@@ -57,7 +57,7 @@ def update_transaction_status(
             api_logger.error(
                 f"Transaction status not updated : transaction status exists ({payload.transaction_status})"
             )
-            error_logger.error(
+            error_logger.exception(
                 f"Transaction status not updated : transaction status exists ({payload.transaction_status})"
             )
             raise HttpError(400, "Transaction status already exists")
@@ -66,14 +66,14 @@ def update_transaction_status(
             api_logger.error(
                 "Transaction status not updated : db integrity error"
             )
-            error_logger.error(
+            error_logger.exception(
                 "Transaction status not updated : db integrity error"
             )
             raise HttpError(400, "DB integrity error")
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Transaction status not updated")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record update error")
 
 
@@ -109,7 +109,7 @@ def get_transaction_status(request, transactionstatus_id: int):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Transaction status not retrieved")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record retrieval error")
 
 
@@ -133,7 +133,7 @@ def list_transaction_statuses(request):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Transaction status list not retrieved")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record retrieval error")
 
 
@@ -172,5 +172,5 @@ def delete_transaction_status(request, transactionstatus_id: int):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Transaction status not deleted")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record retrieval error")

--- a/backend/transactions/api/views/transaction_type.py
+++ b/backend/transactions/api/views/transaction_type.py
@@ -57,7 +57,7 @@ def update_transaction_type(
             api_logger.error(
                 f"Transaction type not updated : transaction type exists ({payload.transaction_type})"
             )
-            error_logger.error(
+            error_logger.exception(
                 f"Transaction type not updated : transaction type exists ({payload.transaction_type})"
             )
             raise HttpError(400, "Transaction type already exists")
@@ -66,14 +66,14 @@ def update_transaction_type(
             api_logger.error(
                 "Transaction type not updated : db integrity error"
             )
-            error_logger.error(
+            error_logger.exception(
                 "Transaction type not updated : db integrity error"
             )
             raise HttpError(400, "DB integrity error")
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Transaction type not updated")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record update error")
 
 
@@ -108,7 +108,7 @@ def get_transaction_type(request, transaction_type_id: int):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Transaction type not retrieved")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record retrieval error")
 
 
@@ -132,7 +132,7 @@ def list_transaction_types(request):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Transaction type list not retrieved")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record retrieval error")
 
 
@@ -169,5 +169,5 @@ def delete_transaction_type(request, transaction_type_id: int):
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Transaction type not deleted")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         raise HttpError(500, "Record retrieval error")

--- a/backend/transactions/tasks.py
+++ b/backend/transactions/tasks.py
@@ -252,7 +252,7 @@ def roll_over_budgets():
     except Exception as e:
         # Log other types of exceptions
         task_logger.error("Budget roll overs not calculated")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
 
 
 def calculate_repeat_window(start_date: datetime, repeat: Repeat) -> tuple:
@@ -680,7 +680,7 @@ def archive_transactions():
         task_logger.info("Transactions successfully archived.")
     except Exception as e:
         task_logger.error("Transactions not archived")
-        error_logger.error(f"{str(e)}")
+        error_logger.exception(f"{str(e)}")
         return f"Error archiving transactions: {str(e)}"
 
 

--- a/frontend/src/composables/logentriesComposable.js
+++ b/frontend/src/composables/logentriesComposable.js
@@ -1,3 +1,4 @@
+import { unref } from "vue";
 import { useQuery, useQueryClient } from "@tanstack/vue-query";
 import apiClient from "./apiClient";
 import { useMainStore } from "@/stores/main";
@@ -27,11 +28,11 @@ export function useLogs({ logType, page, pageSize, level, search } = {}) {
     queryKey: ["logs", logType, page, pageSize, level, search],
     queryFn: () =>
       getLogsFunction({
-        logType: logType?.value ?? logType ?? "error",
-        page: page?.value ?? page ?? 1,
-        pageSize: pageSize?.value ?? pageSize ?? 100,
-        level: level?.value ?? level ?? null,
-        search: search?.value ?? search ?? null,
+        logType: unref(logType) ?? "error",
+        page: unref(page) ?? 1,
+        pageSize: unref(pageSize) ?? 100,
+        level: unref(level) ?? null,
+        search: unref(search) ?? null,
       }),
     client: queryClient,
   });

--- a/frontend/src/composables/logentriesComposable.js
+++ b/frontend/src/composables/logentriesComposable.js
@@ -13,7 +13,8 @@ function handleApiError(error, message) {
 async function getLogsFunction({ logType = "error", page = 1, pageSize = 100, level = null, search = null } = {}) {
   try {
     const params = { log_type: logType, page, page_size: pageSize };
-    if (level) params.level = level;
+    const levelList = Array.isArray(level) ? level : (level ? [level] : []);
+    if (levelList.length > 0) params.level = levelList.join(",");
     if (search) params.search = search;
     const response = await apiClient.get("/administration/logs", { params });
     return response.data;
@@ -48,7 +49,7 @@ export async function downloadLogBundle() {
     const url = URL.createObjectURL(response.data);
     const a = document.createElement("a");
     a.href = url;
-    a.download = "lenore_logs.zip";
+    a.download = "lenorefin_logs.zip";
     a.click();
     URL.revokeObjectURL(url);
   } catch (error) {

--- a/frontend/src/composables/logentriesComposable.js
+++ b/frontend/src/composables/logentriesComposable.js
@@ -5,39 +5,53 @@ import { useMainStore } from "@/stores/main";
 function handleApiError(error, message) {
   if (error.response?.status === 401) throw error;
   const mainstore = useMainStore();
-  if (error.response) {
-    console.error("Response error:", error.response.data);
-    console.error("Status code:", error.response.status);
-    console.error("Headers", error.response.headers);
-  } else if (error.request) {
-    console.error("No response received:", error.request);
-  } else {
-    console.error("Error during request setup:", error.message);
-  }
-  mainstore.showSnackbar(message + "Error #" + error.response.status, "error");
+  mainstore.showSnackbar(message + " : " + (error.response?.data?.detail ?? error.message), "error");
   throw error;
 }
 
-async function getLogEntriesFunction() {
+async function getLogsFunction({ logType = "error", page = 1, pageSize = 100, level = null, search = null } = {}) {
   try {
-    const response = await apiClient.get("/administration/log-entries/list");
+    const params = { log_type: logType, page, page_size: pageSize };
+    if (level) params.level = level;
+    if (search) params.search = search;
+    const response = await apiClient.get("/administration/logs", { params });
     return response.data;
   } catch (error) {
-    handleApiError(error, "Log entries not fetched: ");
+    return handleApiError(error, "Failed to load logs");
   }
 }
 
-export function useLogEntries() {
+export function useLogs({ logType, page, pageSize, level, search } = {}) {
   const queryClient = useQueryClient();
-  const { data: log_entries, isLoading } = useQuery({
-    queryKey: ["log_entries"],
-    queryFn: () => getLogEntriesFunction(),
-    select: response => response,
+  const { data: logPage, isLoading, refetch } = useQuery({
+    queryKey: ["logs", logType, page, pageSize, level, search],
+    queryFn: () =>
+      getLogsFunction({
+        logType: logType?.value ?? logType ?? "error",
+        page: page?.value ?? page ?? 1,
+        pageSize: pageSize?.value ?? pageSize ?? 100,
+        level: level?.value ?? level ?? null,
+        search: search?.value ?? search ?? null,
+      }),
     client: queryClient,
   });
 
-  return {
-    isLoading,
-    log_entries,
-  };
+  return { logPage, isLoading, refetch };
+}
+
+export async function downloadLogBundle() {
+  try {
+    const response = await apiClient.get("/administration/logs/bundle", {
+      responseType: "blob",
+    });
+    const url = URL.createObjectURL(response.data);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "lenore_logs.zip";
+    a.click();
+    URL.revokeObjectURL(url);
+  } catch (error) {
+    const mainstore = useMainStore();
+    mainstore.showSnackbar("Failed to download log bundle", "error");
+  }
 }

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -18,6 +18,7 @@ import NotesView from "@/views/NotesView.vue";
 import RetirementView from "@/views/RetirementView.vue";
 import BudgetsView from "@/views/BudgetsView.vue";
 import BackupView from "@/views/BackupView.vue";
+import LogsView from "@/views/LogsView.vue";
 import LoginView from "@/views/LoginView.vue";
 
 const routes = [
@@ -116,6 +117,11 @@ const routes = [
     path: "/backup",
     name: "backup",
     component: BackupView,
+  },
+  {
+    path: "/logs",
+    name: "logs",
+    component: LogsView,
   },
   {
     path: "/:catchAll(.*)",

--- a/frontend/src/views/AppNavigationVue.vue
+++ b/frontend/src/views/AppNavigationVue.vue
@@ -198,6 +198,16 @@
             ></v-list-item>
           </template>
         </v-tooltip>
+        <v-tooltip text="Logs">
+          <template v-slot:activator="{ props }">
+            <v-list-item
+              prepend-icon="mdi-file-document-outline"
+              to="/logs"
+              v-bind="props"
+              color="selected"
+            ></v-list-item>
+          </template>
+        </v-tooltip>
         <v-tooltip text="Settings">
           <template v-slot:activator="{ props }">
             <v-list-item

--- a/frontend/src/views/LogsView.vue
+++ b/frontend/src/views/LogsView.vue
@@ -44,6 +44,7 @@
           item-value="value"
           density="compact"
           variant="outlined"
+          multiple
           clearable
           hide-details
         ></v-select>
@@ -138,7 +139,7 @@
 
   const activeTab = ref("error");
   const currentPage = ref(1);
-  const selectedLevel = ref(null);
+  const selectedLevel = ref([]);
   const searchText = ref("");
   const appliedSearch = ref("");
   const isDownloading = ref(false);
@@ -171,7 +172,7 @@
 
   watch(activeTab, () => {
     currentPage.value = 1;
-    selectedLevel.value = null;
+    selectedLevel.value = [];
     searchText.value = "";
     appliedSearch.value = "";
   });

--- a/frontend/src/views/LogsView.vue
+++ b/frontend/src/views/LogsView.vue
@@ -1,0 +1,221 @@
+<template>
+  <v-container fluid>
+    <v-row>
+      <v-col>
+        <h4 class="text-h5 font-weight-bold mb-2">Application Logs</h4>
+      </v-col>
+      <v-col class="d-flex justify-end align-center">
+        <v-btn
+          prepend-icon="mdi-download"
+          variant="outlined"
+          size="small"
+          :loading="isDownloading"
+          @click="handleDownloadBundle"
+        >
+          Download Log Bundle
+        </v-btn>
+      </v-col>
+    </v-row>
+
+    <!-- Log type tabs -->
+    <v-tabs v-model="activeTab" color="primary" class="mb-4">
+      <v-tab value="error">
+        <v-icon start>mdi-alert-circle</v-icon>
+        Error
+      </v-tab>
+      <v-tab value="api">
+        <v-icon start>mdi-api</v-icon>
+        API
+      </v-tab>
+      <v-tab value="task">
+        <v-icon start>mdi-cog-play</v-icon>
+        Task
+      </v-tab>
+    </v-tabs>
+
+    <!-- Filters -->
+    <v-row dense class="mb-2">
+      <v-col cols="12" sm="4" md="3">
+        <v-select
+          v-model="selectedLevel"
+          label="Level"
+          :items="levelOptions"
+          item-title="label"
+          item-value="value"
+          density="compact"
+          variant="outlined"
+          clearable
+          hide-details
+        ></v-select>
+      </v-col>
+      <v-col cols="12" sm="6" md="5">
+        <v-text-field
+          v-model="searchText"
+          label="Search"
+          density="compact"
+          variant="outlined"
+          prepend-inner-icon="mdi-magnify"
+          clearable
+          hide-details
+          @keyup.enter="applySearch"
+          @click:clear="clearSearch"
+        ></v-text-field>
+      </v-col>
+      <v-col cols="auto" class="d-flex align-center">
+        <v-btn size="small" variant="text" icon="mdi-refresh" @click="refetch"></v-btn>
+      </v-col>
+    </v-row>
+
+    <!-- Log table -->
+    <v-sheet border rounded>
+      <v-data-table
+        :headers="headers"
+        :items="entries"
+        :loading="isLoading"
+        density="compact"
+        no-data-text="No log entries found"
+        :items-per-page="-1"
+        hide-default-footer
+        @click:row="(_, { item }) => openDetail(item)"
+      >
+        <template v-slot:item.timestamp="{ item }">
+          <span class="text-caption text-no-wrap">{{ item.timestamp }}</span>
+        </template>
+        <template v-slot:item.level="{ item }">
+          <v-chip :color="levelColor(item.level)" size="x-small" label>
+            {{ item.level }}
+          </v-chip>
+        </template>
+        <template v-slot:item.message="{ item }">
+          <span class="text-caption" style="font-family: monospace; white-space: pre-wrap">{{
+            truncate(item.message)
+          }}</span>
+        </template>
+      </v-data-table>
+    </v-sheet>
+
+    <!-- Pagination -->
+    <v-row class="mt-2" v-if="logPage">
+      <v-col class="d-flex justify-center">
+        <v-pagination
+          v-model="currentPage"
+          :length="logPage.pages"
+          :total-visible="7"
+          density="compact"
+        ></v-pagination>
+      </v-col>
+      <v-col cols="auto" class="d-flex align-center text-caption text-medium-emphasis">
+        {{ logPage.total }} entries
+      </v-col>
+    </v-row>
+
+    <!-- Detail dialog -->
+    <v-dialog v-model="detailDialog" max-width="800">
+      <v-card v-if="selectedEntry">
+        <v-card-title class="d-flex align-center ga-2">
+          <v-chip :color="levelColor(selectedEntry.level)" size="small" label>
+            {{ selectedEntry.level }}
+          </v-chip>
+          <span class="text-caption text-medium-emphasis">{{ selectedEntry.timestamp }}</span>
+        </v-card-title>
+        <v-card-text>
+          <pre class="text-caption pa-3 bg-surface-variant rounded" style="white-space: pre-wrap; overflow-x: auto">{{
+            selectedEntry.message
+          }}</pre>
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer></v-spacer>
+          <v-btn @click="detailDialog = false">Close</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+  </v-container>
+</template>
+
+<script setup>
+  import { ref, computed, watch } from "vue";
+  import { useLogs, downloadLogBundle } from "@/composables/logentriesComposable";
+
+  const activeTab = ref("error");
+  const currentPage = ref(1);
+  const selectedLevel = ref(null);
+  const searchText = ref("");
+  const appliedSearch = ref("");
+  const isDownloading = ref(false);
+  const detailDialog = ref(false);
+  const selectedEntry = ref(null);
+
+  const levelOptions = [
+    { label: "DEBUG", value: "DEBUG" },
+    { label: "INFO", value: "INFO" },
+    { label: "WARNING", value: "WARNING" },
+    { label: "ERROR", value: "ERROR" },
+    { label: "CRITICAL", value: "CRITICAL" },
+  ];
+
+  const headers = [
+    { title: "Timestamp", key: "timestamp", width: "200px" },
+    { title: "Level", key: "level", width: "100px" },
+    { title: "Message", key: "message" },
+  ];
+
+  const { logPage, isLoading, refetch } = useLogs({
+    logType: activeTab,
+    page: currentPage,
+    pageSize: ref(100),
+    level: selectedLevel,
+    search: appliedSearch,
+  });
+
+  const entries = computed(() => logPage.value?.entries ?? []);
+
+  watch(activeTab, () => {
+    currentPage.value = 1;
+    selectedLevel.value = null;
+    searchText.value = "";
+    appliedSearch.value = "";
+  });
+
+  watch(selectedLevel, () => {
+    currentPage.value = 1;
+  });
+
+  function applySearch() {
+    appliedSearch.value = searchText.value;
+    currentPage.value = 1;
+  }
+
+  function clearSearch() {
+    searchText.value = "";
+    appliedSearch.value = "";
+    currentPage.value = 1;
+  }
+
+  function openDetail(entry) {
+    selectedEntry.value = entry;
+    detailDialog.value = true;
+  }
+
+  async function handleDownloadBundle() {
+    isDownloading.value = true;
+    await downloadLogBundle();
+    isDownloading.value = false;
+  }
+
+  function levelColor(level) {
+    const map = {
+      DEBUG: "grey",
+      INFO: "info",
+      WARNING: "warning",
+      ERROR: "error",
+      CRITICAL: "deep-purple",
+    };
+    return map[level] ?? "grey";
+  }
+
+  function truncate(msg, max = 200) {
+    if (!msg) return "";
+    const first = msg.split("\n")[0];
+    return first.length > max ? first.slice(0, max) + "…" : first;
+  }
+</script>


### PR DESCRIPTION
## Summary
Three improvements shipped together as a logging phase:

**1. Error traceback capture (all 33 backend view files)**
- Replaced `error_logger.error()` with `error_logger.exception()` at 173 call sites
- `.exception()` logs at the same ERROR level but automatically captures the full stack trace via `exc_info=True`
- Previously, 500-class errors were logged with just a bare string — the traceback was silently dropped

**2. Log viewer API** (`/api/v1/administration/logs`)
- `GET /administration/logs?log_type=error&page=1&level=ERROR&search=text` — paginated, parsed log entries
- Supports log types: `error`, `api`, `task`; optional level and text search filters
- Multiline entries (tracebacks) are grouped as single entries
- `GET /administration/logs/bundle` — streams a zip of all log files for offline error reporting
- Both endpoints require FullAccessAuth

**3. Frontend log viewer** (`/logs`)
- Tabs for Error / API / Task logs
- Level filter and text search
- Click any row to expand the full message/traceback in a dialog
- "Download Log Bundle" button for sending logs to support
- Nav item added next to Backup & Restore

## Test plan
- [ ] `pytest` → 526 passed
- [ ] Docker up → `/logs` page loads, tabs switch, entries display
- [ ] Click a row → detail dialog shows full message
- [ ] Level filter and search filter entries correctly
- [ ] Download Log Bundle → zip downloads with all log files
- [ ] Verify error.log entries now contain stack traces for exceptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)