### PR TITLE
fix: backup restore — reminders 500, bank logos, expense graph, cache rebuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,8 +143,6 @@ DJANGO_SUPERUSER_EMAIL=someone@somewhere.com
 DJANGO_SUPERUSER_USERNAME=supervisor
 VITE_API_KEY=someapikey
 TIMEZONE=America/New_York
-# Optional: set to "true" to enable Contributions, Notes, and Calculator in the Planning menu
-VITE_OPT_FEATURES=false
 ```
 
 Adjust these values according to your environment and application requirements.
@@ -256,12 +254,6 @@ Replace your existing `docker-compose.yml` with the new 3-service format shown i
 
 ### 4. Update your `.env` file
 
-Add the new optional variable (it defaults to `false` if omitted):
-
-```env
-VITE_OPT_FEATURES=false
-```
-
 ### 5. Rename volumes (if using named volumes from the old setup)
 
 The old setup used volumes named `lenorefin_static_volume`, `lenorefin_media_volume`, and `lenorefin_postgres_data`. The new setup uses `lenorefin_static`, `lenorefin_media`, and `lenorefin_postgres`.
@@ -304,7 +296,7 @@ See the full <a href="https://novanglus96.github.io/LenoreFin"><strong>documenta
 <!-- ROADMAP -->
 ## Roadmap
 
-### Shipped in v1.4 (current alpha)
+### Shipped in v1.4
 - [x] Django 5.2 LTS migration
 - [x] Consolidated single-container deployment (nginx + gunicorn + worker in one image)
 - [x] Parent accounts (combined balance view across child accounts)

--- a/README.md
+++ b/README.md
@@ -79,12 +79,21 @@
 <!-- ABOUT THE PROJECT -->
 ## About The Project
 
-Screenshots - COMING SOON
-<!--[![Product Name Screen Shot][product-screenshot]]-->
-
 LenoreFin began as a simple Excel spreadsheet I used to manage my family's budget. But over time, I realized no existing tools gave me the control, flexibility, and privacy I wanted. So I built LenoreFin—a personal finance tracker that puts you in charge.
 
-Designed for self-hosting, LenoreFin keeps your financial data completely local, with no third-party syncing or hidden services. It includes tools for tracking cash flow, setting up custom budgets, tagging transactions, planning for retirement or big purchases, getting bill reminders, and even forecasting account balances. Whether you're budgeting for groceries or planning a 10-year savings goal, LenoreFin helps you see the full picture—on your terms.
+Designed for self-hosting, LenoreFin keeps your financial data completely local, with no third-party syncing or hidden services.
+
+**Key features:**
+- **Account tracking** — checking, savings, credit cards, investments, and loans with real-time balance forecasting
+- **Transaction management** — full CRUD, bulk editing, CSV import, file attachments, and tag-based categorization
+- **Credit card tools** — statement cycle tracking, due dates, minimum payment calculation, rewards tracking
+- **Budgeting & planning** — tag-based budgets, contribution rules, retirement forecasting, calculator
+- **Bill reminders** — recurring reminder engine with customizable repeat schedules
+- **Custom reports** — totals and year-over-year comparison reports, filterable by account, tag, and status
+- **Logging & diagnostics** — structured log viewer with level filtering and downloadable log bundle
+- **PWA / offline mode** — installable as a PWA; read-only access and graceful degradation when offline
+- **Multi-user auth** — Full Access and Readonly permission groups
+- **Self-hosted** — single Docker image, no telemetry, no third-party data sharing
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
@@ -295,13 +304,26 @@ See the full <a href="https://novanglus96.github.io/LenoreFin"><strong>documenta
 <!-- ROADMAP -->
 ## Roadmap
 
-- [ ] v1.2 Release
-  - [ ] Credit Card Bill Calculations
-  - [ ] Loading Screen on app load
-  - [ ] Interest Tracking On Loans 
-- [ ] Financial Wizard
+### Shipped in v1.4 (current alpha)
+- [x] Django 5.2 LTS migration
+- [x] Consolidated single-container deployment (nginx + gunicorn + worker in one image)
+- [x] Parent accounts (combined balance view across child accounts)
+- [x] Interest earned on savings / investment accounts
+- [x] Custom report builder (totals & year-over-year comparison)
+- [x] File attachments on transactions
+- [x] Backup & restore system
+- [x] PWA packaging + offline read-only mode
+- [x] Multi-user auth (Full Access / Readonly groups)
+- [x] Structured log viewer with bundle download
+- [x] Bank logos on account header and navigation
+- [x] Transaction filtering (search, status, type, tag, date range)
 
-See the [open issues](https://github.com/Novanglus96/LenoreFin/issues) for a full list of proposed features (and known issues).
+### Planned
+- [ ] Scheduled reports (run a saved report on a schedule, deliver to inbox)
+- [ ] WebSocket real-time sync (live updates across multiple connected clients)
+- [ ] Vuetify 4 migration (planned for later 2026)
+
+See the [open issues](https://github.com/Novanglus96/LenoreFin/issues) for a full list of proposed features and known issues.
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Designed for self-hosting, LenoreFin keeps your financial data completely local,
 - **Account tracking** — checking, savings, credit cards, investments, and loans with real-time balance forecasting
 - **Transaction management** — full CRUD, bulk editing, CSV import, file attachments, and tag-based categorization
 - **Credit card tools** — statement cycle tracking, due dates, minimum payment calculation, rewards tracking
-- **Budgeting & planning** — tag-based budgets, contribution rules, retirement forecasting, calculator
+- **Budgeting & planning** — tag-based budgets, savings goal tracking
 - **Bill reminders** — recurring reminder engine with customizable repeat schedules
 - **Custom reports** — totals and year-over-year comparison reports, filterable by account, tag, and status
 - **Logging & diagnostics** — structured log viewer with level filtering and downloadable log bundle

--- a/backend/accounts/services/account_financials.py
+++ b/backend/accounts/services/account_financials.py
@@ -29,7 +29,12 @@ class AccountNotFound(Exception):
 
 def get_account_financials(account_id: int, today: date | None = None):
     """
-    Returns an Account annotated with all calculated financial fields.
+    Returns a DomainAccount with all calculated financial fields, served from cache when available.
+
+    Due and statement dates are computed relative to today: if the day-of-month hasn't
+    passed yet this month, the date lands this month; otherwise it rolls to next month.
+    Parent accounts sum cleared and pending balances across all children instead of
+    querying their own (empty) transaction set.
     """
     # Check Cache
     key = account_financials(account_id)
@@ -124,6 +129,13 @@ def get_account_financials(account_id: int, today: date | None = None):
 
 
 def last_six_month_reward_amounts(account_id: int):
+    """
+    Returns the most-recent reward balance for each of the past 5 months plus the
+    current month, ordered oldest → newest (for charting left-to-right).
+
+    Uses a Subquery/OuterRef to find the latest reward entry per month rather than
+    a simple Max(amount), because reward_amount is cumulative — not per-month earned.
+    """
     today = get_todays_date_timezone_adjusted()
     first_of_current_month = today.replace(day=1)
 
@@ -159,6 +171,10 @@ def last_six_month_reward_amounts(account_id: int):
 
 
 def last_year_six_month_reward_amounts(account_id: int):
+    """
+    Same as last_six_month_reward_amounts but anchored to the same 6-month window
+    one year ago, for year-over-year comparison charting.
+    """
     today = get_todays_date_timezone_adjusted()
 
     # Move 1 year back

--- a/backend/administration/management/commands/export_user_data.py
+++ b/backend/administration/management/commands/export_user_data.py
@@ -48,6 +48,7 @@ class Command(BaseCommand):
         all_tags = list(Tag.objects.all().select_related("parent", "child", "tag_type"))
         tag_pk_to_slug = {t.pk: t.slug for t in all_tags}
         account_pk_to_name = {a.pk: a.account_name for a in Account.objects.all()}
+        main_tag_pk_to_slug = {mt.pk: mt.slug for mt in MainTag.objects.all()}
 
         def convert_id_json_array(id_str, pk_to_key):
             """Convert a JSON array of PKs stored as a string to a JSON array of natural keys."""
@@ -69,7 +70,7 @@ class Command(BaseCommand):
 
         # 2. Banks
         data["banks"] = [
-            {"bank_name": b.bank_name}
+            {"bank_name": b.bank_name, "logo_url": b.logo_url}
             for b in Bank.objects.all()
         ]
 
@@ -321,8 +322,8 @@ class Command(BaseCommand):
                 "auto_archive": option.auto_archive,
                 "archive_length": option.archive_length,
                 "enable_cc_bill_calculation": option.enable_cc_bill_calculation,
-                "report_main": option.report_main,
-                "report_individual": option.report_individual,
+                "report_main": convert_id_json_array(option.report_main, main_tag_pk_to_slug),
+                "report_individual": convert_id_json_array(option.report_individual, main_tag_pk_to_slug),
                 "retirement_accounts": convert_id_json_array(option.retirement_accounts, account_pk_to_name),
                 "christmas_accounts": convert_id_json_array(option.christmas_accounts, account_pk_to_name),
                 "christmas_rewards": convert_id_json_array(option.christmas_rewards, account_pk_to_name),

--- a/backend/administration/management/commands/export_user_data.py
+++ b/backend/administration/management/commands/export_user_data.py
@@ -41,6 +41,7 @@ class Command(BaseCommand):
         from transactions.models import Transaction, Paycheck, TransactionDetail
         from reminders.models import Reminder, ReminderExclusion
         from planning.models import ContribRule, Contribution, Note, ChristmasGift, Budget, CalculationRule
+        from reports.models import ReportConfig
 
         data = {}
 
@@ -121,6 +122,8 @@ class Command(BaseCommand):
                 "statement_balance": str(a.statement_balance) if a.statement_balance is not None else None,
                 "archive_balance": str(a.archive_balance) if a.archive_balance is not None else None,
                 "funding_account_name": a.funding_account.account_name if a.funding_account else None,
+                "parent_account_name": a.parent_account.account_name if a.parent_account else None,
+                "interest_child_account_name": a.interest_child_account.account_name if a.interest_child_account else None,
                 "calculate_payments": a.calculate_payments,
                 "calculate_interest": a.calculate_interest,
                 "payment_strategy": a.payment_strategy,
@@ -131,7 +134,9 @@ class Command(BaseCommand):
                 "pay_day": a.pay_day,
                 "interest_deposit_day": a.interest_deposit_day,
             }
-            for a in Account.objects.all().select_related("account_type", "bank", "funding_account")
+            for a in Account.objects.all().select_related(
+                "account_type", "bank", "funding_account", "parent_account", "interest_child_account"
+            )
         ]
 
         # 7. DescriptionHistory
@@ -201,6 +206,7 @@ class Command(BaseCommand):
                 "transaction_id": td.transaction_id,
                 "detail_amt": str(td.detail_amt),
                 "tag_slug": td.tag.slug if td.tag else None,
+                "full_toggle": td.full_toggle,
             }
             for td in TransactionDetail.objects.all().select_related("tag")
         ]
@@ -298,7 +304,34 @@ class Command(BaseCommand):
                 "destination_account_name": account_pk_to_name.get(cr.destination_account_id),
             })
 
-        # 20. Option singleton
+        # 20. ReportConfigs
+        data["report_configs"] = []
+        for rc in ReportConfig.objects.prefetch_related("accounts", "tag_selections__tag", "tag_selections__sub_tag", "tag_selections__main_tag"):
+            data["report_configs"].append({
+                "name": rc.name,
+                "description": rc.description,
+                "report_type": rc.report_type,
+                "date_range_type": rc.date_range_type,
+                "date_from": str(rc.date_from) if rc.date_from else None,
+                "date_to": str(rc.date_to) if rc.date_to else None,
+                "period2_date_from": str(rc.period2_date_from) if rc.period2_date_from else None,
+                "period2_date_to": str(rc.period2_date_to) if rc.period2_date_to else None,
+                "account_names": [a.account_name for a in rc.accounts.all()],
+                "group_by": rc.group_by,
+                "show_transactions": rc.show_transactions,
+                "show_subtotal": rc.show_subtotal,
+                "include_pending": rc.include_pending,
+                "tag_selections": [
+                    {
+                        "tag_slug": sel.tag.slug if sel.tag else None,
+                        "sub_tag_slug": sel.sub_tag.slug if sel.sub_tag else None,
+                        "main_tag_slug": sel.main_tag.slug if sel.main_tag else None,
+                    }
+                    for sel in rc.tag_selections.all()
+                ],
+            })
+
+        # 21. Option singleton
         option = Option.load()
         if option:
             data["option"] = {
@@ -329,7 +362,7 @@ class Command(BaseCommand):
                 "christmas_rewards": convert_id_json_array(option.christmas_rewards, account_pk_to_name),
             }
 
-        # 21. BackupConfig singleton
+        # 22. BackupConfig singleton
         config = BackupConfig.load()
         data["backup_config"] = {
             "backup_enabled": config.backup_enabled,

--- a/backend/administration/management/commands/import_user_data.py
+++ b/backend/administration/management/commands/import_user_data.py
@@ -2,6 +2,7 @@ import gzip
 import json
 import os
 from django.core.management.base import BaseCommand, CommandError
+from django.core.management import call_command
 from django.db import transaction as db_transaction
 
 
@@ -29,6 +30,7 @@ class Command(BaseCommand):
             self._clear_user_data()
             self._restore_data(data)
 
+        call_command("load_caches")
         self.stdout.write(self.style.SUCCESS("Restore completed successfully."))
 
     def _clear_user_data(self):
@@ -116,7 +118,10 @@ class Command(BaseCommand):
 
         # --- 2. Banks ---
         for item in data.get("banks", []):
-            Bank.objects.get_or_create(bank_name=item["bank_name"])
+            bank, created = Bank.objects.get_or_create(bank_name=item["bank_name"])
+            if item.get("logo_url") and (created or not bank.logo_url):
+                bank.logo_url = item["logo_url"]
+                bank.save()
         bank_by_name = {b.bank_name: b for b in Bank.objects.all()}
 
         # --- 3. MainTags (user-created) ---
@@ -380,8 +385,9 @@ class Command(BaseCommand):
             option.auto_archive = opt.get("auto_archive", True)
             option.archive_length = opt.get("archive_length", 2)
             option.enable_cc_bill_calculation = opt.get("enable_cc_bill_calculation", True)
-            option.report_main = opt.get("report_main")
-            option.report_individual = opt.get("report_individual")
+            main_tag_slug_to_pk = {slug: mt.pk for slug, mt in main_tag_by_slug.items()}
+            option.report_main = convert_slug_json_array(opt.get("report_main"), main_tag_slug_to_pk)
+            option.report_individual = convert_slug_json_array(opt.get("report_individual"), main_tag_slug_to_pk)
             option.retirement_accounts = convert_slug_json_array(opt.get("retirement_accounts"), account_name_to_pk)
             option.christmas_accounts = convert_slug_json_array(opt.get("christmas_accounts"), account_name_to_pk)
             option.christmas_rewards = convert_slug_json_array(opt.get("christmas_rewards"), account_name_to_pk)

--- a/backend/administration/management/commands/import_user_data.py
+++ b/backend/administration/management/commands/import_user_data.py
@@ -46,6 +46,7 @@ class Command(BaseCommand):
             ContribRule, Contribution, Note, ChristmasGift,
             Budget, CalculationRule,
         )
+        from reports.models import ReportConfig
 
         # Cache tables first (generated data, not user data)
         ForecastCacheTransaction.objects.all().delete()
@@ -60,8 +61,10 @@ class Command(BaseCommand):
         ReminderExclusion.objects.all().delete()
         Reminder.objects.all().delete()
 
-        # Accounts: clear self-referential FK before delete
-        Account.objects.update(funding_account=None)
+        ReportConfig.objects.all().delete()
+
+        # Accounts: clear self-referential FKs before delete
+        Account.objects.update(funding_account=None, parent_account=None, interest_child_account=None)
         Account.objects.all().delete()
         Bank.objects.all().delete()
 
@@ -90,6 +93,7 @@ class Command(BaseCommand):
         )
         from reminders.models import Repeat, Reminder, ReminderExclusion
         from planning.models import ContribRule, Contribution, Note, ChristmasGift, Budget, CalculationRule
+        from reports.models import ReportConfig, ReportConfigTag
 
         # --- System lookup tables (slug → object) ---
         account_type_by_slug = {o.slug: o for o in AccountType.objects.all()}
@@ -191,14 +195,27 @@ class Command(BaseCommand):
             a.save()
             account_by_name[a.account_name] = a
 
-        # Second pass: set funding_account
+        # Second pass: set self-referential FKs (funding_account, parent_account, interest_child_account)
         for item in data.get("accounts", []):
+            acct = account_by_name[item["account_name"]]
+            changed = False
             if item.get("funding_account_name"):
                 funding = account_by_name.get(item["funding_account_name"])
                 if funding:
-                    acct = account_by_name[item["account_name"]]
                     acct.funding_account = funding
-                    acct.save()
+                    changed = True
+            if item.get("parent_account_name"):
+                parent = account_by_name.get(item["parent_account_name"])
+                if parent:
+                    acct.parent_account = parent
+                    changed = True
+            if item.get("interest_child_account_name"):
+                child = account_by_name.get(item["interest_child_account_name"])
+                if child:
+                    acct.interest_child_account = child
+                    changed = True
+            if changed:
+                acct.save()
 
         account_name_to_pk = {name: a.pk for name, a in account_by_name.items()}
 
@@ -272,6 +289,7 @@ class Command(BaseCommand):
                     transaction=t,
                     detail_amt=item["detail_amt"],
                     tag=tag_by_slug.get(item["tag_slug"]) if item.get("tag_slug") else None,
+                    full_toggle=item.get("full_toggle", False),
                 ))
         if detail_batch:
             TransactionDetail.objects.bulk_create(detail_batch)
@@ -358,7 +376,35 @@ class Command(BaseCommand):
                 destination_account_id=account_name_to_pk.get(item.get("destination_account_name"), 0),
             )
 
-        # --- 20. Option singleton (update in place) ---
+        # --- 20. ReportConfigs ---
+        for item in data.get("report_configs", []):
+            rc = ReportConfig.objects.create(
+                name=item["name"],
+                description=item.get("description", ""),
+                report_type=item["report_type"],
+                date_range_type=item["date_range_type"],
+                date_from=item.get("date_from"),
+                date_to=item.get("date_to"),
+                period2_date_from=item.get("period2_date_from"),
+                period2_date_to=item.get("period2_date_to"),
+                group_by=item["group_by"],
+                show_transactions=item.get("show_transactions", False),
+                show_subtotal=item.get("show_subtotal", True),
+                include_pending=item.get("include_pending", False),
+            )
+            for account_name in item.get("account_names", []):
+                acct = account_by_name.get(account_name)
+                if acct:
+                    rc.accounts.add(acct)
+            for sel in item.get("tag_selections", []):
+                ReportConfigTag.objects.create(
+                    report=rc,
+                    tag=tag_by_slug.get(sel["tag_slug"]) if sel.get("tag_slug") else None,
+                    sub_tag=sub_tag_by_slug.get(sel["sub_tag_slug"]) if sel.get("sub_tag_slug") else None,
+                    main_tag=main_tag_by_slug.get(sel["main_tag_slug"]) if sel.get("main_tag_slug") else None,
+                )
+
+        # --- 21. Option singleton (update in place) ---
         if "option" in data:
             opt = data["option"]
             option = Option.load()
@@ -393,7 +439,7 @@ class Command(BaseCommand):
             option.christmas_rewards = convert_slug_json_array(opt.get("christmas_rewards"), account_name_to_pk)
             option.save()
 
-        # --- 21. BackupConfig singleton (update in place) ---
+        # --- 22. BackupConfig singleton (update in place) ---
         if "backup_config" in data:
             bc = data["backup_config"]
             config = BackupConfig.load()

--- a/backend/administration/tests/unit/test_backup_commands.py
+++ b/backend/administration/tests/unit/test_backup_commands.py
@@ -297,3 +297,147 @@ def test_import_rollback_on_restore_failure(tmp_path, test_checking_account):
 
     # Clear was rolled back — accounts are still present
     assert Account.objects.count() == original_count
+
+
+# ---------------------------------------------------------------------------
+# Round-trip: fields added after initial backup/restore implementation
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+def test_roundtrip_bank_logo_url(tmp_path, bank):
+    """Bank.logo_url is exported and restored."""
+    bank.logo_url = "https://icon.horse/icon/example.com"
+    bank.save()
+
+    output = str(tmp_path / "backup.json.gz")
+    call_command("export_user_data", output=output)
+    call_command("import_user_data", output)
+
+    from accounts.models import Bank
+    restored = Bank.objects.get(bank_name=bank.bank_name)
+    assert restored.logo_url == "https://icon.horse/icon/example.com"
+
+
+@pytest.mark.django_db
+def test_roundtrip_parent_account(tmp_path, bank, checking_account_type, savings_account_type):
+    """Account.parent_account self-referential FK is correctly restored."""
+    from accounts.models import Account
+
+    parent = Account.objects.create(
+        account_name="Parent Savings",
+        account_type=savings_account_type,
+        bank=bank,
+        opening_balance="1000.00",
+    )
+    Account.objects.create(
+        account_name="Child Savings",
+        account_type=savings_account_type,
+        bank=bank,
+        opening_balance="500.00",
+        parent_account=parent,
+    )
+
+    output = str(tmp_path / "backup.json.gz")
+    call_command("export_user_data", output=output)
+    call_command("import_user_data", output)
+
+    restored_child = Account.objects.get(account_name="Child Savings")
+    assert restored_child.parent_account is not None
+    assert restored_child.parent_account.account_name == "Parent Savings"
+
+
+@pytest.mark.django_db
+def test_roundtrip_interest_child_account(tmp_path, bank, checking_account_type, savings_account_type):
+    """Account.interest_child_account FK is correctly restored."""
+    from accounts.models import Account
+
+    parent = Account.objects.create(
+        account_name="Interest Parent",
+        account_type=savings_account_type,
+        bank=bank,
+        opening_balance="5000.00",
+    )
+    child = Account.objects.create(
+        account_name="Interest Child",
+        account_type=savings_account_type,
+        bank=bank,
+        opening_balance="0.00",
+        parent_account=parent,
+    )
+    parent.interest_child_account = child
+    parent.save()
+
+    output = str(tmp_path / "backup.json.gz")
+    call_command("export_user_data", output=output)
+    call_command("import_user_data", output)
+
+    restored_parent = Account.objects.get(account_name="Interest Parent")
+    assert restored_parent.interest_child_account is not None
+    assert restored_parent.interest_child_account.account_name == "Interest Child"
+
+
+@pytest.mark.django_db
+def test_roundtrip_transaction_detail_full_toggle(
+    tmp_path, test_checking_account, test_tag,
+    test_pending_transaction_status, test_expense_transaction_type,
+):
+    """TransactionDetail.full_toggle is preserved through export/import."""
+    from transactions.models import Transaction, TransactionDetail
+
+    txn = Transaction.objects.create(
+        description="Full Toggle Expense",
+        status=test_pending_transaction_status,
+        transaction_type=test_expense_transaction_type,
+        source_account=test_checking_account,
+        total_amount="200.00",
+    )
+    TransactionDetail.objects.create(
+        transaction=txn, detail_amt="200.00", tag=test_tag, full_toggle=True
+    )
+
+    output = str(tmp_path / "backup.json.gz")
+    call_command("export_user_data", output=output)
+    call_command("import_user_data", output)
+
+    restored_txn = Transaction.objects.get(description="Full Toggle Expense")
+    detail = TransactionDetail.objects.get(transaction=restored_txn)
+    assert detail.full_toggle is True
+
+
+@pytest.mark.django_db
+def test_roundtrip_report_config(
+    tmp_path, test_checking_account, test_tag, test_main_tag, test_sub_tag,
+):
+    """ReportConfig with tag selections and account filters is fully restored."""
+    from reports.models import ReportConfig, ReportConfigTag
+
+    rc = ReportConfig.objects.create(
+        name="My Annual Report",
+        description="Year over year comparison",
+        report_type="COMPARISON",
+        date_range_type="THIS_YEAR",
+        group_by="TAG",
+        show_transactions=True,
+        show_subtotal=True,
+        include_pending=False,
+    )
+    rc.accounts.add(test_checking_account)
+    ReportConfigTag.objects.create(report=rc, tag=test_tag)
+    ReportConfigTag.objects.create(report=rc, main_tag=test_main_tag)
+
+    output = str(tmp_path / "backup.json.gz")
+    call_command("export_user_data", output=output)
+    call_command("import_user_data", output)
+
+    restored = ReportConfig.objects.get(name="My Annual Report")
+    assert restored.report_type == "COMPARISON"
+    assert restored.group_by == "TAG"
+    assert restored.show_transactions is True
+    assert restored.accounts.filter(account_name=test_checking_account.account_name).exists()
+
+    selections = list(restored.tag_selections.all())
+    assert len(selections) == 2
+    tag_slugs = {s.tag.slug for s in selections if s.tag_id}
+    main_slugs = {s.main_tag.slug for s in selections if s.main_tag_id}
+    assert test_tag.slug in tag_slugs
+    assert test_main_tag.slug in main_slugs

--- a/backend/docs/api.md
+++ b/backend/docs/api.md
@@ -102,13 +102,7 @@ All routes are prefixed with `/api/v1/`.
 | POST | `/planning/budget` | Create budget |
 | PUT | `/planning/budget/{id}` | Update budget |
 | DELETE | `/planning/budget/{id}` | Delete budget |
-| GET | `/planning/contributions` | List contributions |
-| GET | `/planning/contrib-rules` | List contribution rules |
 | GET | `/planning/graph` | Planning graph data |
-| GET | `/planning/retirement` | Retirement projection data |
-| GET | `/planning/calculator` | Financial calculator |
-| GET | `/planning/notes` | List notes |
-| POST | `/planning/notes` | Create note |
 
 ### Reports
 

--- a/backend/docs/api.md
+++ b/backend/docs/api.md
@@ -1,1 +1,165 @@
-### API
+# API Reference
+
+LenoreFin exposes a REST API built with [Django Ninja](https://django-ninja.dev/). All endpoints are under `/api/v1/` and require authentication.
+
+## Interactive Docs
+
+The full interactive API documentation (ReDoc) is available at:
+
+```
+http://<your-host>/api/v1/docs
+```
+
+Use this page to browse all endpoints, view request/response schemas, and try requests directly.
+
+## Authentication
+
+All API requests require an API key passed as a query parameter or header.
+
+**Query parameter:**
+```
+GET /api/v1/accounts?api_key=<your-key>
+```
+
+**Header:**
+```
+Authorization: Bearer <your-key>
+```
+
+Generate API keys in **Django Admin → Authentication → API Keys**. The key used by the frontend is configured via `VITE_API_KEY` in your `.env` file.
+
+## Endpoints
+
+All routes are prefixed with `/api/v1/`.
+
+### Accounts
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/accounts` | List all accounts |
+| POST | `/accounts` | Create an account |
+| GET | `/accounts/{id}` | Get account by ID |
+| PUT | `/accounts/{id}` | Update account |
+| DELETE | `/accounts/{id}` | Delete account |
+| GET | `/accounts/account-types` | List account types |
+| GET | `/accounts/banks` | List banks |
+| POST | `/accounts/banks` | Create bank |
+| PUT | `/accounts/banks/{id}` | Update bank |
+| DELETE | `/accounts/banks/{id}` | Delete bank |
+| GET | `/accounts/forecast` | Get forecast data for an account |
+
+### Transactions
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/transactions` | List transactions (supports filtering) |
+| POST | `/transactions` | Create a transaction |
+| GET | `/transactions/{id}` | Get transaction by ID |
+| PUT | `/transactions/{id}` | Update transaction |
+| DELETE | `/transactions/{id}` | Delete transaction |
+| GET | `/transactions/transaction-types` | List transaction types |
+| GET | `/transactions/transaction-statuses` | List transaction statuses |
+| GET | `/transactions/transaction-details` | List transaction details (tag splits) |
+| POST | `/transactions/transaction-details` | Create transaction detail |
+| PUT | `/transactions/transaction-details/{id}` | Update transaction detail |
+| DELETE | `/transactions/transaction-details/{id}` | Delete transaction detail |
+| GET | `/transactions/attachments` | List attachments |
+| POST | `/transactions/attachments` | Upload an attachment |
+| DELETE | `/transactions/attachments/{id}` | Delete an attachment |
+| GET | `/transactions/paychecks` | List paychecks |
+| POST | `/transactions/paychecks` | Create paycheck |
+
+### Tags
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/tags` | List tags |
+| POST | `/tags` | Create tag |
+| DELETE | `/tags/{id}` | Delete tag |
+| GET | `/tags/tag-types` | List tag types |
+| GET | `/tags/main-tags` | List main tags |
+| POST | `/tags/main-tags` | Create main tag |
+| GET | `/tags/sub-tags` | List sub-tags |
+| POST | `/tags/sub-tags` | Create sub-tag |
+| GET | `/tags/graph-by-tags` | Tag spending graph data |
+
+### Reminders
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/reminders` | List reminders |
+| POST | `/reminders` | Create reminder |
+| GET | `/reminders/{id}` | Get reminder by ID |
+| PUT | `/reminders/{id}` | Update reminder |
+| DELETE | `/reminders/{id}` | Delete reminder |
+| GET | `/reminders/repeat` | List repeat types |
+
+### Planning
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/planning/budget` | List budgets |
+| POST | `/planning/budget` | Create budget |
+| PUT | `/planning/budget/{id}` | Update budget |
+| DELETE | `/planning/budget/{id}` | Delete budget |
+| GET | `/planning/contributions` | List contributions |
+| GET | `/planning/contrib-rules` | List contribution rules |
+| GET | `/planning/graph` | Planning graph data |
+| GET | `/planning/retirement` | Retirement projection data |
+| GET | `/planning/calculator` | Financial calculator |
+| GET | `/planning/notes` | List notes |
+| POST | `/planning/notes` | Create note |
+
+### Reports
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/reports` | List saved reports |
+| POST | `/reports` | Run a report |
+| GET | `/reports/{id}` | Get report by ID |
+
+### Administration
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/administration/options` | Get application options |
+| PUT | `/administration/options/{id}` | Update application options |
+| GET | `/administration/version` | Get current version |
+| GET | `/administration/health` | Health check |
+| GET | `/administration/payees` | List payees |
+| POST | `/administration/payees` | Create payee |
+| GET | `/administration/messages` | List system messages |
+| GET | `/administration/backups` | List backups |
+| POST | `/administration/backups` | Create a backup |
+| GET | `/administration/logs` | Retrieve application logs |
+
+### Imports
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/file-imports` | Upload and process a CSV import |
+| GET | `/file-imports` | List import records |
+
+### Auth
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/auth/login` | Log in and obtain session |
+| POST | `/auth/logout` | Log out |
+| GET | `/auth/me` | Get current user info |
+
+## Transaction Filters
+
+The `GET /transactions` endpoint supports the following query parameters:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `account_id` | int | Filter by account |
+| `search` | string | Search description field |
+| `status_id` | int | Filter by status |
+| `transaction_type_id` | int | Filter by transaction type |
+| `tag_id` | int | Filter by tag |
+| `date_from` | date | Start of date range (`YYYY-MM-DD`) |
+| `date_to` | date | End of date range (`YYYY-MM-DD`) |
+| `page` | int | Page number for pagination |
+| `page_size` | int | Results per page |

--- a/backend/docs/configuration.md
+++ b/backend/docs/configuration.md
@@ -39,7 +39,6 @@ These variables create the initial admin user on first startup. They are only us
 |----------|----------|---------|-------------|
 | `VITE_API_KEY` | Yes | — | API key embedded into the frontend at build time. Must match the key you create in the admin panel under **Auth → API Keys**. |
 | `TIMEZONE` | No | `UTC` | Server timezone (e.g. `America/New_York`). Affects scheduled tasks and date display. |
-| `VITE_OPT_FEATURES` | No | `false` | Set to `true` to enable optional Planning features: Contributions, Notes, and Calculator. |
 
 ## Networking
 

--- a/backend/docs/configuration.md
+++ b/backend/docs/configuration.md
@@ -1,0 +1,64 @@
+# Configuration
+
+All configuration is done via environment variables in your `.env` file. The table below covers every supported variable.
+
+## Django / Security
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `SECRET_KEY` | Yes | — | Django secret key. Use a long random string in production. |
+| `DEBUG` | Yes | `0` | Set to `1` to enable Django debug mode. **Never use `1` in production.** |
+| `DJANGO_ALLOWED_HOSTS` | Yes | — | Space-separated list of hostnames Django will serve (e.g. `localhost myserver.local`). |
+| `CSRF_TRUSTED_ORIGINS` | Yes | — | Comma-separated list of origins trusted for CSRF (e.g. `https://finance.example.com`). |
+
+## Database
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `SQL_ENGINE` | Yes | — | Database backend. Use `django.db.backends.postgresql`. |
+| `SQL_DATABASE` | Yes | — | PostgreSQL database name. |
+| `SQL_USER` | Yes | — | PostgreSQL username. |
+| `SQL_PASSWORD` | Yes | — | PostgreSQL password. |
+| `SQL_HOST` | Yes | — | PostgreSQL hostname. Use `db` when running with the included Compose file. |
+| `SQL_PORT` | Yes | `5432` | PostgreSQL port. |
+| `DATABASE` | Yes | — | Set to `postgres`. Used by the startup script to wait for the database. |
+
+## Superuser Bootstrap
+
+These variables create the initial admin user on first startup. They are only used if no superuser exists yet.
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `DJANGO_SUPERUSER_USERNAME` | Yes | — | Admin username. |
+| `DJANGO_SUPERUSER_EMAIL` | Yes | — | Admin email. |
+| `DJANGO_SUPERUSER_PASSWORD` | Yes | — | Admin password. Change this immediately after first login. |
+
+## Application
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `VITE_API_KEY` | Yes | — | API key embedded into the frontend at build time. Must match the key you create in the admin panel under **Auth → API Keys**. |
+| `TIMEZONE` | No | `UTC` | Server timezone (e.g. `America/New_York`). Affects scheduled tasks and date display. |
+| `VITE_OPT_FEATURES` | No | `false` | Set to `true` to enable optional Planning features: Contributions, Notes, and Calculator. |
+
+## Networking
+
+The app listens on port `80` inside the container. Map it to any host port you like:
+
+```yaml
+ports:
+  - "8080:80"   # host:container
+```
+
+To serve behind a reverse proxy (e.g. Nginx Proxy Manager, Traefik, Caddy), point the proxy to the container on port `80` and make sure `DJANGO_ALLOWED_HOSTS` and `CSRF_TRUSTED_ORIGINS` include the public hostname.
+
+## Volumes
+
+| Volume | Purpose |
+|--------|---------|
+| `lenorefin_postgres` | PostgreSQL data |
+| `lenorefin_static` | Django static files (CSS, JS) |
+| `lenorefin_media` | User-uploaded files (attachments, exports) |
+| `lenorefin_bkp` | Backup archives |
+
+Back up `lenorefin_postgres` and `lenorefin_media` regularly to protect your financial data.

--- a/backend/docs/features/accounts.md
+++ b/backend/docs/features/accounts.md
@@ -1,0 +1,78 @@
+# Accounts
+
+The Accounts section is the core of LenoreFin. Each account tracks a real-world financial account and drives balances, forecasts, and reports across the app.
+
+## Account Types
+
+| Type | Description |
+|------|-------------|
+| **Checking** | Standard debit/checking account |
+| **Savings** | Savings or money market account |
+| **Credit Card** | Revolving credit with statement cycle tracking |
+| **Investment** | Brokerage, retirement (401k, IRA), or other investment account |
+| **Loan** | Mortgage, auto loan, personal loan |
+
+## Account Header
+
+Each account page shows a header card with key balances and metadata. The card adapts between desktop and mobile layouts.
+
+**Desktop** displays all fields side by side:
+
+- Current balance
+- Statement end date *(credit cards only)*
+- Statement balance or minimum due *(credit cards only)*
+- Due date *(credit cards only)*
+- Rewards amount *(credit cards only)*
+- Available credit *(credit cards only)*
+
+**Mobile** shows the current balance up front, with a **more / less** toggle to reveal credit card fields.
+
+The account's bank logo appears as a watermark on desktop and inline before the account name on mobile.
+
+## Adjusting the Balance
+
+Full Access users can click the current balance to open the **Adjust Balance** dialog. This creates a correction transaction to bring the account to the entered amount.
+
+## Parent Accounts
+
+A parent account is a virtual account that aggregates the balances of its child accounts into a single combined view. It has no transactions of its own — it exists solely for the combined balance display.
+
+**Use cases:**
+
+- View your total checking balance across multiple checking accounts at one bank
+- Group all credit cards under a single card portfolio account
+
+To create a parent account, enable the **Is Parent Account** toggle in the Add/Edit Account form, then assign child accounts to it.
+
+## Credit Card Features
+
+Credit card accounts (account type = Credit Card) have additional fields:
+
+| Field | Description |
+|-------|-------------|
+| **Statement Date** | The end date of the current billing cycle |
+| **Statement Balance** | Balance carried from the last statement |
+| **Due Date** | Payment due date |
+| **Credit Limit** | Total credit limit |
+| **Available Credit** | Credit limit minus current balance |
+| **Rewards Amount** | Current rewards balance |
+| **Payment Strategy** | `Full balance` or `Minimum payment` |
+| **Calculate Payments** | If enabled, shows minimum due instead of statement balance |
+
+### Rewards Tracking
+
+Click the rewards amount (or the chart icon) to open the **Rewards Graph**, which shows monthly rewards earned for the current and prior year side by side.
+
+## Banks
+
+Each account is linked to a bank. Banks display with a logo fetched from [icon.horse](https://icon.horse) using the bank's domain. If no logo is found, a default bank icon is shown.
+
+Banks are managed in the Django admin panel under **Administration → Banks**.
+
+## Navigation
+
+The left sidebar lists all active accounts. Each entry shows the bank logo, account name, and current balance. Inactive accounts are hidden from the sidebar but remain accessible for reporting and history.
+
+## Forecasting
+
+Each account has a **Forecast** tab showing a balance projection chart over a configurable time window. See [Budgeting & Planning](planning.md) for details.

--- a/backend/docs/features/administration.md
+++ b/backend/docs/features/administration.md
@@ -1,0 +1,98 @@
+# Administration
+
+The Administration section covers system management: users, authentication, application options, version info, backup/restore, and the log viewer.
+
+## Accessing the Admin Panel
+
+LenoreFin has two admin interfaces:
+
+- **In-app admin** — accessible from the main navigation under **Admin**. Covers the most common administrative tasks.
+- **Django admin** — available at `/django-admin/`. Full database-level access for advanced configuration.
+
+## Users & Authentication
+
+### Permission Groups
+
+LenoreFin uses two built-in permission groups:
+
+| Group | Permissions |
+|-------|-------------|
+| **Full Access** | Create, edit, and delete all data |
+| **Readonly** | View-only access across the entire app |
+
+Assign users to the appropriate group in **Django Admin → Authentication → Users**.
+
+### API Keys
+
+API key authentication is supported for programmatic access. Generate keys in **Django Admin → Authentication → API Keys** or via the in-app admin panel.
+
+The frontend uses the API key set in `VITE_API_KEY`. Additional keys can be issued for scripts or integrations.
+
+## Application Options
+
+Navigate to **Admin → Options** to configure application-wide settings:
+
+| Option | Description |
+|--------|-------------|
+| **Forecast Window** | Number of days to project in the balance forecast chart |
+| **Currency** | Display currency (default: USD) |
+| **Date Format** | Short date format used across the UI |
+
+## Version
+
+Navigate to **Admin → Version** to view the currently running version of LenoreFin. Use this to verify a successful upgrade.
+
+## Backup & Restore
+
+LenoreFin includes a built-in backup system accessible at **Admin → Backup & Restore**.
+
+### Creating a Backup
+
+Click **Export** to run a full data export. The export generates a JSON archive of all user data (accounts, transactions, tags, reminders, planning data, and options). The file is saved to the `/backups/` volume inside the container.
+
+Click **Download** to retrieve the archive to your local machine.
+
+### Restoring a Backup
+
+Click **Import** and upload a previously exported archive. The restore operation replaces all existing data with the archive contents.
+
+!!! warning
+    Restore is destructive. All current data is replaced by the archive. Back up the current state before restoring.
+
+### Automated Backups
+
+The task worker runs a scheduled daily backup automatically. Backups accumulate in the `lenorefin_bkp` volume. Mount this volume to a persistent location and manage rotation externally (e.g. with a cron job or backup tool).
+
+## Log Viewer
+
+Navigate to **Admin → Logs** to view structured application logs.
+
+| Control | Description |
+|---------|-------------|
+| **Level filter** | Show All, DEBUG, INFO, WARNING, ERROR, or CRITICAL |
+| **Search** | Filter log lines by keyword |
+| **Download bundle** | Download a zip archive of all log files for offline review |
+
+The log viewer is useful for diagnosing errors, reviewing scheduled task output, and monitoring background job activity.
+
+## Payees
+
+Payees are reusable payee records linked to transactions. Navigate to **Admin → Payees** to add, edit, or remove payees.
+
+Payees are optional — transactions can have a free-text description without a linked payee. Linking a payee enables paycheck splitting and payee-level filtering.
+
+## System Messages
+
+System messages are admin-authored notices displayed to all users on the dashboard. Use these to communicate maintenance windows, upgrade notices, or other system-wide alerts.
+
+Manage system messages at **Admin → System Messages**.
+
+## Banks
+
+Banks are managed in **Django Admin → Accounts → Banks**. Each bank has:
+
+- **Bank Name** — display name
+- **Domain** — used to fetch the bank logo from [icon.horse](https://icon.horse)
+- **Logo URL** — auto-populated from the domain; can be overridden manually
+
+If a bank logo doesn't load correctly, verify the domain field and that `https://icon.horse/icon/{domain}` returns a valid image.

--- a/backend/docs/features/planning.md
+++ b/backend/docs/features/planning.md
@@ -1,0 +1,115 @@
+# Budgeting & Planning
+
+The Planning section covers everything forward-looking: balance forecasting, tag-based budgeting, contribution rules, savings goals, retirement modeling, and bill reminders.
+
+## Balance Forecasting
+
+The **Forecast** view projects account balances into the future based on scheduled transactions, reminders, and contribution rules.
+
+- Select an account from the slide-group (desktop) or dropdown (mobile)
+- The chart shows the projected balance over the configured time window
+- The time window is adjustable via the forecast settings
+
+The forecast engine walks forward day by day, applying:
+
+1. Scheduled recurring transactions
+2. Upcoming bill reminders
+3. Contribution rules (savings/investment transfers)
+
+## Budget
+
+The budget is tag-based. Each tag can have a monthly budget allocation.
+
+Navigate to **Planning → Budget** to:
+
+- View actual spending vs. budget by tag for the current period
+- Add or adjust budget amounts per tag
+- See a summary of over- and under-budget categories
+
+Budget calculations use the date range you select and the cleared/pending status filter.
+
+## Contributions
+
+!!! note "Optional Feature"
+    Contributions require `VITE_OPT_FEATURES=true` in your `.env` file.
+
+Contribution rules define automatic recurring transfers between accounts — typically a paycheck-driven savings or investment contribution.
+
+Each rule specifies:
+
+- Source account
+- Destination account
+- Amount or percentage
+- Frequency (weekly, bi-weekly, monthly, etc.)
+
+Contributions appear in the forecast chart and affect projected balances for both the source and destination accounts.
+
+## Savings Goals
+
+Savings goals track progress toward a target balance in a savings or investment account.
+
+Set a goal amount and target date. The goal widget shows:
+
+- Current balance vs. target
+- Required monthly contribution to hit the target on time
+- Progress bar
+
+## Retirement Forecasting
+
+!!! note "Optional Feature"
+    Retirement forecasting requires `VITE_OPT_FEATURES=true` in your `.env` file.
+
+The retirement calculator projects your investment portfolio value at retirement based on:
+
+- Current balance
+- Monthly contribution
+- Expected annual return (%)
+- Years to retirement
+
+The chart shows a growth curve over time.
+
+## Financial Calculator
+
+!!! note "Optional Feature"
+    The calculator requires `VITE_OPT_FEATURES=true` in your `.env` file.
+
+A general-purpose financial calculator with common formulas:
+
+- Loan payment (monthly payment for a given principal, rate, and term)
+- Compound interest (future value of an investment)
+- Savings goal (required monthly savings to reach a target)
+
+## Notes
+
+!!! note "Optional Feature"
+    Notes require `VITE_OPT_FEATURES=true` in your `.env` file.
+
+Free-form notes attached to the Planning section. Use this for budget commentary, financial goals, or any reference text you want alongside your plan.
+
+## Bill Reminders
+
+Reminders track recurring bills so nothing gets missed.
+
+Navigate to **Planning → Reminders** to manage reminders. Each reminder has:
+
+| Field | Description |
+|-------|-------------|
+| **Name** | Bill name (e.g. "Electric Bill") |
+| **Account** | Account to charge when confirmed |
+| **Amount** | Expected bill amount |
+| **Due Date** | Next due date |
+| **Repeat Type** | Monthly, weekly, bi-weekly, quarterly, annual, etc. |
+| **Payee** | Optional payee link |
+| **Tag** | Tag applied to the created transaction |
+
+### Confirming a Reminder
+
+When a reminder is due, it appears in the transaction list as an upcoming item. Click **Confirm** to create the real transaction and advance the reminder to its next due date. The reminder stays active and continues repeating.
+
+### Reminder Repeat Schedule
+
+The repeat engine supports:
+
+- **Fixed interval** — every N days, weeks, months
+- **Day of month** — e.g. the 15th of every month
+- **Last day of month** — handles months of different lengths correctly

--- a/backend/docs/features/planning.md
+++ b/backend/docs/features/planning.md
@@ -1,10 +1,10 @@
 # Budgeting & Planning
 
-The Planning section covers everything forward-looking: balance forecasting, tag-based budgeting, contribution rules, savings goals, retirement modeling, and bill reminders.
+The Planning section covers everything forward-looking: balance forecasting, tag-based budgeting, savings goals, and bill reminders.
 
 ## Balance Forecasting
 
-The **Forecast** view projects account balances into the future based on scheduled transactions, reminders, and contribution rules.
+The **Forecast** view projects account balances into the future based on scheduled transactions and reminders.
 
 - Select an account from the slide-group (desktop) or dropdown (mobile)
 - The chart shows the projected balance over the configured time window
@@ -14,7 +14,6 @@ The forecast engine walks forward day by day, applying:
 
 1. Scheduled recurring transactions
 2. Upcoming bill reminders
-3. Contribution rules (savings/investment transfers)
 
 ## Budget
 
@@ -28,22 +27,6 @@ Navigate to **Planning → Budget** to:
 
 Budget calculations use the date range you select and the cleared/pending status filter.
 
-## Contributions
-
-!!! note "Optional Feature"
-    Contributions are an optional feature that can be enabled in the admin settings.
-
-Contribution rules define automatic recurring transfers between accounts — typically a paycheck-driven savings or investment contribution.
-
-Each rule specifies:
-
-- Source account
-- Destination account
-- Amount or percentage
-- Frequency (weekly, bi-weekly, monthly, etc.)
-
-Contributions appear in the forecast chart and affect projected balances for both the source and destination accounts.
-
 ## Savings Goals
 
 Savings goals track progress toward a target balance in a savings or investment account.
@@ -53,38 +36,6 @@ Set a goal amount and target date. The goal widget shows:
 - Current balance vs. target
 - Required monthly contribution to hit the target on time
 - Progress bar
-
-## Retirement Forecasting
-
-!!! note "Optional Feature"
-    Retirement forecasting is an optional feature that can be enabled in the admin settings.
-
-The retirement calculator projects your investment portfolio value at retirement based on:
-
-- Current balance
-- Monthly contribution
-- Expected annual return (%)
-- Years to retirement
-
-The chart shows a growth curve over time.
-
-## Financial Calculator
-
-!!! note "Optional Feature"
-    The financial calculator is an optional feature that can be enabled in the admin settings.
-
-A general-purpose financial calculator with common formulas:
-
-- Loan payment (monthly payment for a given principal, rate, and term)
-- Compound interest (future value of an investment)
-- Savings goal (required monthly savings to reach a target)
-
-## Notes
-
-!!! note "Optional Feature"
-    Notes are an optional feature that can be enabled in the admin settings.
-
-Free-form notes attached to the Planning section. Use this for budget commentary, financial goals, or any reference text you want alongside your plan.
 
 ## Bill Reminders
 

--- a/backend/docs/features/planning.md
+++ b/backend/docs/features/planning.md
@@ -31,7 +31,7 @@ Budget calculations use the date range you select and the cleared/pending status
 ## Contributions
 
 !!! note "Optional Feature"
-    Contributions require `VITE_OPT_FEATURES=true` in your `.env` file.
+    Contributions are an optional feature that can be enabled in the admin settings.
 
 Contribution rules define automatic recurring transfers between accounts — typically a paycheck-driven savings or investment contribution.
 
@@ -57,7 +57,7 @@ Set a goal amount and target date. The goal widget shows:
 ## Retirement Forecasting
 
 !!! note "Optional Feature"
-    Retirement forecasting requires `VITE_OPT_FEATURES=true` in your `.env` file.
+    Retirement forecasting is an optional feature that can be enabled in the admin settings.
 
 The retirement calculator projects your investment portfolio value at retirement based on:
 
@@ -71,7 +71,7 @@ The chart shows a growth curve over time.
 ## Financial Calculator
 
 !!! note "Optional Feature"
-    The calculator requires `VITE_OPT_FEATURES=true` in your `.env` file.
+    The financial calculator is an optional feature that can be enabled in the admin settings.
 
 A general-purpose financial calculator with common formulas:
 
@@ -82,7 +82,7 @@ A general-purpose financial calculator with common formulas:
 ## Notes
 
 !!! note "Optional Feature"
-    Notes require `VITE_OPT_FEATURES=true` in your `.env` file.
+    Notes are an optional feature that can be enabled in the admin settings.
 
 Free-form notes attached to the Planning section. Use this for budget commentary, financial goals, or any reference text you want alongside your plan.
 

--- a/backend/docs/features/reporting.md
+++ b/backend/docs/features/reporting.md
@@ -1,0 +1,59 @@
+# Reporting
+
+LenoreFin includes a custom report builder that lets you analyze spending and income by tag, account, and time period.
+
+## Report Types
+
+| Type | Description |
+|------|-------------|
+| **Totals** | Aggregate income and spending by tag for a date range |
+| **Year-over-Year Comparison** | Compare the same period across two calendar years side by side |
+
+## Running a Report
+
+Navigate to **Reports** and configure:
+
+| Field | Description |
+|-------|-------------|
+| **Report Type** | Totals or Year-over-Year Comparison |
+| **Date Range** | Start and end date for the report period |
+| **Accounts** | Filter to one or more accounts (leave blank for all) |
+| **Tags** | Filter to specific tags (leave blank for all) |
+| **Status** | Include Pending, Cleared, Reconciled, or any combination |
+
+Click **Run** to execute the report. Results appear immediately in a table below the filter form. No saving required — run as many variations as you like.
+
+## Totals Report
+
+The Totals report groups transactions by tag and shows:
+
+- Total credits (income/deposits)
+- Total debits (spending/withdrawals)
+- Net amount
+
+Rows are grouped by the top-level main tag, with sub-tags expanded in nested rows.
+
+## Year-over-Year Comparison
+
+The comparison report runs the same tag grouping for two separate years and displays them side by side with a delta column showing the change.
+
+Useful for:
+
+- Comparing annual spending in a category
+- Identifying cost increases over time
+- Reviewing income growth
+
+## Filtering by Status
+
+Use the status filter to control which transactions are included:
+
+- **Pending only** — upcoming/unposted items
+- **Cleared** — posted and verified transactions
+- **Reconciled** — finalized transactions
+- **All** — include every status
+
+For accurate historical reporting, filter to Cleared + Reconciled and exclude Pending.
+
+## Printing Reports
+
+Use your browser's **Print** function (`Ctrl+P` / `Cmd+P`) to print or save a report as PDF. The report table is formatted for print with a clean layout.

--- a/backend/docs/features/transactions.md
+++ b/backend/docs/features/transactions.md
@@ -1,0 +1,93 @@
+# Transactions
+
+Transactions are the primary data entry point. Every movement of money — deposits, withdrawals, transfers, credit card charges — is recorded as a transaction.
+
+## Transaction Fields
+
+| Field | Description |
+|-------|-------------|
+| **Account** | The account this transaction belongs to |
+| **Date** | Transaction date |
+| **Description** | Free-text description or payee name |
+| **Amount** | Dollar amount (positive = credit/deposit, negative = debit/charge) |
+| **Transaction Type** | Debit, Credit, or Transfer |
+| **Status** | Pending, Cleared, or Reconciled |
+| **Tags** | One or more tags for categorization |
+| **Notes** | Optional free-text notes |
+| **Attachments** | One or more file attachments (receipts, statements) |
+
+## Transaction List
+
+The transaction list displays all transactions for the selected account. Use the filter bar to narrow results:
+
+| Filter | Description |
+|--------|-------------|
+| **Search** | Full-text search on description |
+| **Status** | Filter by Pending, Cleared, or Reconciled |
+| **Type** | Filter by transaction type |
+| **Tag** | Filter by one or more tags |
+| **Date From / To** | Filter by date range |
+
+Transactions are paginated. The list shows the running balance alongside each transaction.
+
+## Adding Transactions
+
+Click the **+** button to open the Add Transaction form. Fill in the required fields and save. The account balance updates immediately.
+
+## Editing Transactions
+
+Click any transaction row to open the Edit Transaction form. All fields are editable. Full Access users can edit any transaction; Readonly users can only view.
+
+## Bulk Editing
+
+Select multiple transactions using the checkboxes, then use the bulk action toolbar to:
+
+- Change status on all selected
+- Delete selected
+- Apply tags to selected
+
+## CSV Import
+
+Upload a CSV file from your bank's export to import multiple transactions at once. The import pipeline:
+
+1. Parses the CSV
+2. Shows a preview table for review
+3. Applies on save; duplicate detection prevents re-importing already-present transactions
+
+Navigate to **Transactions → Import** to start an import.
+
+## File Attachments
+
+Each transaction can have one or more file attachments. Supported types include PDF, PNG, JPG, and other common document formats.
+
+Attachments are stored in the `lenorefin_media` volume and linked to the transaction record. Click the paperclip icon on a transaction to view or add attachments.
+
+## Tags
+
+Tags are the primary categorization mechanism. The tag hierarchy is:
+
+```
+Main Tag  (e.g. "Housing")
+  └── Sub Tag  (e.g. "Rent")
+        └── Tag  (e.g. "Apartment 4B")
+```
+
+Assign one or more tags to each transaction. Tags drive budgeting and reporting.
+
+## Paycheck Transactions
+
+Paycheck transactions are a special transaction type that auto-splits a paycheck deposit into its component parts (gross pay, taxes, deductions). Configure paycheck rules in **Administration → Payees** and use the **Add Paycheck** shortcut to record a paycheck with all splits in one step.
+
+## Reminders
+
+Recurring bill reminders appear in the transaction list as upcoming items. Confirm a reminder to create the real transaction. See [Budgeting & Planning](planning.md) for reminder configuration.
+
+## Statuses
+
+| Status | Meaning |
+|--------|---------|
+| **Pending** | Transaction entered but not yet posted by the bank |
+| **Cleared** | Posted and verified against the bank statement |
+| **Reconciled** | Included in a completed reconciliation |
+
+Use status filtering in reports to exclude pending transactions from cleared totals.

--- a/backend/docs/getting-started.md
+++ b/backend/docs/getting-started.md
@@ -1,0 +1,163 @@
+# Installation
+
+LenoreFin runs as a single Docker image bundling the frontend, backend, nginx, and task worker. You need Docker, Docker Compose, a PostgreSQL database, and a Redis instance — all provided by the included Compose file.
+
+## Prerequisites
+
+- [Docker](https://www.docker.com/get-started)
+- [Docker Compose](https://docs.docker.com/compose/install/)
+
+## Step 1 — Create a `.env` file
+
+Create a `.env` file in the directory where you'll run Compose. Adjust all values for your environment:
+
+```env
+DEBUG=0
+SECRET_KEY=change-me-to-a-long-random-string
+DJANGO_ALLOWED_HOSTS=localhost
+CSRF_TRUSTED_ORIGINS=http://localhost
+
+SQL_ENGINE=django.db.backends.postgresql
+SQL_DATABASE=lenorefin
+SQL_USER=lenorefinuser
+SQL_PASSWORD=somepassword
+SQL_HOST=db
+SQL_PORT=5432
+DATABASE=postgres
+
+DJANGO_SUPERUSER_PASSWORD=supervisorpassword
+DJANGO_SUPERUSER_EMAIL=someone@somewhere.com
+DJANGO_SUPERUSER_USERNAME=supervisor
+
+VITE_API_KEY=someapikey
+TIMEZONE=America/New_York
+
+# Set to "true" to enable Contributions, Notes, and Calculator in the Planning menu
+VITE_OPT_FEATURES=false
+```
+
+See [Configuration](configuration.md) for a full reference of all available variables.
+
+## Step 2 — Create a `docker-compose.yml` file
+
+```yaml
+services:
+  app:
+    image: novanglus96/lenorefin:latest
+    container_name: lenorefin
+    command: /home/app/web/start.app.sh
+    volumes:
+      - lenorefin_static:/home/app/web/staticfiles
+      - lenorefin_media:/home/app/web/mediafiles
+      - lenorefin_bkp:/backups/
+    ports:
+      - "8080:80"
+    depends_on:
+      - db
+      - redis
+    networks:
+      - lenorefin
+    env_file:
+      - ./.env
+    environment:
+      - DEBUG=0
+
+  db:
+    image: postgres:15
+    container_name: lenorefin_db
+    volumes:
+      - lenorefin_postgres:/var/lib/postgresql/data/
+      - lenorefin_bkp:/backups/
+    networks:
+      - lenorefin
+    env_file:
+      - ./.env
+    environment:
+      - TZ=UTC
+      - POSTGRES_USER=${SQL_USER}
+      - POSTGRES_PASSWORD=${SQL_PASSWORD}
+      - POSTGRES_DB=${SQL_DATABASE}
+
+  redis:
+    image: redis:7-alpine
+    container_name: lenorefin_redis
+    command: ["redis-server", "--appendonly", "yes"]
+    networks:
+      - lenorefin
+    restart: unless-stopped
+
+networks:
+  lenorefin:
+
+volumes:
+  lenorefin_postgres:
+  lenorefin_static:
+  lenorefin_media:
+  lenorefin_bkp:
+```
+
+## Step 3 — Start the application
+
+```bash
+docker compose up -d
+```
+
+Open your browser at `http://localhost:8080`. Log in with the superuser credentials you set in `.env`.
+
+---
+
+## Migrating from pre-v1.4
+
+Version 1.4 consolidates the old multi-container setup (`frontend`, `backend`, `worker`, `nginx`) into a single `app` container.
+
+### 1. Back up your data
+
+```bash
+docker exec lenorefin_backend python manage.py export_user_data
+```
+
+Copy the backup file to a safe location before proceeding.
+
+### 2. Stop old containers
+
+```bash
+docker compose down
+```
+
+### 3. Replace your `docker-compose.yml`
+
+Use the new 3-service format above. Remove the old `frontend`, `backend`, `worker`, and `nginx` service definitions.
+
+### 4. Update `.env`
+
+Add the new variable if it isn't already present:
+
+```env
+VITE_OPT_FEATURES=false
+```
+
+### 5. Rename volumes (if needed)
+
+The old setup used volume names ending in `_volume` (e.g. `lenorefin_postgres_data`). The new names drop that suffix. Migrate data if you want to preserve it:
+
+```bash
+docker run --rm \
+  -v lenorefin_postgres_data:/from \
+  -v lenorefin_postgres:/to \
+  alpine sh -c "cp -av /from/. /to/"
+```
+
+Repeat for `lenorefin_static_volume` → `lenorefin_static` and `lenorefin_media_volume` → `lenorefin_media`.
+
+Alternatively, restore from the backup you took in step 1 via **Admin → Backup & Restore** after the new stack is running.
+
+### 6. Pull and start
+
+```bash
+docker compose pull
+docker compose up -d
+```
+
+### 7. Verify
+
+Open the app. Check **Admin → Version** to confirm you are on v1.4 or later.

--- a/backend/docs/getting-started.md
+++ b/backend/docs/getting-started.md
@@ -32,8 +32,6 @@ DJANGO_SUPERUSER_USERNAME=supervisor
 VITE_API_KEY=someapikey
 TIMEZONE=America/New_York
 
-# Set to "true" to enable Contributions, Notes, and Calculator in the Planning menu
-VITE_OPT_FEATURES=false
 ```
 
 See [Configuration](configuration.md) for a full reference of all available variables.
@@ -130,11 +128,7 @@ Use the new 3-service format above. Remove the old `frontend`, `backend`, `worke
 
 ### 4. Update `.env`
 
-Add the new variable if it isn't already present:
-
-```env
-VITE_OPT_FEATURES=false
-```
+Review your `.env` file and remove any variables that are no longer needed. The new setup does not require any additional variables beyond those listed in [Configuration](configuration.md).
 
 ### 5. Rename volumes (if needed)
 

--- a/backend/docs/index.md
+++ b/backend/docs/index.md
@@ -1,375 +1,45 @@
-<!-- Improved compatibility of back to top link: See: https://github.com/othneildrew/Best-README-Template/pull/73 -->
-<a name="readme-top"></a>
-<!--
-*** Thanks for checking out the Best-README-Template. If you have a suggestion
-*** that would make this better, please fork the repo and create a pull request
-*** or simply open an issue with the tag "enhancement".
-*** Don't forget to give the project a star!
-*** Thanks again! Now go create something AMAZING! :D
--->
+# LenoreFin
 
-
-
-<!-- PROJECT SHIELDS -->
-<!--
-*** I'm using markdown "reference style" links for readability.
-*** Reference links are enclosed in brackets [ ] instead of parentheses ( ).
-*** See the bottom of this document for the declaration of the reference variables
-*** for contributors-url, forks-url, etc. This is an optional, concise syntax you may use.
-*** https://www.markdownguide.org/basic-syntax/#reference-style-links
--->
-[![Contributors][contributors-shield]][contributors-url]
-[![Forks][forks-shield]][forks-url]
-[![Stargazers][stars-shield]][stars-url]
-[![Issues][issues-shield]][issues-url]
-[![MIT License][license-shield]][license-url]
-[![LinkedIn][linkedin-shield]][linkedin-url]
-
-
-
-<!-- PROJECT LOGO -->
-<br />
 <div align="center">
-  <a href="https://github.com/Novanglus96/LenoreFin">
-    <img src="https://novanglus96.github.io/LenoreFin/images/logov2.png" alt="Logo" height="40">
-  </a>
-
-  <p align="center">
-    An advanced finance tracker.
-    <br />
-    <a href="https://novanglus96.github.io/LenoreFin"><strong>Explore the docs »</strong></a>
-    <br />
-    <br />
-    <a href="https://github.com/Novanglus96/LenoreFin/issues/new?template=bug_report.md">Report Bug</a>
-    ·
-    <a href="https://github.com/Novanglus96/LenoreFin/issues/new?template=feature_request.md">Request Feature</a>
-  </p>
+  <img src="images/logov2.png" alt="LenoreFin" height="60">
+  <p><em>A self-hosted personal finance tracker built for privacy and control.</em></p>
 </div>
 
-
-
-<!-- ABOUT THE PROJECT -->
-## About The Project
-
-Screenshots - COMING SOON
-<!--[![Product Name Screen Shot][product-screenshot]]-->
-
-LenoreFin began as a simple Excel spreadsheet I used to manage my family's budget. But over time, I realized no existing tools gave me the control, flexibility, and privacy I wanted. So I built LenoreFin—a personal finance tracker that puts you in charge.
-
-Designed for self-hosting, LenoreFin keeps your financial data completely local, with no third-party syncing or hidden services. It includes tools for tracking cash flow, setting up custom budgets, tagging transactions, planning for retirement or big purchases, getting bill reminders, and even forecasting account balances. Whether you're budgeting for groceries or planning a 10-year savings goal, LenoreFin helps you see the full picture—on your terms.
-
-<p align="right">(<a href="#readme-top">back to top</a>)</p>
-
-
- 
-### Built With
-
-* [![Django][Django]][Django-url]
-* [![Vue][Vue.js]][Vue-url]
-* [![Docker][Docker]][Docker-url]
-
-<p align="right">(<a href="#readme-top">back to top</a>)</p>
-
-
-
-<!-- GETTING STARTED -->
-## Getting Started
-
-Welcome to LenoreFin! This guide will help you set up and run the application using Docker and Docker Compose.
-
-### Prerequisites
-
-Make sure you have the following installed on your system:
-
-* [Docker](https://www.docker.com/get-started)
-* [Docker Compose](https://docs.docker.com/compose/install/)
-
-<!-- INSTALLATION -->
-### Step 1: Create a `.env` File
-
-Create a `.env` file in the root directory of the project. This file will store environment variables required to run the application. Below is an example of the variables you need to define:
-
-```env
-DEBUG=0
-SECRET_KEY=mysupersecretkey
-DJANGO_ALLOWED_HOSTS=localhost
-CSRF_TRUSTED_ORIGINS=http://localhost
-SQL_ENGINE=django.db.backends.postgresql
-SQL_DATABASE=lenorefin
-SQL_USER=lenorefinuser
-SQL_PASSWORD=somepassword
-SQL_HOST=db
-SQL_PORT=5432
-DATABASE=postgres
-DJANGO_SUPERUSER_PASSWORD=suepervisorpassword
-DJANGO_SUPERUSER_EMAIL=someone@somewhere.com
-DJANGO_SUPERUSER_USERNAME=supervisor
-VITE_API_KEY=someapikey
-TIMEZONE=America/New_York
-```
-
-Adjust these values according to your environment and application requirements.
-
-### Step 2: Create a `docker-compose.yml` File
-
-Create a `docker-compose.yml` file in the root directory of the project. Below is an example configuration:
-
-```yaml
-services:
-  frontend:
-    image: novanglus96/lenorefin_frontend:latest
-    container_name: lenorefin_frontend
-    networks:
-      - lenorefin
-    restart: unless-stopped
-    expose:
-      - 80
-    env_file:
-      - ./.env
-  backend:
-    image: novanglus96/lenorefin_backend:latest
-    container_name: lenorefin_backend
-    command: /home/app/web/start.sh
-    volumes:
-      - lenorefin_static_volume:/home/app/web/staticfiles
-      - lenorefin_media_volume:/home/app/web/mediafiles
-    expose:
-      - 8000
-    depends_on:
-      - db
-    networks:
-      - lenorefin
-    env_file:
-      - ./.env
-  db:
-    image: postgres:15
-    container_name: lenorefin_db
-    volumes:
-      - lenorefin_postgres_data:/var/lib/postgresql/data/
-    env_file:
-      - ./.env.db
-    networks:
-      - lenorefin
-  nginx:
-    image: novanglus96/lenoreapps_proxy:latest
-    container_name: lenorefin_nginx
-    ports:
-      - "8080:80"
-    volumes:
-      - lenorefin_static_volume:/home/app/web/staticfiles
-      - lenorefin_media_volume:/home/app/web/mediafiles
-    depends_on:
-      - backend
-      - frontend
-    networks:
-      - lenorefin
-
-networks:
-  lenorefin:
-
-volumes:
-  lenorefin_postgres_data:
-    external: true
-  lenorefin_static_volume:
-    external: true
-  lenorefin_media_volume:
-    external: true
-```
-
-### Step 3: Run the Application
-
-1. Start the services:
-
-   ```bash
-   docker compose up -d
-   ```
-
-2. Access the application in your browser at `http://localhost:8080`.
-
-### Notes
-
-* Adjust exposed ports as needed for your environment.
-* If you encounter any issues, ensure your `.env` file has the correct values and your Docker and Docker Compose installations are up to date.
-
-Enjoy using LenoreFin!
-
-<p align="right">(<a href="#readme-top">back to top</a>)</p>
-
-
-
-<!-- USAGE EXAMPLES -->
-## Roadmap
-
-- [ ] v1.2 Release
-  - [ ] Credit Card Bill Calculations
-  - [ ] Loading Screen on app load
-  - [ ] Interest Tracking On Loans 
-- [ ] Financial Wizard
-
-See the [open issues](https://github.com/Novanglus96/LenoreFin/issues) for a full list of proposed features (and known issues).
-
-<p align="right">(<a href="#readme-top">back to top</a>)</p>
-
-
-
-<!-- CONTRIBUTING -->
-## Contributing
-
-Contributions are what make the open source community such an amazing place to learn, inspire, and create. Any contributions you make are **greatly appreciated**. Please follow these steps and guidelines to help us maintain a smooth development process.
-
-### 1. Fork the Repository
-
-- Click the **Fork** button at the top-right of this repository to create your own copy.
-- Clone your fork locally.
-
-### 2. Branch Naming
-Create branches following this pattern:
-
-- **Features**: feature/**branch-name** - *For new features or enhancements*.
-- **Fixes**: fix/**branch-name** - *For bug fixes or patches*.
-
-### 3. Pull Request Targets
-Submit pull requests to the appropriate branch based on the stability of your changes:
-
-|Target Branch|Purpose|
-|-------------|-------|
-|main|	Production-ready changes for release.|
-|rc|	Release candidates for staging releases.|
-|alpha|	Experimental and unstable changes.|
-|beta|	More stable than alpha, for broader testing.|
-
-*PRs to main and rc branches are for finalized changes intended for the next release.
-PRs to alpha and beta are for testing and experimental work.*
-
-### 4. Commit Message Format
-We use semantic commit messages to automate changelog and versioning.
-
-Format:
-
-```cpp
-<type>(optional scope): <short description>
-```
-|Common types|       | 
-|-----|--------------|
-|feat:| A new feature|
-|fix: | A bug fix    |
-|chore:| Changes to build process or auxiliary tools|
-|docs:| Documentation only|
-|style:| Formatting, missing semicolons, etc; no code change|
-|refactor:| Code change that neither fixes a bug nor adds a feature|
-|perf:| Performance improvements|
-|test:| Adding or fixing tests|
-
-**Breaking changes**: Add ! after type or scope
-
-```makefile
-feat!: drop support for Node 10
-fix(api)!: change endpoint response format
-```
-
-Examples:
-
-- feat: add user profile page
-- fix(auth): handle expired tokens gracefully
-- chore: update dependencies
-- perf: optimize image loading
-
-### 5. Pull Request Checklist
-Before submitting your PR, please ensure:
-
-- Your branch is up to date with the target branch.
-- Your code passes all tests and linters.
-- You have added or updated tests if applicable.
-- Relevant documentation has been added or updated.
-- Your PR description clearly explains your changes and references related issues.
-
-### 6. Testing Changes
-Please test your changes locally or in a staging environment before opening a PR. Use alpha or beta branches for testing experimental changes.
-
-
-<p align="right">(<a href="#readme-top">back to top</a>)</p>
-
-
-
-<!-- LICENSE -->
-## License
-
-Distributed under the MIT License. See `LICENSE.txt` for more information.
-
-<p align="right">(<a href="#readme-top">back to top</a>)</p>
-
-
-## Support
-
-<a href="https://www.buymeacoffee.com/novanglus" target="_blank"><img src="https://www.buymeacoffee.com/assets/img/custom_images/purple_img.png" alt="Buy Me A Coffee" style="height: 41px !important;width: 174px !important;box-shadow: 0px 3px 2px 0px rgba(190, 190, 190, 0.5) !important;-webkit-box-shadow: 0px 3px 2px 0px rgba(190, 190, 190, 0.5) !important;" ></a>
-
-<p>Or</p> 
-
-<a href="https://www.patreon.com/novanglus">
-    <img src="https://c5.patreon.com/external/logo/become_a_patron_button@2x.png" width="160">
-</a>
-
-<!-- CONTACT -->
-## Contact
-
-John Adams - Lenore.Apps@gmail.com
-
-Project Link: [https://github.com/Novanglus96/LenoreFin](https://github.com/Novanglus96/LenoreFin)
-
-<p align="right">(<a href="#readme-top">back to top</a>)</p>
-
-<!-- ACKNOWLEDGMENTS -->
-## Acknowledgements
-
-A heartfelt thanks to our Patrons for their generous support! Your contributions help us maintain and improve this project.
-
-### ⭐ Thank You to Our Supporters:
-
-![Red Supporter Badge](https://img.shields.io/badge/Eleanor-E41B17?style=for-the-badge&logo=patreon&logoColor=gray)
-![Red Supporter Badge](https://img.shields.io/badge/Danielle-E41B17?style=for-the-badge&logo=patreon&logoColor=gray)
-![BuyMeACoffee Supporter Badge](https://img.shields.io/badge/SuperDev-white?style=for-the-badge&logo=buymeacoffee&logoColor=black)
-<!--![Gold Supporter Badge](https://img.shields.io/badge/Eleanor-gold?style=for-the-badge&logo=patreon&logoColor=gray)-->
-<!--![Silver Supporter Badge](https://img.shields.io/badge/Jane_Smith-silver?style=for-the-badge&logo=patreon&logoColor=gray)-->
-<!--![BuyMeACoffee Supporter Badge](https://img.shields.io/badge/Jane_Smith-white?style=for-the-badge&logo=buymeacoffee&logoColor=black)-->
-
-Want to see your name here? Support us on [Patreon](https://www.patreon.com/novanglus) to join our amazing community and shape the future of LenoreFin!
-
-<p align="right">(<a href="#readme-top">back to top</a>)</p>
-
-
-
-<!-- MARKDOWN LINKS & IMAGES -->
-<!-- https://www.markdownguide.org/basic-syntax/#reference-style-links -->
-[contributors-shield]: https://img.shields.io/github/contributors/Novanglus96/LenoreFin?style=for-the-badge
-[contributors-url]: https://github.com/Novanglus96/LenoreFin/graphs/contributors
-[forks-shield]: https://img.shields.io/github/forks/Novanglus96/LenoreFin?style=for-the-badge
-[forks-url]: https://github.com/Novanglus96/LenoreFin/forks
-[stars-shield]: https://img.shields.io/github/stars/Novanglus96/LenoreFin?style=for-the-badge
-[stars-url]: https://github.com/Novanglus96/LenoreFin/stargazers
-[issues-shield]: https://img.shields.io/github/issues/Novanglus96/LenoreFin?style=for-the-badge
-[issues-url]: https://github.com/Novanglus96/LenoreFin/issues
-[license-shield]: https://img.shields.io/badge/License-MIT-yellow.svg?style=for-the-badge
-[license-url]: https://github.com/Novanglus96/LenoreFin/blob/main/LICENSE
-[linkedin-shield]: https://img.shields.io/badge/-LinkedIn-black.svg?style=for-the-badge&logo=linkedin&colorB=555
-[linkedin-url]: https://www.linkedin.com/in/johnmadamsjr
-[product-screenshot]: images/LenoreFin_Screenshot.png
-[Next.js]: https://img.shields.io/badge/next.js-000000?style=for-the-badge&logo=nextdotjs&logoColor=white
-[Next-url]: https://nextjs.org/
-[React.js]: https://img.shields.io/badge/React-20232A?style=for-the-badge&logo=react&logoColor=61DAFB
-[React-url]: https://reactjs.org/
-[Vue.js]: https://img.shields.io/badge/Vue.js-35495E?style=for-the-badge&logo=vuedotjs&logoColor=4FC08D
-[Vue-url]: https://vuejs.org/
-[Angular.io]: https://img.shields.io/badge/Angular-DD0031?style=for-the-badge&logo=angular&logoColor=white
-[Angular-url]: https://angular.io/
-[Svelte.dev]: https://img.shields.io/badge/Svelte-4A4A55?style=for-the-badge&logo=svelte&logoColor=FF3E00
-[Svelte-url]: https://svelte.dev/
-[Laravel.com]: https://img.shields.io/badge/Laravel-FF2D20?style=for-the-badge&logo=laravel&logoColor=white
-[Laravel-url]: https://laravel.com
-[Bootstrap.com]: https://img.shields.io/badge/Bootstrap-563D7C?style=for-the-badge&logo=bootstrap&logoColor=white
-[Bootstrap-url]: https://getbootstrap.com
-[JQuery.com]: https://img.shields.io/badge/jQuery-0769AD?style=for-the-badge&logo=jquery&logoColor=white
-[JQuery-url]: https://jquery.com 
-[Django]: https://img.shields.io/badge/django-092E20?style=for-the-badge&logo=django&logoColor=white
-[Django-url]: https://www.djangoproject.com/
-[Docker]: https://img.shields.io/badge/Docker-2496ED?style=for-the-badge&logo=docker&logoColor=white
-[Docker-url]: https://www.docker.com/
+---
+
+LenoreFin began as a simple spreadsheet and grew into a full-featured finance tracker designed for self-hosting. Your data stays on your own infrastructure — no third-party syncing, no telemetry, no subscription fees.
+
+## Features at a Glance
+
+| Area | What you get |
+|------|-------------|
+| **Accounts** | Checking, savings, credit cards, investments, loans; parent accounts for combined views; bank logo display |
+| **Transactions** | Full CRUD, bulk editing, CSV import, file attachments, tag-based categorization, filtering |
+| **Credit Cards** | Statement cycle tracking, due dates, minimum payment calculation, rewards tracking |
+| **Forecasting** | Balance forecast chart per account; configurable time window |
+| **Budgeting** | Tag-based budget, contribution rules, savings goal tracking |
+| **Planning** | Retirement forecasting, financial calculator, notes |
+| **Reminders** | Recurring bill reminders with customizable repeat schedules |
+| **Reporting** | Totals and year-over-year comparison reports; filterable by account, tag, and status |
+| **Logging** | Structured log viewer with level filtering and downloadable log bundle |
+| **Auth** | Full Access and Readonly permission groups; API key authentication |
+| **PWA** | Installable as a Progressive Web App; offline read-only mode |
+| **Self-hosted** | Single Docker image; PostgreSQL + Redis; no external dependencies |
+
+## Stack
+
+- **Backend**: Django 5.2 + Django Ninja (REST API) + PostgreSQL + Redis
+- **Frontend**: Vue 3 + Vuetify 3 + Pinia + TanStack Query
+- **Task Queue**: django-q2 (scheduled tasks and async jobs)
+- **Deployment**: Single Docker image with nginx + gunicorn + supervisord + worker
+
+## Quick Start
+
+See the [Installation guide](getting-started.md) to get up and running with Docker Compose in minutes.
+
+## Links
+
+- [GitHub Repository](https://github.com/Novanglus96/LenoreFin)
+- [Report a Bug](https://github.com/Novanglus96/LenoreFin/issues/new?template=bug_report.md)
+- [Request a Feature](https://github.com/Novanglus96/LenoreFin/issues/new?template=feature_request.md)
+- [Support on Patreon](https://www.patreon.com/novanglus)

--- a/backend/docs/index.md
+++ b/backend/docs/index.md
@@ -17,8 +17,7 @@ LenoreFin began as a simple spreadsheet and grew into a full-featured finance tr
 | **Transactions** | Full CRUD, bulk editing, CSV import, file attachments, tag-based categorization, filtering |
 | **Credit Cards** | Statement cycle tracking, due dates, minimum payment calculation, rewards tracking |
 | **Forecasting** | Balance forecast chart per account; configurable time window |
-| **Budgeting** | Tag-based budget, contribution rules, savings goal tracking |
-| **Planning** | Retirement forecasting, financial calculator, notes |
+| **Budgeting** | Tag-based budget, savings goal tracking |
 | **Reminders** | Recurring bill reminders with customizable repeat schedules |
 | **Reporting** | Totals and year-over-year comparison reports; filterable by account, tag, and status |
 | **Logging** | Structured log viewer with level filtering and downloadable log bundle |

--- a/backend/docs/models.md
+++ b/backend/docs/models.md
@@ -1,0 +1,257 @@
+# Models
+
+This page is a reference for the core Django models in LenoreFin. Auto-generated fields (`id`, `created_at`, `updated_at`) are omitted unless notable.
+
+## Accounts
+
+### AccountType
+
+Classifies an account (Checking, Savings, Credit Card, Investment, Loan).
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `account_type` | CharField | Display name, unique |
+| `color` | CharField | Hex color for UI display |
+| `icon` | CharField | MDI icon name |
+
+### Bank
+
+A financial institution linked to accounts.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `bank_name` | CharField | Display name, unique |
+| `logo_url` | CharField | Optional; populated from `icon.horse` |
+
+### Account
+
+The core account entity. Represents a real-world financial account.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `account_name` | CharField | Unique |
+| `account_type` | FK → AccountType | |
+| `bank` | FK → Bank | |
+| `opening_balance` | DecimalField | |
+| `active` | BooleanField | Inactive accounts hidden from nav |
+| `open_date` | DateField | |
+| `credit_limit` | DecimalField | Credit cards only |
+| `statement_balance` | DecimalField | Balance from last statement |
+| `statement_day` | IntegerField | Day of month statement closes |
+| `due_day` | IntegerField | Day of month payment is due |
+| `statement_cycle_length` | IntegerField | Billing cycle length |
+| `statement_cycle_period` | CharField | `D` (days), `M` (months) |
+| `calculate_payments` | BooleanField | Auto-calculate minimum payment |
+| `payment_strategy` | CharField | `F` (full balance) or `M` (minimum) |
+| `calculate_interest` | BooleanField | Auto-post interest earned |
+| `annual_rate` | DecimalField | Annual interest rate (%) |
+| `parent_account` | FK → Account (self) | Optional parent for combined view |
+
+### Reward
+
+A credit card reward entry earned on a specific date.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `reward_account` | FK → Account | |
+| `reward_date` | DateField | |
+| `reward_amount` | DecimalField | |
+
+---
+
+## Transactions
+
+### TransactionType
+
+Classification for a transaction's direction (Debit, Credit, Transfer).
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `transaction_type` | CharField | Unique |
+
+### TransactionStatus
+
+A transaction's posting status (Pending, Cleared, Reconciled).
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `transaction_status` | CharField | Unique |
+
+### Transaction
+
+A single financial transaction between two accounts.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `transaction_date` | DateField | |
+| `total_amount` | DecimalField | |
+| `description` | CharField | Payee or free-text description |
+| `memo` | TextField | Optional notes |
+| `transaction_type` | FK → TransactionType | |
+| `status` | FK → TransactionStatus | |
+| `source_account` | FK → Account | Money leaves here |
+| `destination_account` | FK → Account | Money arrives here |
+| `paycheck` | FK → Paycheck | Optional; set for paycheck splits |
+| `check_number` | IntegerField | Optional |
+
+### TransactionDetail
+
+A tagged line item within a transaction. A single transaction may have multiple details splitting the total across different tags.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `transaction` | FK → Transaction | |
+| `tag` | FK → Tag | |
+| `detail_amt` | DecimalField | Amount for this line item |
+| `full_toggle` | BooleanField | If true, detail represents the full transaction amount |
+
+### TransactionImage
+
+A file attachment linked to a transaction (receipt, statement, etc.).
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `transaction` | FK → Transaction | |
+| `image` | FileField | Stored in `lenorefin_media` |
+
+### Paycheck
+
+Itemized paycheck deductions linked to a transaction.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `gross` | DecimalField | |
+| `net` | DecimalField | |
+| `taxes` | DecimalField | |
+| `health` | DecimalField | Health insurance |
+| `pension` | DecimalField | |
+| `fsa` | DecimalField | Flexible spending account |
+| `dca` | DecimalField | Dependent care account |
+| `union_dues` | DecimalField | |
+| `four_fifty_seven_b` | DecimalField | 457(b) retirement contribution |
+| `payee` | FK → Payee | |
+
+---
+
+## Tags
+
+### TagType
+
+Classifies tags by type (Expense, Income, Transfer).
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `tag_type` | CharField | Unique |
+
+### MainTag
+
+Top-level tag category (e.g. "Housing", "Food").
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `tag_name` | CharField | Unique |
+| `tag_type` | FK → TagType | |
+
+### SubTag
+
+Second-level tag (e.g. "Rent" under "Housing").
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `tag_name` | CharField | Unique |
+| `tag_type` | FK → TagType | |
+
+### Tag
+
+The composite tag entity combining a MainTag and optional SubTag. This is the tag you assign to transactions.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `parent` | FK → MainTag | |
+| `child` | FK → SubTag | Optional |
+| `tag_type` | FK → TagType | |
+
+---
+
+## Planning
+
+### Budget
+
+A spending limit for transactions matching specific tags.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `name` | CharField | Unique |
+| `tag_ids` | CharField | Comma-separated tag IDs |
+| `amount` | DecimalField | Budget cap |
+| `roll_over` | BooleanField | Carry unused balance to next period |
+| `roll_over_amt` | DecimalField | Current rolled-over balance |
+| `repeat` | FK → Repeat | How often the budget resets |
+| `start_day` | DateField | Start of current budget period |
+| `next_start` | DateField | Start of next budget period |
+| `active` | BooleanField | |
+| `widget` | BooleanField | Show on dashboard widget |
+
+### Contribution
+
+A recurring paycheck contribution rule.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `contribution` | CharField | Unique name |
+| `per_paycheck` | DecimalField | Amount per paycheck |
+| `cap` | DecimalField | Annual contribution cap |
+| `active` | BooleanField | |
+
+### Note
+
+A free-form planning note.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `note_text` | CharField | |
+| `note_date` | DateField | |
+
+---
+
+## Reminders
+
+### Repeat
+
+A recurrence interval combining days, weeks, months, and years.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `repeat_name` | CharField | Unique display name |
+| `days` | IntegerField | |
+| `weeks` | IntegerField | |
+| `months` | IntegerField | |
+| `years` | IntegerField | |
+
+### Reminder
+
+A scheduled recurring transaction.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `description` | CharField | |
+| `amount` | DecimalField | |
+| `transaction_type` | FK → TransactionType | |
+| `reminder_source_account` | FK → Account | |
+| `reminder_destination_account` | FK → Account | Optional |
+| `tag` | FK → Tag | Applied to confirmed transaction |
+| `repeat` | FK → Repeat | Recurrence interval |
+| `start_date` | DateField | First occurrence |
+| `next_date` | DateField | Next upcoming occurrence |
+| `end_date` | DateField | Optional end date |
+| `auto_add` | BooleanField | Auto-create transactions without manual confirmation |
+| `memo` | TextField | Optional notes |
+
+### ReminderExclusion
+
+Marks a specific date as excluded from a reminder's recurrence.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `reminder` | FK → Reminder | |
+| `exclude_date` | DateField | |

--- a/backend/docs/models.md
+++ b/backend/docs/models.md
@@ -192,26 +192,6 @@ A spending limit for transactions matching specific tags.
 | `active` | BooleanField | |
 | `widget` | BooleanField | Show on dashboard widget |
 
-### Contribution
-
-A recurring paycheck contribution rule.
-
-| Field | Type | Notes |
-|-------|------|-------|
-| `contribution` | CharField | Unique name |
-| `per_paycheck` | DecimalField | Amount per paycheck |
-| `cap` | DecimalField | Annual contribution cap |
-| `active` | BooleanField | |
-
-### Note
-
-A free-form planning note.
-
-| Field | Type | Notes |
-|-------|------|-------|
-| `note_text` | CharField | |
-| `note_date` | DateField | |
-
 ---
 
 ## Reminders

--- a/backend/mkdocs.yml
+++ b/backend/mkdocs.yml
@@ -1,11 +1,20 @@
 site_name: LenoreFin
-site_description: An advanced financial tracker.
+site_description: A self-hosted personal finance tracker.
 site_author: John Adams
 site_url: https://novanglus96.github.io/LenoreFin/
 repo_url: https://github.com/Novanglus96/LenoreFin
 copyright: 2026 John Adams
 nav:
   - Home: index.md
+  - Getting Started:
+      - Installation: getting-started.md
+      - Configuration: configuration.md
+  - Features:
+      - Accounts: features/accounts.md
+      - Transactions: features/transactions.md
+      - Budgeting & Planning: features/planning.md
+      - Reporting: features/reporting.md
+      - Administration: features/administration.md
   - Reference:
       - Models: models.md
       - API: api.md
@@ -13,24 +22,28 @@ theme:
   name: material
   palette:
     - scheme: default
-      primary: indigo
-      accent: indigo
-      toggle:
-        icon: material/weather-sunny
-        name: Switch to light mode
-    - scheme: slate
-      primary: indigo
-      accent: indigo
+      primary: teal
+      accent: teal
       toggle:
         icon: material/weather-night
         name: Switch to dark mode
+    - scheme: slate
+      primary: teal
+      accent: teal
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.top
+    - search.highlight
   custom_dir: docs/overrides
 plugins:
   - search
   - mkdocstrings:
       handlers:
         python:
-          #docstring_style: google
           options:
             show_root_heading: true
             show_root_full_path: false
@@ -39,13 +52,15 @@ plugins:
             show_defaults: true
             members:
               - __str__
-          #rendering:
-          #  show_defaults: true
 markdown_extensions:
   - attr_list
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
   - pymdownx.emoji:
       emoji_index: !!python/name:material.extensions.emoji.twemoji
       emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - tables
 extra:
   version:
     provider: mike

--- a/backend/reminders/api/schemas/reminder.py
+++ b/backend/reminders/api/schemas/reminder.py
@@ -29,16 +29,16 @@ class ReminderIn(Schema):
 # The class ReminderOut is a schema for representing Reminders.
 class ReminderOut(Schema):
     id: int
-    tag: TagOut
+    tag: Optional[TagOut] = None
     amount: AmountDecimal
-    reminder_source_account: AccountOut
+    reminder_source_account: Optional[AccountOut] = None
     reminder_destination_account: Optional[AccountOut] = None
     description: str
-    transaction_type: TransactionTypeOut
+    transaction_type: Optional[TransactionTypeOut] = None
     start_date: date
     next_date: Optional[date] = None
     end_date: Optional[date] = None
-    repeat: RepeatOut
+    repeat: Optional[RepeatOut] = None
     auto_add: bool
     memo: Optional[str] = None
 

--- a/backend/transactions/management/commands/load_caches.py
+++ b/backend/transactions/management/commands/load_caches.py
@@ -57,6 +57,8 @@ class Command(BaseCommand):
 
 
 def reset_ids_for_model(app_label, model_label):
+    if connection.vendor != "postgresql":
+        return
     table = f"{app_label}_{model_label}"
     with connection.cursor() as cursor:
         cursor.execute(f"ALTER SEQUENCE {table}_id_seq RESTART WITH 1")

--- a/backend/transactions/services/transactions_and_balances.py
+++ b/backend/transactions/services/transactions_and_balances.py
@@ -49,16 +49,13 @@ def get_account_transactions_and_balances(
     cleared_only: Optional[bool] = False,
 ) -> Tuple[List[TransactionOut], Decimal]:
     """
-    The function `get_transactions_by_account` returns a list of
-    transactions, temporary reminder transactions, etc.
+    Returns transactions and running balance for a single account up to end_date.
 
-    Args:
-        start_date (Date): The first date of the transactions.
-        end_date (Date): The last date of the transactions.
-        account (Int): The ID of the account to get transactions for.
-
-    Returns:
-        transactions: List of transaction objects
+    Delegates to get_parent_account_transactions_and_balances when account_id
+    belongs to a parent account. Skips the Redis cache when forecast=True so
+    simulated forecast transactions are never served stale. Simulated transaction
+    IDs are negated (and offset by -10000 for forecast) to avoid colliding with
+    real transaction PKs when merging lists.
     """
     # Delegate to the parent-account handler when this account has children
     if Account.objects.filter(parent_account_id=account_id).exists():

--- a/backend/transactions/tasks.py
+++ b/backend/transactions/tasks.py
@@ -514,13 +514,12 @@ def prune_task_history():
 
 def archive_transactions():
     """
-    The function `archive_transactions` archives older transactions based on the
-    options set.
+    Marks old transactions as archived and updates each account's archive_balance.
 
-    Args:
-
-    Returns:
-
+    Two correlated subqueries compute the signed sum of all archived transactions
+    for each account as source and as destination separately, then combine them.
+    This avoids a single GROUP BY that would conflate the two perspectives for
+    transfer transactions.
     """
     try:
         # Load archive options
@@ -686,13 +685,13 @@ def archive_transactions():
 
 def update_reminder_cache(reminder_id):
     """
-    The function `archive_transactions` archives older transactions based on the
-    options set.
+    Rebuilds the ReminderCacheTransaction entries for a single reminder, projecting
+    occurrences up to 1 year out.
 
-    Args:
-
-    Returns:
-
+    A zero-delta Repeat (no recurrence) emits exactly one future transaction.
+    The loop guards against a non-advancing date to prevent infinite loops when a
+    Repeat is misconfigured. After rebuild, invalidates the forecast cache for both
+    source and destination accounts.
     """
     try:
         # Set up variables
@@ -1008,13 +1007,14 @@ def update_interest_forecast_cache(account_id):
 
 def update_cc_forecast_cache(account_id):
     """
-    The function `archive_transactions` archives older transactions based on the
-    options set.
+    Rebuilds ForecastCacheTransactions for a credit card account: estimated interest
+    charges and payment transactions for each statement cycle over the next year.
 
-    Args:
-
-    Returns:
-
+    Payment strategy controls the cycle_payment amount: F = full balance,
+    M = minimum payment, C = custom fixed amount. Existing payments within a
+    cycle's payment window (statement_end → next statement_end) are summed from
+    real and reminder transactions so the forecast payment is only the remainder.
+    The first cycle's payment is also written back to account.statement_balance.
     """
     try:
         account = Account.objects.get(id=account_id)
@@ -1246,20 +1246,14 @@ def generate_statement_cycles(
     non_trans_bal: Decimal,
 ):
     """
-    The function `generate_statement_cycle` generates a list of dictionaries of statement
-    information.
+    Generates one dict per statement cycle from the most-recently-closed period
+    through forecast_end_date, each containing credits, debits, due/pay dates,
+    and the running previous_balance used by update_cc_forecast_cache.
 
-    Args:
-        last_statement_end_date (date): Last statement end date.
-        last_statment_due_date (date): Last statement due date.
-        forecast_end_date (date): Forecast end date.
-        statement_cycle_length (int): Statement cycle length.
-        statement_cycle_period (str): Statement cycle period.
-        transactions (List[TransactionOut]): Transactions for the account for the forecast
-        period.
-
-    Returns:
-        (List[dict]): A list of dictionaries of statement information
+    Always anchors to one_month_prior so the just-closed cycle (with its upcoming
+    payment due date) is included. Due/pay dates are pushed forward one month when
+    their day-of-month would land before the statement closes (e.g. due on the 15th
+    for a card that closes on the 18th).
     """
     statement_cycles = []
     today = get_todays_date_timezone_adjusted()
@@ -1386,9 +1380,9 @@ def annotate_transaction_total(
     transactions: QuerySet[Transaction], account_id: Optional[int] = 0
 ) -> QuerySet[Transaction]:
     """
-    annotate_transaction_total
-
-    _extended_summary_
+    Annotates each transaction with a signed `pretty_total` from the perspective
+    of account_id: income is always positive, expense always negative, and transfers
+    are negative when account_id is the source and positive when it is the destination.
     """
     # Check we received a QuerySet
     if not isinstance(transactions, QuerySet):

--- a/example.env
+++ b/example.env
@@ -14,5 +14,3 @@ DJANGO_SUPERUSER_EMAIL=someone@somewhere.com
 DJANGO_SUPERUSER_USERNAME=superuser
 VITE_API_KEY=secretkey
 TIMEZONE=America/New_York
-# Optional: set to "true" to enable Contributions, Notes, and Calculator in the Planning menu
-VITE_OPT_FEATURES=false

--- a/frontend/src/components/CalculatorWidget.vue
+++ b/frontend/src/components/CalculatorWidget.vue
@@ -19,8 +19,7 @@
             </v-col>
             <v-col
               cols="2"
-              class="d-flex justify-end align-center"
-              style="align-items: center"
+              class="d-flex flex-column justify-center align-center ga-1"
             >
               <v-tooltip text="Send Amount to Form" location="top">
                 <template v-slot:activator="{ props }">
@@ -28,9 +27,20 @@
                     icon="mdi-check-bold"
                     rounded="xl"
                     color="success"
-                    block
                     size="x-small"
                     @click="clickUpdateAmount"
+                    v-bind="props"
+                  ></v-btn>
+                </template>
+              </v-tooltip>
+              <v-tooltip text="Cancel" location="top">
+                <template v-slot:activator="{ props }">
+                  <v-btn
+                    icon="mdi-close"
+                    rounded="xl"
+                    color="error"
+                    size="x-small"
+                    @click="clickCancel"
                     v-bind="props"
                   ></v-btn>
                 </template>
@@ -214,6 +224,12 @@
     emit("updateAmount", parseFloat(displayAmount.value));
   };
 
+  const clickCancel = () => {
+    resetCalculator();
+    emit("updateDialog", false);
+    emit("update:modelValue", false);
+  };
+
   const watchPassedAmount = () => {
     watchEffect(() => {
       if (props.amount) {
@@ -355,9 +371,12 @@
     } else if (key === "Backspace") {
       event.preventDefault();
       backspace();
-    } else if (key === "Delete" || key === "Escape") {
+    } else if (key === "Delete") {
       event.preventDefault();
       clickClear();
+    } else if (key === "Escape") {
+      event.preventDefault();
+      clickCancel();
     }
   };
 

--- a/frontend/src/components/CalculatorWidget.vue
+++ b/frontend/src/components/CalculatorWidget.vue
@@ -194,7 +194,7 @@
   </v-dialog>
 </template>
 <script setup>
-  import { ref, defineEmits, defineProps, onMounted, watchEffect, watch } from "vue";
+  import { ref, defineEmits, defineProps, watch } from "vue";
 
   const emit = defineEmits(["updateDialog", "updateAmount"]);
 
@@ -225,18 +225,8 @@
   };
 
   const clickCancel = () => {
-    resetCalculator();
     emit("updateDialog", false);
     emit("update:modelValue", false);
-  };
-
-  const watchPassedAmount = () => {
-    watchEffect(() => {
-      if (props.amount) {
-        resetCalculator();
-        displayAmount.value = formatMoney(props.amount);
-      }
-    });
   };
 
   const resetCalculator = () => {
@@ -384,14 +374,14 @@
     () => props.modelValue,
     open => {
       if (open) {
+        resetCalculator();
+        if (props.amount) {
+          displayAmount.value = formatMoney(props.amount);
+        }
         document.addEventListener("keydown", handleKeydown);
       } else {
         document.removeEventListener("keydown", handleKeydown);
       }
     },
   );
-
-  onMounted(() => {
-    watchPassedAmount();
-  });
 </script>

--- a/frontend/src/components/CalculatorWidget.vue
+++ b/frontend/src/components/CalculatorWidget.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-dialog v-model="dialog" width="300">
+  <v-dialog :model-value="modelValue" @update:model-value="emit('update:modelValue', $event); emit('updateDialog', $event)" width="300">
     <v-card color="secondary" variant="elevated" border="md" rounded="lg">
       <v-card-text>
         <v-container>
@@ -184,12 +184,15 @@
   </v-dialog>
 </template>
 <script setup>
-  import { ref, defineEmits, defineProps, onMounted, watchEffect } from "vue";
+  import { ref, defineEmits, defineProps, onMounted, watchEffect, watch } from "vue";
 
-  // Define emits
   const emit = defineEmits(["updateDialog", "updateAmount"]);
 
   const props = defineProps({
+    modelValue: {
+      type: Boolean,
+      default: false,
+    },
     amount: {
       type: Number,
       default: 0,
@@ -203,10 +206,11 @@
   const operand = ref(null);
   const operationInProgress = ref(false);
   const newEquation = ref(true);
-  const resetTriggeredByEquals = ref(false); // New flag
+  const resetTriggeredByEquals = ref(false);
 
   const clickUpdateAmount = () => {
     emit("updateDialog", false);
+    emit("update:modelValue", false);
     emit("updateAmount", parseFloat(displayAmount.value));
   };
 
@@ -227,23 +231,22 @@
     operand.value = null;
     operationInProgress.value = false;
     newEquation.value = true;
-    resetTriggeredByEquals.value = false; // Reset the flag
+    resetTriggeredByEquals.value = false;
   };
 
   const formatMoney = value => {
-    // Format value to ensure two decimal places
     return parseFloat(value).toFixed(2);
   };
 
   const appendNumber = number => {
     if (newEquation.value) {
       if (resetTriggeredByEquals.value) {
-        memoryText.value = ""; // Clear memory text only if '=' was pressed
+        memoryText.value = "";
       }
       displayAmount.value = String(number);
       newEquation.value = false;
       operationInProgress.value = false;
-      resetTriggeredByEquals.value = false; // Reset the flag after use
+      resetTriggeredByEquals.value = false;
     } else if (operationInProgress.value) {
       displayAmount.value = String(number);
       operationInProgress.value = false;
@@ -279,13 +282,12 @@
     operand.value = operation;
     memoryText.value = `$${runningTotal.value} ${operation}`;
     operationInProgress.value = true;
-    resetTriggeredByEquals.value = false; // Operation button doesn't trigger '=' behavior
+    resetTriggeredByEquals.value = false;
   };
 
   const performOperation = () => {
     const currentValue = parseFloat(displayAmount.value);
 
-    // Build equation string for memory text
     let equation = `$${runningTotal.value} ${
       operand.value || ""
     } $${currentValue}`;
@@ -315,17 +317,60 @@
       }
     }
 
-    // Fix JavaScript precision and format result
     runningTotal.value = parseFloat(runningTotal.value.toFixed(2));
-
-    // Update display and memory text
     displayAmount.value = formatMoney(runningTotal.value);
-    memoryText.value = `${equation} =`; // Show full equation
+    memoryText.value = `${equation} =`;
     operand.value = null;
     operationInProgress.value = false;
     newEquation.value = true;
-    resetTriggeredByEquals.value = true; // '=' was pressed
+    resetTriggeredByEquals.value = true;
   };
+
+  const handleKeydown = event => {
+    if (!props.modelValue) return;
+
+    const key = event.key;
+
+    if (key >= "0" && key <= "9") {
+      event.preventDefault();
+      appendNumber(parseInt(key));
+    } else if (key === ".") {
+      event.preventDefault();
+      appendPeriod();
+    } else if (key === "+") {
+      event.preventDefault();
+      clickOperation("+");
+    } else if (key === "-") {
+      event.preventDefault();
+      clickOperation("-");
+    } else if (key === "*") {
+      event.preventDefault();
+      clickOperation("*");
+    } else if (key === "/") {
+      event.preventDefault();
+      clickOperation("/");
+    } else if (key === "Enter" || key === "=") {
+      event.preventDefault();
+      performOperation();
+    } else if (key === "Backspace") {
+      event.preventDefault();
+      backspace();
+    } else if (key === "Delete" || key === "Escape") {
+      event.preventDefault();
+      clickClear();
+    }
+  };
+
+  watch(
+    () => props.modelValue,
+    open => {
+      if (open) {
+        document.addEventListener("keydown", handleKeydown);
+      } else {
+        document.removeEventListener("keydown", handleKeydown);
+      }
+    },
+  );
 
   onMounted(() => {
     watchPassedAmount();


### PR DESCRIPTION
## Summary

- **Reminders 500 after restore**: `ReminderOut` schema had `tag`, `reminder_source_account`, `transaction_type`, `repeat` as non-Optional, but the Django model allows NULL on all four. Any restored reminder with a NULL FK caused Pydantic to reject the entire list response. Made those fields Optional.
- **Bank logos not restored**: `export_user_data` exported banks with only `bank_name`, omitting `logo_url`. Export now includes `logo_url`; import restores it.
- **Expense planning graph error after restore**: `Option.report_main` and `report_individual` store JSON arrays of MainTag PKs. They were exported as raw PKs (stale after restore) — now converted to slug arrays on export and back to current PKs on import, matching the pattern used for widget tag IDs.
- **Reminder/forecast caches not rebuilt after restore**: `_clear_user_data` deletes `ReminderCacheTransaction` and `ForecastCacheTransaction` rows but the restore never rebuilds them. Added `call_command("load_caches")` after the atomic restore block.

## Test plan

- [ ] Create a backup on a running instance with reminders, bank logos, and expense graph configured
- [ ] Restore the backup and verify: reminders list loads, bank logos appear, expense graph renders, reminder cache is populated
- [ ] Verify old backups (without `logo_url` in bank export) still restore without error (`.get("logo_url")` handles missing key gracefully)

🤖 Generated with [Claude Code](https://claude.com/claude-code)