### PR TITLE
feat: add transaction filtering by description, status, type, and tag

### DIFF
--- a/backend/transactions/api/schemas/transaction.py
+++ b/backend/transactions/api/schemas/transaction.py
@@ -113,3 +113,5 @@ class TransactionQuery(Schema):
     status_id: Optional[int] = None
     transaction_type_id: Optional[int] = None
     tag_id: Optional[int] = None
+    date_from: Optional[date] = None
+    date_to: Optional[date] = None

--- a/backend/transactions/api/schemas/transaction.py
+++ b/backend/transactions/api/schemas/transaction.py
@@ -109,3 +109,7 @@ class TransactionQuery(Schema):
     page: Optional[int] = 1
     page_size: Optional[int] = 60
     rule_id: Optional[int] = None
+    search: Optional[str] = None
+    status_id: Optional[int] = None
+    transaction_type_id: Optional[int] = None
+    tag_id: Optional[int] = None

--- a/backend/transactions/api/views/transaction.py
+++ b/backend/transactions/api/views/transaction.py
@@ -376,6 +376,16 @@ def list_transactions(request, query: TransactionQuery = Query(...)):
                     ]
                 except Tag.DoesNotExist:
                     all_transactions_list = []
+            if query.date_from:
+                all_transactions_list = [
+                    t for t in all_transactions_list
+                    if t.transaction_date and t.transaction_date >= query.date_from
+                ]
+            if query.date_to:
+                all_transactions_list = [
+                    t for t in all_transactions_list
+                    if t.transaction_date and t.transaction_date <= query.date_to
+                ]
 
             # Reverse transactions if not forecast
             if not query.forecast:

--- a/backend/transactions/api/views/transaction.py
+++ b/backend/transactions/api/views/transaction.py
@@ -2,6 +2,7 @@ from ninja import Router, Query
 from ninja.errors import HttpError
 from transactions.models import Transaction, TransactionDetail, TransactionStatus
 from accounts.models import Account
+from tags.models import Tag
 from transactions.api.schemas.transaction import (
     TransactionIn,
     TransactionList,
@@ -343,6 +344,38 @@ def list_transactions(request, query: TransactionQuery = Query(...)):
                     end_date, query.account, False, query.forecast
                 )
             )
+
+            # Apply optional filters to the assembled list
+            if query.search:
+                s = query.search.lower()
+                all_transactions_list = [
+                    t for t in all_transactions_list
+                    if t.description and s in t.description.lower()
+                ]
+            if query.status_id:
+                all_transactions_list = [
+                    t for t in all_transactions_list
+                    if t.status and t.status.id == query.status_id
+                ]
+            if query.transaction_type_id:
+                all_transactions_list = [
+                    t for t in all_transactions_list
+                    if t.transaction_type and t.transaction_type.id == query.transaction_type_id
+                ]
+            if query.tag_id:
+                try:
+                    tag = Tag.objects.select_related("parent", "child").get(id=query.tag_id)
+                    tag_display = (
+                        f"{tag.parent.tag_name} / {tag.child.tag_name}"
+                        if tag.child
+                        else tag.parent.tag_name
+                    )
+                    all_transactions_list = [
+                        t for t in all_transactions_list
+                        if tag_display in (t.tags or [])
+                    ]
+                except Tag.DoesNotExist:
+                    all_transactions_list = []
 
             # Reverse transactions if not forecast
             if not query.forecast:

--- a/frontend/src/components/AccountsMenu.vue
+++ b/frontend/src/components/AccountsMenu.vue
@@ -428,9 +428,9 @@
   }
 
   const setAccount = (account, forecast) => {
+    transactions_store.resetFilters();
     transactions_store.pageinfo.account_id = account;
     transactions_store.pageinfo.forecast = forecast;
-    transactions_store.pageinfo.page = 1;
     transactions_store.pageinfo.maxdays = 14;
     transactions_store.pageinfo.view_type = 1;
     router.push("/accounts/" + account);

--- a/frontend/src/components/EditAccountForm.vue
+++ b/frontend/src/components/EditAccountForm.vue
@@ -545,7 +545,6 @@
     errors => {
       // Validation failed
       generalError.value = "Please fix the errors below before saving.";
-      console.log(errors);
     },
   );
 

--- a/frontend/src/components/EditAccountForm.vue
+++ b/frontend/src/components/EditAccountForm.vue
@@ -542,8 +542,7 @@
       editAccount(values);
       closeForm();
     },
-    errors => {
-      // Validation failed
+    () => {
       generalError.value = "Please fix the errors below before saving.";
     },
   );

--- a/frontend/src/components/TransactionTableWidget.vue
+++ b/frontend/src/components/TransactionTableWidget.vue
@@ -758,7 +758,7 @@
 
   const maxDateTo = computed(() => {
     const d = new Date();
-    d.setDate(d.getDate() + 14);
+    d.setDate(d.getDate() + (transactions_store.pageinfo.maxdays || 14));
     return d.toISOString().slice(0, 10);
   });
 

--- a/frontend/src/components/TransactionTableWidget.vue
+++ b/frontend/src/components/TransactionTableWidget.vue
@@ -4,6 +4,22 @@
       <span class="text-subtitle-2 text-primary">
         {{ title[props.variant] }}
         <v-tooltip
+          text="Filter"
+          location="top"
+          v-if="props.variant === 'account'"
+        >
+          <template v-slot:activator="{ props }">
+            <v-btn
+              :icon="hasActiveFilters ? 'mdi-filter' : 'mdi-filter-outline'"
+              flat
+              variant="plain"
+              v-bind="props"
+              @click="showFilters = !showFilters"
+              :color="hasActiveFilters ? 'primary' : undefined"
+            ></v-btn>
+          </template>
+        </v-tooltip>
+        <v-tooltip
           text="File Import"
           location="top"
           v-if="!smAndDown && props.variant === 'account' && authStore.isFullAccess"
@@ -28,6 +44,78 @@
       </span>
     </v-card-title>
     <v-card-text class="ma-0 pa-0 ga-0">
+      <!-- Filter bar (account variant only) -->
+      <v-expand-transition>
+        <div v-if="showFilters && props.variant === 'account'" class="pa-2 bg-surface">
+          <v-row dense>
+            <v-col cols="12" sm="6" md="4">
+              <v-text-field
+                v-model="filterSearch"
+                label="Search description"
+                prepend-inner-icon="mdi-magnify"
+                clearable
+                density="compact"
+                variant="outlined"
+                hide-details
+                @update:model-value="applyFilters"
+              />
+            </v-col>
+            <v-col cols="12" sm="6" md="2">
+              <v-select
+                v-model="filterStatusId"
+                :items="statuses_data"
+                item-title="transaction_status"
+                item-value="id"
+                label="Status"
+                clearable
+                density="compact"
+                variant="outlined"
+                hide-details
+                @update:model-value="applyFilters"
+              />
+            </v-col>
+            <v-col cols="12" sm="6" md="2">
+              <v-select
+                v-model="filterTypeId"
+                :items="types_data"
+                item-title="transaction_type"
+                item-value="id"
+                label="Type"
+                clearable
+                density="compact"
+                variant="outlined"
+                hide-details
+                @update:model-value="applyFilters"
+              />
+            </v-col>
+            <v-col cols="12" sm="6" md="3">
+              <v-select
+                v-model="filterTagId"
+                :items="tags_data"
+                item-title="tag_name"
+                item-value="id"
+                label="Tag"
+                clearable
+                density="compact"
+                variant="outlined"
+                hide-details
+                @update:model-value="applyFilters"
+              />
+            </v-col>
+            <v-col cols="12" md="1" class="d-flex align-center">
+              <v-btn
+                variant="text"
+                size="small"
+                color="error"
+                @click="clearFilters"
+                :disabled="!hasActiveFilters"
+              >
+                Clear
+              </v-btn>
+            </v-col>
+          </v-row>
+        </div>
+      </v-expand-transition>
       <!-- Large Display View -->
       <v-data-table-server
         :headers="displayHeaders"
@@ -626,6 +714,9 @@
   import { useAuthStore } from "@/stores/auth";
   import { useAccountByID } from "@/composables/accountsComposable";
   import { useOnlineStatus } from "@/composables/useOnlineStatus";
+  import { useTransactionStatuses } from "@/composables/transactionStatusesComposable";
+  import { useTransactionTypes } from "@/composables/transactionTypesComposable";
+  import { useTags } from "@/composables/tagsComposable";
   const { isOnline } = useOnlineStatus();
 
   const { removeTransaction, clearTransaction } = useTransactions();
@@ -633,6 +724,35 @@
   const authStore = useAuthStore();
   const { smAndDown, mdAndUp } = useDisplay();
   const transactions_store = useTransactionsStore();
+  const { transaction_statuses: statuses_data } = useTransactionStatuses();
+  const { transaction_types: types_data } = useTransactionTypes();
+  const { tags: tags_data } = useTags(null);  // null = all tag types
+
+  const showFilters = ref(false);
+  const filterSearch = ref(null);
+  const filterStatusId = ref(null);
+  const filterTypeId = ref(null);
+  const filterTagId = ref(null);
+
+  const hasActiveFilters = computed(
+    () => !!(filterSearch.value || filterStatusId.value || filterTypeId.value || filterTagId.value)
+  );
+
+  function applyFilters() {
+    transactions_store.pageinfo.search = filterSearch.value || null;
+    transactions_store.pageinfo.status_id = filterStatusId.value || null;
+    transactions_store.pageinfo.transaction_type_id = filterTypeId.value || null;
+    transactions_store.pageinfo.tag_id = filterTagId.value || null;
+    transactions_store.pageinfo.page = 1;
+  }
+
+  function clearFilters() {
+    filterSearch.value = null;
+    filterStatusId.value = null;
+    filterTypeId.value = null;
+    filterTagId.value = null;
+    applyFilters();
+  }
   const today = new Date();
   const year = today.getFullYear();
   const month = String(today.getMonth() + 1).padStart(2, "0");

--- a/frontend/src/components/TransactionTableWidget.vue
+++ b/frontend/src/components/TransactionTableWidget.vue
@@ -16,6 +16,7 @@
               v-bind="props"
               @click="showFilters = !showFilters"
               :color="hasActiveFilters ? 'primary' : undefined"
+              :disabled="isActive"
             ></v-btn>
           </template>
         </v-tooltip>
@@ -1021,24 +1022,25 @@
   const clickRemoveTransaction = async transactions => {
     removeTransaction(transactions);
     selected_all.value = [];
+    clearFilters();
   };
 
   const clickClearTransaction = async (transactions, reminderTransactions) => {
     clearTransaction(transactions);
-    console.log("emitting clear transaction", transactions);
     open.value = false;
     selected_all.value = [];
     reminderTransactions.forEach(transaction => {
       addReminderTransaction(transaction);
-      console.log("emitting add reminder transaction", transaction);
     });
     selected_transactions.value = [];
     selected_reminders.value = [];
     clearDisable.value = true;
+    clearFilters();
   };
 
   const updateAddDialog = () => {
     transactionAddFormDialog.value = false;
+    clearFilters();
   };
 
   const updateImportFileDialog = () => {
@@ -1048,9 +1050,11 @@
   const updateEditDialog = () => {
     transactionEditFormDialog.value = false;
     uncheck_all();
+    clearFilters();
   };
   const updateMultipleEditDialog = () => {
     showMultipleTransactionEditDialog.value = false;
+    clearFilters();
   };
   const formatCurrency = value => {
     return new Intl.NumberFormat("en-US", {

--- a/frontend/src/components/TransactionTableWidget.vue
+++ b/frontend/src/components/TransactionTableWidget.vue
@@ -112,6 +112,7 @@
                 variant="outlined"
                 hide-details
                 clearable
+                :min="minDateFrom"
                 :error="dateRangeError"
                 @update:model-value="applyFilters"
               />
@@ -762,6 +763,10 @@
     d.setDate(d.getDate() + (transactions_store.pageinfo.maxdays || 14));
     return d.toISOString().slice(0, 10);
   });
+
+  const minDateFrom = computed(() =>
+    transactions_store.pageinfo.forecast ? new Date().toISOString().slice(0, 10) : undefined
+  );
 
   const showFilters = ref(false);
   const filterSearch = ref(null);

--- a/frontend/src/components/TransactionTableWidget.vue
+++ b/frontend/src/components/TransactionTableWidget.vue
@@ -102,6 +102,33 @@
                 @update:model-value="applyFilters"
               />
             </v-col>
+            <v-col cols="12" sm="6" md="2">
+              <v-text-field
+                v-model="filterDateFrom"
+                label="From"
+                type="date"
+                density="compact"
+                variant="outlined"
+                hide-details
+                clearable
+                :error="dateRangeError"
+                @update:model-value="applyFilters"
+              />
+            </v-col>
+            <v-col cols="12" sm="6" md="2">
+              <v-text-field
+                v-model="filterDateTo"
+                label="To"
+                type="date"
+                density="compact"
+                variant="outlined"
+                :hide-details="!dateRangeError"
+                clearable
+                :error="dateRangeError"
+                :error-messages="dateRangeError ? '\"From\" must not be after \"To\"' : []"
+                @update:model-value="applyFilters"
+              />
+            </v-col>
             <v-col cols="12" md="1" class="d-flex align-center">
               <v-btn
                 variant="text"
@@ -733,16 +760,32 @@
   const filterStatusId = ref(null);
   const filterTypeId = ref(null);
   const filterTagId = ref(null);
+  const filterDateFrom = ref(null);
+  const filterDateTo = ref(null);
+
+  const dateRangeError = computed(
+    () => !!(filterDateFrom.value && filterDateTo.value && filterDateFrom.value > filterDateTo.value)
+  );
 
   const hasActiveFilters = computed(
-    () => !!(filterSearch.value || filterStatusId.value || filterTypeId.value || filterTagId.value)
+    () => !!(
+      filterSearch.value ||
+      filterStatusId.value ||
+      filterTypeId.value ||
+      filterTagId.value ||
+      filterDateFrom.value ||
+      filterDateTo.value
+    )
   );
 
   function applyFilters() {
+    if (dateRangeError.value) return;
     transactions_store.pageinfo.search = filterSearch.value || null;
     transactions_store.pageinfo.status_id = filterStatusId.value || null;
     transactions_store.pageinfo.transaction_type_id = filterTypeId.value || null;
     transactions_store.pageinfo.tag_id = filterTagId.value || null;
+    transactions_store.pageinfo.date_from = filterDateFrom.value || null;
+    transactions_store.pageinfo.date_to = filterDateTo.value || null;
     transactions_store.pageinfo.page = 1;
   }
 
@@ -751,6 +794,8 @@
     filterStatusId.value = null;
     filterTypeId.value = null;
     filterTagId.value = null;
+    filterDateFrom.value = null;
+    filterDateTo.value = null;
     applyFilters();
   }
   const today = new Date();

--- a/frontend/src/components/TransactionTableWidget.vue
+++ b/frontend/src/components/TransactionTableWidget.vue
@@ -124,6 +124,7 @@
                 variant="outlined"
                 :hide-details="!dateRangeError"
                 clearable
+                :max="maxDateTo"
                 :error="dateRangeError"
                 :error-messages="dateRangeError ? '\"From\" must not be after \"To\"' : []"
                 @update:model-value="applyFilters"
@@ -754,6 +755,12 @@
   const { transaction_statuses: statuses_data } = useTransactionStatuses();
   const { transaction_types: types_data } = useTransactionTypes();
   const { tags: tags_data } = useTags(null);  // null = all tag types
+
+  const maxDateTo = computed(() => {
+    const d = new Date();
+    d.setDate(d.getDate() + 14);
+    return d.toISOString().slice(0, 10);
+  });
 
   const showFilters = ref(false);
   const filterSearch = ref(null);

--- a/frontend/src/components/TransactionTableWidget.vue
+++ b/frontend/src/components/TransactionTableWidget.vue
@@ -126,7 +126,7 @@
                 clearable
                 :max="maxDateTo"
                 :error="dateRangeError"
-                :error-messages="dateRangeError ? '\"From\" must not be after \"To\"' : []"
+                :error-messages="dateRangeError ? ['From must not be after To'] : []"
                 @update:model-value="applyFilters"
               />
             </v-col>

--- a/frontend/src/composables/accountsComposable.js
+++ b/frontend/src/composables/accountsComposable.js
@@ -187,7 +187,6 @@ export function useAccountByID(account_id) {
   const deleteAccountMutation = useMutation({
     mutationFn: deleteAccountFunction,
     onSuccess: () => {
-      console.log("Success deleting account");
       queryClient.invalidateQueries({ queryKey: ["transactions"] });
       queryClient.invalidateQueries({ queryKey: ["accounts"] });
       queryClient.invalidateQueries({ queryKey: ["account_forecast"] });
@@ -199,7 +198,6 @@ export function useAccountByID(account_id) {
   const updateAccountMutation = useMutation({
     mutationFn: updateAccountFunction,
     onSuccess: () => {
-      console.log("Success updating account");
       queryClient.invalidateQueries({ queryKey: ["transactions"] });
       queryClient.invalidateQueries({ queryKey: ["accounts"] });
       queryClient.invalidateQueries({ queryKey: ["account_forecast"] });

--- a/frontend/src/composables/banksComposable.js
+++ b/frontend/src/composables/banksComposable.js
@@ -50,7 +50,6 @@ export function useBanks() {
   const createBankMutation = useMutation({
     mutationFn: createBankFunction,
     onSuccess: () => {
-      console.log("Success adding bank");
       queryClient.invalidateQueries({ queryKey: ["banks"] });
     },
   });

--- a/frontend/src/composables/budgetsComposable.js
+++ b/frontend/src/composables/budgetsComposable.js
@@ -112,7 +112,6 @@ export function useBudgets(widget) {
   const createBudgetMutation = useMutation({
     mutationFn: createBudgetFunction,
     onSuccess: () => {
-      console.log("Success adding budget");
       queryClient.invalidateQueries({ queryKey: ["budgets"] });
     },
   });
@@ -120,7 +119,6 @@ export function useBudgets(widget) {
   const deleteBudgetMutation = useMutation({
     mutationFn: deleteBudgetFunction,
     onSuccess: () => {
-      console.log("Success deleting budget");
       queryClient.invalidateQueries({ queryKey: ["budgets"] });
     },
   });
@@ -128,7 +126,6 @@ export function useBudgets(widget) {
   const updateBudgetMutation = useMutation({
     mutationFn: updateBudgetFunction,
     onSuccess: () => {
-      console.log("Success updating budget");
       queryClient.invalidateQueries({ queryKey: ["budgets"] });
     },
   });

--- a/frontend/src/composables/calculatorComposable.js
+++ b/frontend/src/composables/calculatorComposable.js
@@ -109,7 +109,6 @@ export function useCalculationRule() {
   const createCalculationRuleMutation = useMutation({
     mutationFn: createCalculationRuleFunction,
     onSuccess: () => {
-      console.log("Success adding calculation rule");
       queryClient.invalidateQueries({ queryKey: ["calculation_rules"] });
     },
   });
@@ -117,7 +116,6 @@ export function useCalculationRule() {
   const deleteCalculationRuleMutation = useMutation({
     mutationFn: deleteCalculationRuleFunction,
     onSuccess: () => {
-      console.log("Success deleteing calculation rule");
       queryClient.invalidateQueries({ queryKey: ["calculation_rules"] });
     },
   });
@@ -125,7 +123,6 @@ export function useCalculationRule() {
   const updateCalculationRuleMutation = useMutation({
     mutationFn: updateCalculationRuleFunction,
     onSuccess: () => {
-      console.log("Success updating calculation rule");
       queryClient.invalidateQueries({ queryKey: ["calculation_rules"] });
     },
   });

--- a/frontend/src/composables/contributionsComposable.js
+++ b/frontend/src/composables/contributionsComposable.js
@@ -136,7 +136,6 @@ export function useContributions() {
   const createContributionMutation = useMutation({
     mutationFn: createContributionFunction,
     onSuccess: () => {
-      console.log("Success adding contribution");
       queryClient.invalidateQueries({ queryKey: ["contributions"] });
     },
   });
@@ -144,7 +143,6 @@ export function useContributions() {
   const deleteContributionMutation = useMutation({
     mutationFn: deleteContributionFunction,
     onSuccess: () => {
-      console.log("Success deleting contribution");
       queryClient.invalidateQueries({ queryKey: ["contributions"] });
     },
   });
@@ -152,7 +150,6 @@ export function useContributions() {
   const updateContributionMutation = useMutation({
     mutationFn: updateContributionFunction,
     onSuccess: () => {
-      console.log("Success updating contribution");
       queryClient.invalidateQueries({ queryKey: ["contributions"] });
     },
   });
@@ -190,7 +187,6 @@ export function useContributionRules() {
   const createContributionRuleMutation = useMutation({
     mutationFn: createContributionRuleFunction,
     onSuccess: () => {
-      console.log("Success adding contribution rule");
       queryClient.invalidateQueries({ queryKey: ["contributionRules"] });
     },
   });
@@ -198,7 +194,6 @@ export function useContributionRules() {
   const deleteContributionRuleMutation = useMutation({
     mutationFn: deleteContributionRuleFunction,
     onSuccess: () => {
-      console.log("Success deleting contribution rule");
       queryClient.invalidateQueries({ queryKey: ["contributionRules"] });
     },
   });
@@ -206,7 +201,6 @@ export function useContributionRules() {
   const updateContributionRuleMutation = useMutation({
     mutationFn: updateContributionRuleFunction,
     onSuccess: () => {
-      console.log("Success updating contribution rule");
       queryClient.invalidateQueries({ queryKey: ["contributionRules"] });
     },
   });

--- a/frontend/src/composables/messagesComposable.js
+++ b/frontend/src/composables/messagesComposable.js
@@ -86,7 +86,6 @@ export function useMessages() {
   const createMessageMutation = useMutation({
     mutationFn: createMessageFunction,
     onSuccess: () => {
-      console.log("Success adding message");
       queryClient.invalidateQueries({ queryKey: ["messages"] });
     },
   });
@@ -94,7 +93,6 @@ export function useMessages() {
   const markMessagesReadMutation = useMutation({
     mutationFn: readAllMessagesFunction,
     onSuccess: () => {
-      console.log("Success marking messages read");
       queryClient.invalidateQueries({ queryKey: ["messages"] });
     },
   });
@@ -102,7 +100,6 @@ export function useMessages() {
   const deleteAllMessagesMutation = useMutation({
     mutationFn: deleteAllMessagesFunction,
     onSuccess: () => {
-      console.log("Success deleting all messages");
       queryClient.invalidateQueries({ queryKey: ["messages"] });
     },
   });

--- a/frontend/src/composables/notesComposable.js
+++ b/frontend/src/composables/notesComposable.js
@@ -77,7 +77,6 @@ export function useNotes() {
   const createNoteMutation = useMutation({
     mutationFn: createNoteFunction,
     onSuccess: () => {
-      console.log("Success adding note");
       queryClient.invalidateQueries({ queryKey: ["notes"] });
     },
   });
@@ -85,7 +84,6 @@ export function useNotes() {
   const deleteNoteMutation = useMutation({
     mutationFn: deleteNoteFunction,
     onSuccess: () => {
-      console.log("Success deleting note");
       queryClient.invalidateQueries({ queryKey: ["notes"] });
     },
   });
@@ -93,7 +91,6 @@ export function useNotes() {
   const updateNoteMutation = useMutation({
     mutationFn: updateNoteFunction,
     onSuccess: () => {
-      console.log("Success updating note");
       queryClient.invalidateQueries({ queryKey: ["notes"] });
     },
   });

--- a/frontend/src/composables/remindersComposable.js
+++ b/frontend/src/composables/remindersComposable.js
@@ -87,7 +87,6 @@ export function useReminders() {
   const deleteReminderMutation = useMutation({
     mutationFn: deleteReminderFunction,
     onSuccess: () => {
-      console.log("Success deleting reminder");
       queryClient.invalidateQueries({ queryKey: ["transactions"] });
       queryClient.invalidateQueries({ queryKey: ["accounts"] });
       queryClient.invalidateQueries({ queryKey: ["account_forecast"] });
@@ -99,7 +98,6 @@ export function useReminders() {
   const createReminderMutation = useMutation({
     mutationFn: createReminderFunction,
     onSuccess: () => {
-      console.log("Success creating reminder");
       queryClient.invalidateQueries({ queryKey: ["transactions"] });
       queryClient.invalidateQueries({ queryKey: ["accounts"] });
       queryClient.invalidateQueries({ queryKey: ["account_forecast"] });
@@ -111,7 +109,6 @@ export function useReminders() {
   const updateReminderMutation = useMutation({
     mutationFn: updateReminderFunction,
     onSuccess: () => {
-      console.log("Success updating reminder");
       queryClient.invalidateQueries({ queryKey: ["transactions"] });
       queryClient.invalidateQueries({ queryKey: ["accounts"] });
       queryClient.invalidateQueries({ queryKey: ["account_forecast"] });
@@ -123,7 +120,6 @@ export function useReminders() {
   const addReminderTransMutation = useMutation({
     mutationFn: addReminderTrans,
     onSuccess: () => {
-      console.log("Success adding reminder transaction");
       queryClient.invalidateQueries({ queryKey: ["transactions"] });
       queryClient.invalidateQueries({ queryKey: ["accounts"] });
       queryClient.invalidateQueries({ queryKey: ["account_forecast"] });

--- a/frontend/src/composables/transactionsComposable.js
+++ b/frontend/src/composables/transactionsComposable.js
@@ -199,8 +199,7 @@ export function useTransactions() {
 
   const createTransactionMutation = useMutation({
     mutationFn: createTransactionFunction,
-    onSuccess: data => {
-      console.log("Success adding transaction", data);
+    onSuccess: () => {
       invalidateTransactionDependencies(queryClient, [["description-history"]]);
       scheduleForecastRefetch(queryClient);
     },
@@ -209,7 +208,6 @@ export function useTransactions() {
   const deleteTransactionMutation = useMutation({
     mutationFn: deleteTransactionFunction,
     onSuccess: () => {
-      console.log("Success deleting transaction");
       invalidateTransactionDependencies(queryClient);
       scheduleForecastRefetch(queryClient);
     },
@@ -218,7 +216,6 @@ export function useTransactions() {
   const clearTransactionMutation = useMutation({
     mutationFn: clearTransactionFunction,
     onSuccess: () => {
-      console.log("Success clearing transaction");
       invalidateTransactionDependencies(queryClient);
       scheduleForecastRefetch(queryClient);
     },
@@ -227,7 +224,6 @@ export function useTransactions() {
   const multiEditTransactionsMutation = useMutation({
     mutationFn: multiEditTransactionsFunction,
     onSuccess: () => {
-      console.log("Success editing dates of transactions");
       invalidateTransactionDependencies(queryClient);
       scheduleForecastRefetch(queryClient);
     },
@@ -236,7 +232,6 @@ export function useTransactions() {
   const updateTransactionMutation = useMutation({
     mutationFn: updateTransactionFunction,
     onSuccess: () => {
-      console.log("Success updating transaction");
       invalidateTransactionDependencies(queryClient, [["description-history"]]);
       scheduleForecastRefetch(queryClient);
     },

--- a/frontend/src/composables/transactionsComposable.js
+++ b/frontend/src/composables/transactionsComposable.js
@@ -46,6 +46,18 @@ async function getTransactionsFunction(querydata) {
       if (querydata.rule_id) {
         querytext = querytext + "&rule_id=" + querydata.rule_id;
       }
+      if (querydata.search) {
+        querytext = querytext + "&search=" + encodeURIComponent(querydata.search);
+      }
+      if (querydata.status_id) {
+        querytext = querytext + "&status_id=" + querydata.status_id;
+      }
+      if (querydata.transaction_type_id) {
+        querytext = querytext + "&transaction_type_id=" + querydata.transaction_type_id;
+      }
+      if (querydata.tag_id) {
+        querytext = querytext + "&tag_id=" + querydata.tag_id;
+      }
       const response = await apiClient.get("/transactions/list" + querytext);
       return response.data;
     } else {

--- a/frontend/src/composables/transactionsComposable.js
+++ b/frontend/src/composables/transactionsComposable.js
@@ -58,6 +58,12 @@ async function getTransactionsFunction(querydata) {
       if (querydata.tag_id) {
         querytext = querytext + "&tag_id=" + querydata.tag_id;
       }
+      if (querydata.date_from) {
+        querytext = querytext + "&date_from=" + querydata.date_from;
+      }
+      if (querydata.date_to) {
+        querytext = querytext + "&date_to=" + querydata.date_to;
+      }
       const response = await apiClient.get("/transactions/list" + querytext);
       return response.data;
     } else {

--- a/frontend/src/stores/transactions.js
+++ b/frontend/src/stores/transactions.js
@@ -10,8 +10,20 @@ export const useTransactionsStore = defineStore("transactions", {
       page_size: 60,
       view_type: 2,
       rule_id: null,
+      search: null,
+      status_id: null,
+      transaction_type_id: null,
+      tag_id: null,
     },
   }),
   getters: {},
-  actions: {},
+  actions: {
+    resetFilters() {
+      this.pageinfo.search = null;
+      this.pageinfo.status_id = null;
+      this.pageinfo.transaction_type_id = null;
+      this.pageinfo.tag_id = null;
+      this.pageinfo.page = 1;
+    },
+  },
 });

--- a/frontend/src/stores/transactions.js
+++ b/frontend/src/stores/transactions.js
@@ -14,6 +14,8 @@ export const useTransactionsStore = defineStore("transactions", {
       status_id: null,
       transaction_type_id: null,
       tag_id: null,
+      date_from: null,
+      date_to: null,
     },
   }),
   getters: {},
@@ -23,6 +25,8 @@ export const useTransactionsStore = defineStore("transactions", {
       this.pageinfo.status_id = null;
       this.pageinfo.transaction_type_id = null;
       this.pageinfo.tag_id = null;
+      this.pageinfo.date_from = null;
+      this.pageinfo.date_to = null;
       this.pageinfo.page = 1;
     },
   },

--- a/frontend/src/views/AccountDetailView.vue
+++ b/frontend/src/views/AccountDetailView.vue
@@ -52,6 +52,7 @@
     () => route.params.accountID,
     newAccountID => {
       account_id.value = parseInt(newAccountID);
+      transactions_store.resetFilters();
       transactions_store.pageinfo.account_id = parseInt(newAccountID);
       transactions_store.pageinfo.forecast = false;
     },

--- a/frontend/src/views/AppNavigationVue.vue
+++ b/frontend/src/views/AppNavigationVue.vue
@@ -294,9 +294,9 @@
   const { isOnline } = useOnlineStatus();
 
   const setAccount = (account, forecast) => {
+    transactions_store.resetFilters();
     transactions_store.pageinfo.account_id = account;
     transactions_store.pageinfo.forecast = forecast;
-    transactions_store.pageinfo.page = 1;
     transactions_store.pageinfo.maxdays = 14;
     transactions_store.pageinfo.view_type = 2;
     router.push({ name: "dashboard" });

--- a/frontend/src/views/ForecastView.vue
+++ b/frontend/src/views/ForecastView.vue
@@ -55,9 +55,9 @@
 
   const updateAccount = account => {
     account_id.value = account;
+    transactions_store.resetFilters();
     transactions_store.pageinfo.account_id = account;
     transactions_store.pageinfo.forecast = true;
-    transactions_store.pageinfo.page = 1;
     transactions_store.pageinfo.maxdays = 90;
     transactions_store.pageinfo.view_type = 1;
   };


### PR DESCRIPTION
## Summary
- Collapsible filter bar on the transaction table (account variant only), toggled via a filter icon in the card header
- Filter by description (text search), status, transaction type, tag, and date range (from/to)
- Date range validation: From must not be after To; same date is valid for single-day filtering; filters blocked until valid
- Filter icon fills/highlights when filters are active; Clear button resets all at once
- Filters reset automatically when switching accounts
- Backend filters applied after cache retrieval so the full transaction cache stays intact

## Test plan
- [ ] Open an account, click the filter icon — bar expands
- [ ] Search by description partial match — list updates
- [ ] Filter by status (Pending / Cleared) — list updates
- [ ] Filter by transaction type (Income / Expense / Transfer) — list updates
- [ ] Filter by tag — list updates
- [ ] Set From and To to the same date — returns only that day's transactions
- [ ] Set From after To — error message appears on To field, list does not update
- [ ] Combine multiple filters — list narrows correctly
- [ ] Clear button resets all filters and restores full list
- [ ] Switch to another account — filters reset automatically
- [ ] Filter icon is not visible on non-account variants (tag, upcoming)
- [ ] Pagination still works correctly while filters are active

🤖 Generated with [Claude Code](https://claude.com/claude-code)