### PR TITLE
fix: post-restore discrepancies — schema nullability, custom repeats, CC forecast

### DIFF
--- a/backend/administration/management/commands/export_user_data.py
+++ b/backend/administration/management/commands/export_user_data.py
@@ -212,7 +212,21 @@ class Command(BaseCommand):
             for td in TransactionDetail.objects.all().select_related("tag")
         ]
 
-        # 12. Reminders
+        # 12. Custom Repeats (user-created only; system repeats are fixture-seeded)
+        from reminders.models import Repeat as RepeatModel
+        data["custom_repeats"] = [
+            {
+                "slug": r.slug,
+                "repeat_name": r.repeat_name,
+                "days": r.days,
+                "weeks": r.weeks,
+                "months": r.months,
+                "years": r.years,
+            }
+            for r in RepeatModel.objects.filter(is_system=False)
+        ]
+
+        # 13. Reminders
         data["reminders"] = [
             {
                 "_id": r.id,
@@ -235,7 +249,7 @@ class Command(BaseCommand):
             )
         ]
 
-        # 13. ReminderExclusions
+        # 14. ReminderExclusions
         data["reminder_exclusions"] = [
             {
                 "reminder_id": re.reminder_id,

--- a/backend/administration/management/commands/import_user_data.py
+++ b/backend/administration/management/commands/import_user_data.py
@@ -66,7 +66,7 @@ class Command(BaseCommand):
         )
         from accounts.models import Account, Bank, Reward
         from administration.models import Payee, DescriptionHistory
-        from reminders.models import Reminder, ReminderExclusion
+        from reminders.models import Reminder, ReminderExclusion, Repeat
         from tags.models import Tag, MainTag, SubTag
         from planning.models import (
             ContribRule, Contribution, Note, ChristmasGift,
@@ -86,6 +86,7 @@ class Command(BaseCommand):
         DescriptionHistory.objects.all().delete()
         ReminderExclusion.objects.all().delete()
         Reminder.objects.all().delete()
+        Repeat.objects.filter(is_system=False).delete()
 
         ReportConfig.objects.all().delete()
 
@@ -155,30 +156,27 @@ class Command(BaseCommand):
         bank_by_name = {b.bank_name: b for b in Bank.objects.all()}
 
         # --- 3. MainTags (user-created) ---
-        main_tag_by_slug = {}
+        # System tags loaded first; user tags added second so their old slugs
+        # take precedence over system slugs when both share the same string.
+        main_tag_by_slug = {mt.slug: mt for mt in MainTag.objects.filter(is_system=True)}
         for item in data.get("main_tags", []):
             mt = MainTag.objects.create(
                 tag_name=item["tag_name"],
                 tag_type=tag_type_by_slug.get(item["tag_type_slug"]) if item.get("tag_type_slug") else None,
             )
             main_tag_by_slug[item["slug"]] = mt
-        # Include system main tags so their slugs resolve correctly in tag lookups
-        for mt in MainTag.objects.filter(is_system=True):
-            main_tag_by_slug[mt.slug] = mt
 
         # --- 4. SubTags (user-created) ---
-        sub_tag_by_slug = {}
+        sub_tag_by_slug = {st.slug: st for st in SubTag.objects.filter(is_system=True)}
         for item in data.get("sub_tags", []):
             st = SubTag.objects.create(
                 tag_name=item["tag_name"],
                 tag_type=tag_type_by_slug.get(item["tag_type_slug"]) if item.get("tag_type_slug") else None,
             )
             sub_tag_by_slug[item["slug"]] = st
-        for st in SubTag.objects.filter(is_system=True):
-            sub_tag_by_slug[st.slug] = st
 
         # --- 5. Tags (user-created) ---
-        tag_by_slug = {}
+        tag_by_slug = {t.slug: t for t in Tag.objects.filter(is_system=True).select_related("parent", "child")}
         for item in data.get("tags", []):
             t = Tag.objects.create(
                 parent=main_tag_by_slug.get(item["parent_slug"]) if item.get("parent_slug") else None,
@@ -186,8 +184,6 @@ class Command(BaseCommand):
                 tag_type=tag_type_by_slug.get(item["tag_type_slug"]) if item.get("tag_type_slug") else None,
             )
             tag_by_slug[item["slug"]] = t
-        for t in Tag.objects.filter(is_system=True).select_related("parent", "child"):
-            tag_by_slug[t.slug] = t
 
         tag_slug_to_pk = {slug: t.pk for slug, t in tag_by_slug.items()}
 
@@ -320,7 +316,21 @@ class Command(BaseCommand):
         if detail_batch:
             TransactionDetail.objects.bulk_create(detail_batch)
 
-        # --- 12. Reminders ---
+        # --- 12. Custom Repeats (user-created only) ---
+        for item in data.get("custom_repeats", []):
+            repeat, _ = Repeat.objects.get_or_create(
+                slug=item["slug"],
+                defaults={
+                    "repeat_name": item["repeat_name"],
+                    "days": item.get("days", 0),
+                    "weeks": item.get("weeks", 0),
+                    "months": item.get("months", 0),
+                    "years": item.get("years", 0),
+                },
+            )
+            repeat_by_slug[item["slug"]] = repeat
+
+        # --- 13. Reminders ---
         reminder_id_map = {}
         for item in data.get("reminders", []):
             r = Reminder.objects.create(

--- a/backend/administration/tests/unit/test_backup_commands.py
+++ b/backend/administration/tests/unit/test_backup_commands.py
@@ -513,3 +513,33 @@ def test_roundtrip_report_config(
     main_slugs = {s.main_tag.slug for s in selections if s.main_tag_id}
     assert test_tag.slug in tag_slugs
     assert test_main_tag.slug in main_slugs
+
+
+@pytest.mark.django_db
+def test_roundtrip_custom_repeat(tmp_path):
+    """User-created (non-system) Repeat is exported, cleared, and re-created on import."""
+    from reminders.models import Repeat
+
+    custom = Repeat.objects.create(
+        repeat_name="Bi-weekly",
+        days=0,
+        weeks=2,
+        months=0,
+        years=0,
+    )
+    slug = custom.slug
+
+    output = str(tmp_path / "backup.json.gz")
+    call_command("export_user_data", output=output)
+
+    # Verify the export contains the custom repeat
+    with gzip.open(output, "rb") as f:
+        exported = json.loads(f.read())
+    assert any(r["slug"] == slug for r in exported.get("custom_repeats", []))
+
+    call_command("import_user_data", output)
+
+    restored = Repeat.objects.get(slug=slug)
+    assert restored.repeat_name == "Bi-weekly"
+    assert restored.weeks == 2
+    assert restored.is_system is False

--- a/backend/tags/api/schemas/main_tag.py
+++ b/backend/tags/api/schemas/main_tag.py
@@ -14,7 +14,7 @@ class MainTagIn(Schema):
 class MainTagOut(Schema):
     id: int
     tag_name: str
-    tag_type: TagTypeOut
+    tag_type: Optional[TagTypeOut] = None
     slug: str
     is_system: bool
 

--- a/backend/tags/api/schemas/sub_tag.py
+++ b/backend/tags/api/schemas/sub_tag.py
@@ -14,7 +14,7 @@ class SubTagIn(Schema):
 class SubTagOut(Schema):
     id: int
     tag_name: str
-    tag_type: TagTypeOut
+    tag_type: Optional[TagTypeOut] = None
     slug: str
     is_system: bool
 

--- a/backend/transactions/tasks.py
+++ b/backend/transactions/tasks.py
@@ -1039,6 +1039,12 @@ def update_cc_forecast_cache(account_id):
         statement_cycle_length = account.statement_cycle_length
         statement_cycle_period = account.statement_cycle_period
         funding_account = account.funding_account
+        if not funding_account:
+            ForecastCacheTransaction.objects.filter(
+                Q(source_account_id=account_id) | Q(destination_account_id=account_id)
+            ).delete()
+            delete_pattern(account_all(account_id))
+            return
         annual_rate = account.annual_rate
         payment_strategy = account.payment_strategy
         payment_amount = account.payment_amount


### PR DESCRIPTION
## Summary

- **MainTagOut / SubTagOut `tag_type` → Optional** — `tag_type` is `null=True` on the model; Pydantic was raising `SystemExit: 1` validation errors on the tag list endpoints whenever a tag had no type set (seen as `TransactionOut` error in the log — the detail tag's parent triggered it)
- **CC forecast null guard** — `update_cc_forecast_cache` crashed with `NoneType has no attribute 'id'` for CC accounts that have no `funding_account` configured; now clears those cache rows and returns early
- **Custom repeats export + restore** — user-created `Repeat` objects were silently dropped on restore; export now includes a `custom_repeats` section and import re-creates them, with `_clear_user_data` deleting them first so round-trips are clean
- **Tag slug ordering fix** — `tag_by_slug` / `main_tag_by_slug` / `sub_tag_by_slug` now let user-created tags win over system slugs on collision; this was causing widget 2 to resolve to the wrong tag after restore

## Test plan

- [ ] 21 backup round-trip tests pass (`administration/tests/unit/test_backup_commands.py`)
- [ ] New `test_roundtrip_custom_repeat` test verifies export includes slug, clear removes it, import re-creates it
- [ ] Restore a real backup and verify: widgets correct, custom repeats present, reminders with custom repeats appear in forecast, no validation errors in logs, CC forecast works

🤖 Generated with [Claude Code](https://claude.com/claude-code)