### PR TITLE
feat: version check on backup/restore with warning on mismatch

### DIFF
--- a/backend/administration/api/views/backup.py
+++ b/backend/administration/api/views/backup.py
@@ -8,6 +8,7 @@ from django.core.management import call_command
 from django.http import FileResponse
 from typing import List
 from datetime import datetime
+from io import StringIO
 import os
 import logging
 import tempfile
@@ -137,9 +138,11 @@ def restore_database(request, filename: str):
             raise HttpError(404, "Backup file not found")
         if not os.path.abspath(filepath).startswith(os.path.abspath(location)):
             raise HttpError(400, "Invalid filename")
-        call_command("import_user_data", filepath)
+        result = _run_restore(filepath)
         api_logger.info(f"Database restored from: {filename}")
-        return {"success": True}
+        if result["warning"]:
+            api_logger.warning(f"Version mismatch on restore of {filename}: {result['warning']}")
+        return result
     except HttpError:
         raise
     except Exception as e:
@@ -157,9 +160,11 @@ def restore_from_upload(request, file: UploadedFile = File(...)):
                 tmp.write(chunk)
             tmp_path = tmp.name
         try:
-            call_command("import_user_data", tmp_path)
+            result = _run_restore(tmp_path)
             api_logger.info(f"Database restored from uploaded file: {file.name}")
-            return {"success": True}
+            if result["warning"]:
+                api_logger.warning(f"Version mismatch on upload restore of {file.name}: {result['warning']}")
+            return result
         finally:
             os.unlink(tmp_path)
     except HttpError:
@@ -167,6 +172,18 @@ def restore_from_upload(request, file: UploadedFile = File(...)):
     except Exception as e:
         error_logger.exception(f"Error restoring from upload: {e}")
         raise HttpError(500, f"Restore failed: {str(e)}")
+
+
+def _run_restore(filepath: str) -> dict:
+    """Run import_user_data and return {success, warning}."""
+    out = StringIO()
+    call_command("import_user_data", filepath, stdout=out)
+    warning = None
+    for line in out.getvalue().splitlines():
+        if line.startswith("VERSION_WARNING:"):
+            warning = line[len("VERSION_WARNING:"):].strip()
+            break
+    return {"success": True, "warning": warning}
 
 
 def _reschedule_backup(config):

--- a/backend/administration/management/commands/export_user_data.py
+++ b/backend/administration/management/commands/export_user_data.py
@@ -4,6 +4,7 @@ import os
 from datetime import datetime
 from django.core.management.base import BaseCommand
 from django.conf import settings
+from administration.api.dependencies.version import get_version
 
 
 class Command(BaseCommand):
@@ -43,7 +44,7 @@ class Command(BaseCommand):
         from planning.models import ContribRule, Contribution, Note, ChristmasGift, Budget, CalculationRule
         from reports.models import ReportConfig
 
-        data = {}
+        data = {"app_version": get_version()}
 
         # Build helper maps for converting PKs to natural keys
         all_tags = list(Tag.objects.all().select_related("parent", "child", "tag_type"))

--- a/backend/administration/management/commands/import_user_data.py
+++ b/backend/administration/management/commands/import_user_data.py
@@ -1,6 +1,7 @@
 import gzip
 import json
 import os
+import re
 from django.core.management.base import BaseCommand, CommandError
 from django.core.management import call_command
 from django.db import transaction as db_transaction
@@ -25,6 +26,8 @@ class Command(BaseCommand):
             with open(filepath, "r") as f:
                 data = json.load(f)
 
+        self._check_version(data)
+
         self.stdout.write("Starting restore (atomic)...")
         with db_transaction.atomic():
             self._clear_user_data()
@@ -32,6 +35,29 @@ class Command(BaseCommand):
 
         call_command("load_caches")
         self.stdout.write(self.style.SUCCESS("Restore completed successfully."))
+
+    def _check_version(self, data):
+        from administration.api.dependencies.version import get_version
+
+        backup_version = data.get("app_version")
+        current_version = get_version()
+
+        if not backup_version:
+            self.stdout.write(
+                "VERSION_WARNING: Backup has no version information (created before v1.4.0-alpha.37). "
+                "Verify all data restored correctly."
+            )
+            return
+
+        def minor(v):
+            m = re.match(r"(\d+\.\d+)", v)
+            return m.group(1) if m else v
+
+        if minor(backup_version) != minor(current_version):
+            self.stdout.write(
+                f"VERSION_WARNING: Backup was created on v{backup_version} but the app is "
+                f"v{current_version}. Features added between versions may not be fully restored."
+            )
 
     def _clear_user_data(self):
         from transactions.models import (

--- a/backend/administration/tests/unit/test_backup_commands.py
+++ b/backend/administration/tests/unit/test_backup_commands.py
@@ -263,6 +263,78 @@ def test_roundtrip_reminder_maps(
 
 
 # ---------------------------------------------------------------------------
+# Version check
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+def test_export_includes_app_version(tmp_path):
+    """Exported backup includes the current app version."""
+    output = str(tmp_path / "backup.json.gz")
+    call_command("export_user_data", output=output)
+
+    with gzip.open(output, "rb") as f:
+        data = json.loads(f.read())
+
+    assert "app_version" in data
+    assert data["app_version"]  # non-empty string
+
+
+@pytest.mark.django_db
+def test_import_no_version_warning_when_versions_match(tmp_path, test_checking_account):
+    """No VERSION_WARNING is written when backup and app share the same major.minor."""
+    from io import StringIO
+
+    output = str(tmp_path / "backup.json.gz")
+    call_command("export_user_data", output=output)
+
+    out = StringIO()
+    call_command("import_user_data", output, stdout=out)
+    assert "VERSION_WARNING" not in out.getvalue()
+
+
+@pytest.mark.django_db
+def test_import_version_warning_on_minor_mismatch(tmp_path, test_checking_account):
+    """VERSION_WARNING is written when the backup major.minor differs from the current app."""
+    from io import StringIO
+
+    output = str(tmp_path / "backup.json.gz")
+    call_command("export_user_data", output=output)
+
+    # Patch the backup version to a different minor
+    with gzip.open(output, "rb") as f:
+        data = json.loads(f.read())
+    data["app_version"] = "0.9.0"
+    patched = str(tmp_path / "old.json.gz")
+    with gzip.open(patched, "wb") as f:
+        f.write(json.dumps(data).encode())
+
+    out = StringIO()
+    call_command("import_user_data", patched, stdout=out)
+    assert "VERSION_WARNING" in out.getvalue()
+    assert "0.9.0" in out.getvalue()
+
+
+@pytest.mark.django_db
+def test_import_version_warning_on_missing_version(tmp_path, test_checking_account):
+    """VERSION_WARNING is written when the backup has no app_version field (pre-v1.4.0-alpha.37)."""
+    from io import StringIO
+
+    output = str(tmp_path / "backup.json.gz")
+    call_command("export_user_data", output=output)
+
+    with gzip.open(output, "rb") as f:
+        data = json.loads(f.read())
+    del data["app_version"]
+    patched = str(tmp_path / "no_version.json.gz")
+    with gzip.open(patched, "wb") as f:
+        f.write(json.dumps(data).encode())
+
+    out = StringIO()
+    call_command("import_user_data", patched, stdout=out)
+    assert "VERSION_WARNING" in out.getvalue()
+
+
+# ---------------------------------------------------------------------------
 # Atomic rollback
 # ---------------------------------------------------------------------------
 

--- a/frontend/src/composables/backupComposable.js
+++ b/frontend/src/composables/backupComposable.js
@@ -134,15 +134,21 @@ export function useBackupFiles() {
 
   const restoreMutation = useMutation({
     mutationFn: restoreDatabaseFunction,
-    onSuccess: () => {
+    onSuccess: data => {
       mainstore.showSnackbar("Database restored successfully", "success");
+      if (data?.warning) {
+        setTimeout(() => mainstore.showSnackbar(`Version warning: ${data.warning}`, "warning"), 400);
+      }
     },
   });
 
   const restoreUploadMutation = useMutation({
     mutationFn: restoreFromUploadFunction,
-    onSuccess: () => {
+    onSuccess: data => {
       mainstore.showSnackbar("Database restored from uploaded file", "success");
+      if (data?.warning) {
+        setTimeout(() => mainstore.showSnackbar(`Version warning: ${data.warning}`, "warning"), 400);
+      }
     },
   });
 


### PR DESCRIPTION
## Summary

- **Backups now stamped with app version** — `export_user_data` writes `"app_version": "1.4.0-alpha.37"` (or whatever the current version is) into the backup JSON.
- **Import warns on version mismatch** — `import_user_data` compares the backup's major.minor against the running app. If they differ (e.g. restoring a v1.3 backup onto v1.4), a `VERSION_WARNING` line is written to stdout. Backups created before this change (no `app_version` field) also trigger a warning.
- **API surfaces the warning** — both restore endpoints now return `{"success": true, "warning": "...or null"}` instead of just `{"success": true}`. The warning is also written to the error log.
- **Frontend shows a warning snackbar** — if the response includes a warning, a second amber snackbar appears 400ms after the success toast so the user sees both.
- **Warn, don't block** — the restore always proceeds; the warning is informational only.

## Test plan

- [ ] Create a backup and restore it on the same version — no warning toast should appear
- [ ] Manually patch `app_version` in a backup file to an older minor (e.g. `"0.9.0"`) and restore — warning snackbar should appear describing the version difference
- [ ] Restore a backup that predates this change (no `app_version` field) — warning snackbar should appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)