### PR TITLE
fix: restore signal noise, tag select_related, forecast cache key, backup timezone

### DIFF
--- a/backend/administration/management/commands/import_user_data.py
+++ b/backend/administration/management/commands/import_user_data.py
@@ -28,12 +28,36 @@ class Command(BaseCommand):
 
         self._check_version(data)
 
-        self.stdout.write("Starting restore (atomic)...")
-        with db_transaction.atomic():
-            self._clear_user_data()
-            self._restore_data(data)
+        # Disconnect signals that queue async cache tasks — they race with
+        # load_caches and produce double forecast/reminder entries.
+        from django.db.models.signals import post_save, post_delete
+        from reminders.models import Reminder as ReminderModel
+        from reminders.signals import (
+            update_and_invalidate_cache_on_save as reminder_on_save,
+            update_and_invalidate_cache_on_delete as reminder_on_delete,
+        )
+        from transactions.models import Transaction as TransactionModel
+        from transactions.signals import (
+            update_forecast_cache_on_save as txn_on_save,
+            update_forecast_cache_on_delete as txn_on_delete,
+        )
+        post_save.disconnect(reminder_on_save, sender=ReminderModel)
+        post_delete.disconnect(reminder_on_delete, sender=ReminderModel)
+        post_save.disconnect(txn_on_save, sender=TransactionModel)
+        post_delete.disconnect(txn_on_delete, sender=TransactionModel)
 
-        call_command("load_caches")
+        try:
+            self.stdout.write("Starting restore (atomic)...")
+            with db_transaction.atomic():
+                self._clear_user_data()
+                self._restore_data(data)
+            call_command("load_caches")
+        finally:
+            post_save.connect(reminder_on_save, sender=ReminderModel)
+            post_delete.connect(reminder_on_delete, sender=ReminderModel)
+            post_save.connect(txn_on_save, sender=TransactionModel)
+            post_delete.connect(txn_on_delete, sender=TransactionModel)
+
         self.stdout.write(self.style.SUCCESS("Restore completed successfully."))
 
     def _check_version(self, data):

--- a/backend/transactions/api/dependencies/transaction_utilities.py
+++ b/backend/transactions/api/dependencies/transaction_utilities.py
@@ -279,7 +279,15 @@ def add_tags_to_transactions(
 
     all_details = list(
         detail_model.objects.filter(transaction_id__in=txn_ids)
-        .select_related("transaction", "tag")
+        .select_related(
+            "transaction",
+            "tag",
+            "tag__parent",
+            "tag__parent__tag_type",
+            "tag__child",
+            "tag__child__tag_type",
+            "tag__tag_type",
+        )
         .annotate(
             parent_tag=F("tag__parent__tag_name"),
             child_tag=F("tag__child__tag_name"),


### PR DESCRIPTION
## Summary

- **Suppress signals during restore** — `Reminder` and `Transaction` `post_save`/`post_delete` signals queue async cache tasks for every record created/deleted during restore. These qcluster tasks race with `load_caches` and produce doubled forecast/reminder entries when two workers call `update_cc_forecast_cache` for the same account concurrently. All four signal handlers are disconnected before restore and reconnected in a `finally` block.

- **Deeper `select_related` for tag chain** — `add_tags_to_transactions` only loaded `tag` on `TransactionDetail`; Pydantic's `DjangoGetter` then lazy-loaded `tag__parent` and `tag__parent__tag_type`, raising `SystemExit: 1` during `TransactionOut` serialization for some restored `MainTag` objects. Extended `select_related` to cover the full chain.

- **Forecast graph cache key collision** — `useAccountForecasts` queryKey only included `account` and `end`; the account detail view (`start=14`) and forecast view (`start=0`) shared the same TanStack Query cache entry. Added `start` to the key.

- **Backup timestamp timezone** — `datetime.fromtimestamp(mtime)` produced a naive datetime; Ninja serialized it without a timezone indicator, causing JavaScript to treat it as server local time rather than UTC. Changed to `datetime.fromtimestamp(mtime, tz=timezone.utc)` so the browser correctly converts the Z-suffixed timestamp to the user's local timezone.

## Test plan

- [ ] 21 backup round-trip tests pass
- [ ] Restore a real backup: verify no `SystemExit: 1` in transaction logs
- [ ] Forecast shows reminder virtual transactions exactly once (no doubles)
- [ ] Account detail graph (start=14) and forecast view graph (start=0) show different data ranges independently
- [ ] Backup file timestamps display in browser local timezone

🤖 Generated with [Claude Code](https://claude.com/claude-code)