### PR TITLE
fix: forecast graph cache key collision and backup timestamp timezone

### DIFF
--- a/backend/administration/api/views/backup.py
+++ b/backend/administration/api/views/backup.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from django.core.management import call_command
 from django.http import FileResponse
 from typing import List
-from datetime import datetime
+from datetime import datetime, timezone
 from io import StringIO
 import os
 import logging
@@ -39,7 +39,7 @@ def _list_backup_files():
             BackupFileOut(
                 filename=filename,
                 size=stat.st_size,
-                created_at=datetime.fromtimestamp(stat.st_mtime),
+                created_at=datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc),
                 backup_type="database",
             )
         )

--- a/frontend/src/composables/forecastsComposable.js
+++ b/frontend/src/composables/forecastsComposable.js
@@ -46,7 +46,7 @@ export function useAccountForecasts(account_id, start_integer, end_integer) {
     isLoading,
     isFetching,
   } = useQuery({
-    queryKey: ["account_forecast", { account: account_id, end: end_integer }],
+    queryKey: ["account_forecast", { account: account_id, start: start_integer, end: end_integer }],
     queryFn: () =>
       getAccountForecastFunction(
         account_id,


### PR DESCRIPTION
## Summary

- **Forecast graph cache key collision** — `useAccountForecasts` queryKey only included `account` and `end`; the account detail view (`start=14`) and forecast view (`start=0`) shared the same TanStack Query cache entry. Whichever view loaded first would serve its cached data to the other. Added `start` to the key so each combination caches independently.

- **Backup timestamps in wrong timezone** — `datetime.fromtimestamp(mtime)` produced a naive datetime; Ninja serialized it without a timezone indicator, causing JavaScript to treat it as server local time rather than UTC. Changed to `datetime.fromtimestamp(mtime, tz=timezone.utc)` so the browser correctly converts the Z-suffixed timestamp to the user's local timezone.

## Test plan

- [ ] Load account detail graph (14 days back + 90 days), navigate to forecast view (0 days back + 90 days) — both should show different date ranges independently
- [ ] Backup file timestamps display in browser local timezone, not UTC

🤖 Generated with [Claude Code](https://claude.com/claude-code)