### PR TITLE
chore: fix Jazzmin navbar contrast

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -434,7 +434,7 @@ JAZZMIN_UI_TWEAKS = {
     "brand_small_text": True,
     "brand_colour": "navbar-teal",
     "accent": "accent-success",
-    "navbar": "navbar-teal navbar-dark",
+    "navbar": "navbar-dark",
     "no_navbar_border": False,
     "navbar_fixed": False,
     "layout_boxed": False,


### PR DESCRIPTION
## Summary

- Change top navbar from `navbar-teal navbar-dark` to `navbar-dark` — the teal background was too close to the minty theme's link color, making hamburger menu and nav links invisible

## Test plan

- [ ] Django admin top navbar has dark background with visible white links and hamburger icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)