### PR TITLE
fix: correct CC statement cycle start date and due/pay date sequencing

### DIFF
--- a/backend/transactions/tasks.py
+++ b/backend/transactions/tasks.py
@@ -1140,8 +1140,20 @@ def generate_statement_cycles(
     # the just-closed period, and due/pay dates were incremented at the top
     # of the loop (one month too late). Both are fixed here.
     statement_start = one_month_prior.replace(day=statement_day)
-    statement_due = (statement_start + relativedelta(months=1)).replace(day=due_day)
-    statement_pay_day = (statement_start + relativedelta(months=1)).replace(day=pay_day)
+
+    # Anchor due/pay dates to after the first cycle's statement_end.
+    # When due_day or pay_day < statement_day, a naive +1-month formula
+    # lands before the statement closes; push forward by one more month.
+    _first_end = increment_date(statement_start, statement_cycle_period, statement_cycle_length)
+    _candidate_due = _first_end.replace(day=due_day)
+    if _candidate_due < _first_end:
+        _candidate_due += relativedelta(months=1)
+    statement_due = _candidate_due
+
+    _candidate_pay = _first_end.replace(day=pay_day)
+    if _candidate_pay < _first_end:
+        _candidate_pay += relativedelta(months=1)
+    statement_pay_day = _candidate_pay
 
     previous_balance = (
         transactions.filter(

--- a/backend/transactions/tasks.py
+++ b/backend/transactions/tasks.py
@@ -1133,18 +1133,15 @@ def generate_statement_cycles(
     statement_cycles = []
     today = get_todays_date_timezone_adjusted()
     one_month_prior = today - relativedelta(months=1)
-    statement_start = today
-    statement_due = today
-    statement_pay_day = today
 
-    if today.day > statement_day:
-        statement_start = today.replace(day=statement_day)
-        statement_due = statement_start.replace(day=due_day)
-        statement_pay_day = statement_start.replace(day=pay_day)
-    else:
-        statement_start = one_month_prior.replace(day=statement_day)
-        statement_due = (statement_start + relativedelta(months=1)).replace(day=due_day)
-        statement_pay_day = (statement_start + relativedelta(months=1)).replace(day=pay_day)
+    # Always start from the most recently closed statement period so the
+    # just-closed cycle (with its upcoming payment due date) is included.
+    # Previously the if/else split caused today.day > statement_day to skip
+    # the just-closed period, and due/pay dates were incremented at the top
+    # of the loop (one month too late). Both are fixed here.
+    statement_start = one_month_prior.replace(day=statement_day)
+    statement_due = (statement_start + relativedelta(months=1)).replace(day=due_day)
+    statement_pay_day = (statement_start + relativedelta(months=1)).replace(day=pay_day)
 
     previous_balance = (
         transactions.filter(
@@ -1159,8 +1156,6 @@ def generate_statement_cycles(
             statement_start, statement_cycle_period, statement_cycle_length
         )
 
-        statement_due = increment_date(statement_due, "m", 1)
-        statement_pay_day = increment_date(statement_pay_day, "m", 1)
         statement_transaction_credits = (
             transactions.filter(
                 transaction_date__gt=statement_start,
@@ -1214,6 +1209,8 @@ def generate_statement_cycles(
             }
         )
         statement_start = statement_end
+        statement_due = increment_date(statement_due, "m", 1)
+        statement_pay_day = increment_date(statement_pay_day, "m", 1)
     return statement_cycles
 
 

--- a/backend/transactions/tests/service/test_cc_interest.py
+++ b/backend/transactions/tests/service/test_cc_interest.py
@@ -288,6 +288,96 @@ def test_first_cycle_start_when_today_after_statement_day(
 
 @pytest.mark.django_db
 @pytest.mark.service
+def test_due_date_after_statement_end_when_due_day_less_than_statement_day(
+    bank, credit_card_account_type, test_checking_account,
+):
+    """When due_day < statement_day the due date must land *after* the statement closes.
+
+    Example: statement_day=18, due_day=15, today=2026-05-19
+      statement_start = 2026-04-18, statement_end = 2026-05-18
+      naive formula: (Apr 18 + 1m).replace(15) = May 15  ← before statement_end!
+      correct:       May 18.replace(15) < May 18 → push to June 15
+    """
+    today = date(2026, 5, 19)
+    with patch(PATCH_TODAY, return_value=today):
+        cc = _make_cc_account(
+            bank, credit_card_account_type, test_checking_account,
+            opening_balance=Decimal("-399.73"),
+        )
+        # Override statement_day/due_day/pay_day for this test
+        cc.statement_day = 18
+        cc.due_day = 15
+        cc.pay_day = 15
+        cc.save()
+
+        transactions_qs = annotate_transaction_total(
+            Transaction.objects.filter(source_account_id=cc.id), cc.id
+        )
+        from transactions.models import ReminderCacheTransaction
+        reminder_qs = annotate_transaction_total(
+            ReminderCacheTransaction.objects.filter(source_account_id=cc.id), cc.id
+        )
+        cycles = generate_statement_cycles(
+            statement_day=18,
+            due_day=15,
+            pay_day=15,
+            forecast_end_date=today + timedelta(days=60),
+            statement_cycle_length=1,
+            statement_cycle_period="m",
+            transactions=transactions_qs,
+            reminder_transactions=reminder_qs,
+            account_id=cc.id,
+            non_trans_bal=Decimal("0.00"),
+        )
+
+    # Cycle 0: 2026-04-18 → 2026-05-18
+    assert cycles[0]["statement_start"] == date(2026, 4, 18)
+    assert cycles[0]["statement_end"] == date(2026, 5, 18)
+    # Due/pay date must be AFTER statement_end (May 18) → June 15
+    assert cycles[0]["statement_due"] == date(2026, 6, 15)
+    assert cycles[0]["statement_pay_day"] == date(2026, 6, 15)
+
+
+@pytest.mark.django_db
+@pytest.mark.service
+def test_due_date_correct_when_due_day_after_statement_end_same_month(
+    bank, credit_card_account_type, test_checking_account,
+):
+    """When due_day > statement_day the due date stays in the same month as statement_end.
+
+    Example: statement_day=1, due_day=25
+      statement_end = 2026-06-01, due = June 25 (still in June, no extra month needed).
+    """
+    with patch(PATCH_TODAY, return_value=FIXED_TODAY):
+        cc = _make_cc_account(bank, credit_card_account_type, test_checking_account)
+        transactions_qs = annotate_transaction_total(
+            Transaction.objects.filter(source_account_id=cc.id), cc.id
+        )
+        from transactions.models import ReminderCacheTransaction
+        reminder_qs = annotate_transaction_total(
+            ReminderCacheTransaction.objects.filter(source_account_id=cc.id), cc.id
+        )
+        cycles = generate_statement_cycles(
+            statement_day=1,
+            due_day=25,
+            pay_day=25,
+            forecast_end_date=FIXED_TODAY + timedelta(days=60),
+            statement_cycle_length=1,
+            statement_cycle_period="m",
+            transactions=transactions_qs,
+            reminder_transactions=reminder_qs,
+            account_id=cc.id,
+            non_trans_bal=Decimal("0.00"),
+        )
+
+    # Cycle 0: 2026-05-01 → 2026-06-01; due June 25 (same month as end)
+    assert cycles[0]["statement_end"] == date(2026, 6, 1)
+    assert cycles[0]["statement_due"] == date(2026, 6, 25)
+    assert cycles[0]["statement_pay_day"] == date(2026, 6, 25)
+
+
+@pytest.mark.django_db
+@pytest.mark.service
 def test_first_cycle_start_when_today_before_statement_day(
     bank, credit_card_account_type, test_checking_account,
 ):

--- a/backend/transactions/tests/service/test_cc_interest.py
+++ b/backend/transactions/tests/service/test_cc_interest.py
@@ -10,10 +10,9 @@ Covers:
 
 Note on interest in update_cc_forecast_cache:
   The interest condition is `statement_cycles[0]["statement_due"] < today`.
-  Because statement_due is incremented twice (once before the loop, once inside it),
-  it always lands ~2 months in the future — making this branch unreachable in normal
-  operation.  calculate_interest is therefore tested in isolation below, and the
-  update_cc_forecast_cache tests focus on the payment path.
+  In practice this means interest is only charged when the first cycle's due date
+  has already passed (i.e. the card is past-due).  calculate_interest is tested in
+  isolation below; update_cc_forecast_cache tests focus on the payment path.
 """
 import pytest
 from datetime import date, timedelta
@@ -25,7 +24,7 @@ from transactions.models import Transaction, ForecastCacheTransaction, Transacti
 from transactions.api.dependencies.transaction_utilities import annotate_transaction_total
 
 # Fixed date used across all tests that need a predictable today.
-# statement_day=1, today.day=15 → today.day > statement_day → statement_start = 2026-06-01
+# statement_day=1, today=2026-06-15 → one_month_prior=2026-05-15 → statement_start=2026-05-01
 FIXED_TODAY = date(2026, 6, 15)
 PATCH_TODAY = "transactions.tasks.get_todays_date_timezone_adjusted"
 
@@ -259,9 +258,9 @@ def test_cycles_generated_up_to_forecast_end_date(
 def test_first_cycle_start_when_today_after_statement_day(
     bank, credit_card_account_type, test_checking_account,
 ):
-    """When today.day > statement_day, first cycle starts on statement_day this month."""
-    # FIXED_TODAY = 2026-06-15, statement_day=1, so today.day(15) > 1
-    # → statement_start = 2026-06-01
+    """First cycle always starts on statement_day of the prior month so the just-closed period is included."""
+    # FIXED_TODAY = 2026-06-15, statement_day=1
+    # one_month_prior = 2026-05-15 → statement_start = 2026-05-01
     with patch(PATCH_TODAY, return_value=FIXED_TODAY):
         cc = _make_cc_account(bank, credit_card_account_type, test_checking_account)
         transactions_qs = annotate_transaction_total(
@@ -283,8 +282,8 @@ def test_first_cycle_start_when_today_after_statement_day(
             account_id=cc.id,
             non_trans_bal=Decimal("0.00"),
         )
-    assert cycles[0]["statement_start"] == date(2026, 6, 1)
-    assert cycles[0]["statement_end"] == date(2026, 7, 1)
+    assert cycles[0]["statement_start"] == date(2026, 5, 1)
+    assert cycles[0]["statement_end"] == date(2026, 6, 1)
 
 
 @pytest.mark.django_db
@@ -327,9 +326,10 @@ def test_cycle_debits_only_include_transactions_in_period(
     bank, credit_card_account_type, test_checking_account,
 ):
     """Only expenses with transaction_date > statement_start and <= statement_end count."""
-    # statement_start=2026-06-01, statement_end=2026-07-01
-    # Expense on 2026-06-15 (in period) → counted
-    # Expense on 2026-05-31 (before period) → not counted
+    # Cycle 0: 2026-05-01 to 2026-06-01 (one_month_prior.replace(day=1))
+    # Cycle 1: 2026-06-01 to 2026-07-01
+    # Expense on 2026-05-31 (> May 1, <= Jun 1) → in cycle 0
+    # Expense on 2026-06-15 (> Jun 1, <= Jul 1) → in cycle 1
     with patch(PATCH_TODAY, return_value=FIXED_TODAY):
         cc = _make_cc_account(bank, credit_card_account_type, test_checking_account)
         Transaction.objects.create(
@@ -367,8 +367,10 @@ def test_cycle_debits_only_include_transactions_in_period(
             non_trans_bal=Decimal("0.00"),
         )
 
-    # Cycle 0: 2026-06-01 to 2026-07-01 — only the June 15 expense ($100) is in it
-    assert cycles[0]["statement_debits"] == Decimal("-100.00")
+    # Cycle 0: 2026-05-01 → 2026-06-01 — May 31 expense ($50) is in it
+    assert cycles[0]["statement_debits"] == Decimal("-50.00")
+    # Cycle 1: 2026-06-01 → 2026-07-01 — Jun 15 expense ($100) is in it
+    assert cycles[1]["statement_debits"] == Decimal("-100.00")
 
 
 @pytest.mark.django_db
@@ -379,9 +381,9 @@ def test_previous_balance_includes_non_trans_bal_and_prior_transactions(
     """previous_balance = non_trans_bal + sum of transactions on or before statement_start."""
     with patch(PATCH_TODAY, return_value=FIXED_TODAY):
         cc = _make_cc_account(bank, credit_card_account_type, test_checking_account)
-        # Expense on 2026-05-31 — before statement_start (2026-06-01), so included in previous_balance
+        # Expense on 2026-04-30 — before statement_start (2026-05-01), so included in previous_balance
         Transaction.objects.create(
-            transaction_date=date(2026, 5, 31),
+            transaction_date=date(2026, 4, 30),
             total_amount=Decimal("75.00"),
             status=_pending_status(),
             transaction_type=_expense_type(),
@@ -409,7 +411,7 @@ def test_previous_balance_includes_non_trans_bal_and_prior_transactions(
             non_trans_bal=non_trans_bal,
         )
 
-    # previous_balance = -50.00 + (-75.00) = -125.00
+    # previous_balance = -50.00 (non_trans_bal) + (-75.00) (Apr 30 expense) = -125.00
     assert cycles[0]["previous_balance"] == Decimal("-125.00")
 
 
@@ -579,10 +581,10 @@ def test_existing_payment_reduces_forecast_payment(
             strategy="F", opening_balance=Decimal("-200.00"),
         )
         transfer_type = _transfer_type()
-        # Existing payment: $100 from checking → CC, dated in the first pay window
-        # Payment window: statement_end (2026-07-01) < date <= next_statement_end (2026-08-01)
+        # Existing payment: $100 from checking → CC, dated in the first pay window.
+        # Cycle 0: 2026-05-01 → 2026-06-01; payment window: > 2026-06-01 and <= 2026-07-01
         Transaction.objects.create(
-            transaction_date=date(2026, 7, 15),
+            transaction_date=date(2026, 6, 15),
             total_amount=Decimal("100.00"),
             status=_pending_status(),
             transaction_type=transfer_type,
@@ -612,8 +614,9 @@ def test_fully_covered_payment_creates_no_forecast(
             strategy="F", opening_balance=Decimal("-200.00"),
         )
         transfer_type = _transfer_type()
+        # Cycle 0 payment window: > 2026-06-01 and <= 2026-07-01
         Transaction.objects.create(
-            transaction_date=date(2026, 7, 15),
+            transaction_date=date(2026, 6, 15),
             total_amount=Decimal("200.00"),
             status=_pending_status(),
             transaction_type=transfer_type,


### PR DESCRIPTION
## Summary

- `generate_statement_cycles` had two bugs that caused CC payment forecasts to be wrong once a statement period closed
- Bug 1: the `today.day > statement_day` branch started from the *current* month's statement day, skipping the just-closed period entirely — so the cycle that's actually due for payment was missing
- Bug 2: `statement_due` and `statement_pay_day` were incremented at the **top** of the while loop instead of the bottom, making the first cycle's due/pay dates land one month too late
- Fix: always anchor the first cycle to `one_month_prior.replace(day=statement_day)` (removes the if/else split); move due/pay date increments to after `statement_cycles.append()`

## Test plan

- [ ] All 23 CC interest/forecast tests updated to reflect corrected cycle boundaries and pass
- [ ] Full 488-test suite passes with no regressions
- [ ] Ruff: `All checks passed!`
- [ ] Manually verify: statement end date passes → CC forecast shows correct upcoming payment due

🤖 Generated with [Claude Code](https://claude.com/claude-code)