### PR TITLE
fix: raise Workbox precache limit to 3 MiB for ApexCharts bundle

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -29,6 +29,7 @@ export default defineConfig({
         ],
       },
       workbox: {
+        maximumFileSizeToCacheInBytes: 3 * 1024 * 1024,
         navigateFallback: "/index.html",
         navigateFallbackDenylist: [/^\/api\//, /^\/admin/, /^\/static\//],
         runtimeCaching: [


### PR DESCRIPTION
## Summary

- The ApexCharts migration (#137) increased the main JS bundle to ~2.13 MB, exceeding the default Workbox service worker precache limit of 2 MiB
- This caused the Docker build to fail with: `assets/index-*.js is 2.13 MB, and won't be precached`
- Raises `workbox.maximumFileSizeToCacheInBytes` to 3 MiB in `vite.config.js`

## Test plan

- [ ] Docker build completes without Workbox precache error
- [ ] PWA service worker generates successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)