### PR TITLE
fix: mobile overflow, nav icon sizing, and logs polish

### DIFF
--- a/frontend/src/components/AccountsMenu.vue
+++ b/frontend/src/components/AccountsMenu.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="accounts-menu">
     <v-list
       density="compact"
       nav
@@ -33,7 +33,7 @@
             <template v-slot:prepend>
               <v-icon
                 icon="mdi-checkbook"
-                :size="!isMobile ? 'large' : 'x-large'"
+                :size="!isMobile ? 'default' : 'x-large'"
               ></v-icon>
             </template>
             <v-list-item-title>
@@ -61,10 +61,10 @@
           color="accent"
           @click="setAccount(account.id, False)"
           v-else
-          :class="account.parent_account_id ? 'pl-6' : ''"
+          :style="account.parent_account_id ? { '--child-indent': '44px' } : {}"
         >
           <template v-slot:prepend>
-            <BankLogo :logo-url="account.bank?.logo_url" class="mr-2" />
+            <BankLogo :logo-url="account.bank?.logo_url" :size="20" class="mr-1" />
           </template>
           <v-list-item-title>
             <span :class="isMobile ? 'text-subtitle-1 font-weight-bold' : ''">
@@ -100,7 +100,7 @@
             <template v-slot:prepend>
               <v-icon
                 icon="mdi-piggy-bank"
-                :size="!isMobile ? 'large' : 'x-large'"
+                :size="!isMobile ? 'default' : 'x-large'"
               ></v-icon>
             </template>
             <v-list-item-title>
@@ -128,10 +128,10 @@
           color="accent"
           @click="setAccount(account.id, False)"
           v-else
-          :class="account.parent_account_id ? 'pl-6' : ''"
+          :style="account.parent_account_id ? { '--child-indent': '44px' } : {}"
         >
           <template v-slot:prepend>
-            <BankLogo :logo-url="account.bank?.logo_url" class="mr-2" />
+            <BankLogo :logo-url="account.bank?.logo_url" :size="20" class="mr-1" />
           </template>
           <v-list-item-title>
             <span :class="isMobile ? 'text-subtitle-1 font-weight-bold' : ''">
@@ -167,7 +167,7 @@
             <template v-slot:prepend>
               <v-icon
                 icon="mdi-credit-card"
-                :size="!isMobile ? 'large' : 'x-large'"
+                :size="!isMobile ? 'default' : 'x-large'"
               ></v-icon>
             </template>
             <v-list-item-title>
@@ -195,10 +195,10 @@
           color="accent"
           @click="setAccount(account.id, False)"
           v-else
-          :class="account.parent_account_id ? 'pl-6' : ''"
+          :style="account.parent_account_id ? { '--child-indent': '44px' } : {}"
         >
           <template v-slot:prepend>
-            <BankLogo :logo-url="account.bank?.logo_url" class="mr-2" />
+            <BankLogo :logo-url="account.bank?.logo_url" :size="20" class="mr-1" />
           </template>
           <v-list-item-title>
             <span :class="isMobile ? 'text-subtitle-1 font-weight-bold' : ''">
@@ -234,7 +234,7 @@
             <template v-slot:prepend>
               <v-icon
                 icon="mdi-finance"
-                :size="!isMobile ? 'large' : 'x-large'"
+                :size="!isMobile ? 'default' : 'x-large'"
               ></v-icon>
             </template>
             <v-list-item-title>
@@ -262,10 +262,10 @@
           color="accent"
           @click="setAccount(account.id, False)"
           v-else
-          :class="account.parent_account_id ? 'pl-6' : ''"
+          :style="account.parent_account_id ? { '--child-indent': '44px' } : {}"
         >
           <template v-slot:prepend>
-            <BankLogo :logo-url="account.bank?.logo_url" class="mr-2" />
+            <BankLogo :logo-url="account.bank?.logo_url" :size="20" class="mr-1" />
           </template>
           <v-list-item-title>
             <span :class="isMobile ? 'text-subtitle-1 font-weight-bold' : ''">
@@ -301,7 +301,7 @@
             <template v-slot:prepend>
               <v-icon
                 icon="mdi-car-back"
-                :size="!isMobile ? 'large' : 'x-large'"
+                :size="!isMobile ? 'default' : 'x-large'"
               ></v-icon>
             </template>
             <v-list-item-title>
@@ -329,10 +329,10 @@
           color="accent"
           @click="setAccount(account.id, False)"
           v-else
-          :class="account.parent_account_id ? 'pl-6' : ''"
+          :style="account.parent_account_id ? { '--child-indent': '44px' } : {}"
         >
           <template v-slot:prepend>
-            <BankLogo :logo-url="account.bank?.logo_url" class="mr-2" />
+            <BankLogo :logo-url="account.bank?.logo_url" :size="20" class="mr-1" />
           </template>
           <v-list-item-title>
             <span :class="isMobile ? 'text-subtitle-1 font-weight-bold' : ''">
@@ -368,7 +368,7 @@
             <template v-slot:prepend>
               <v-icon
                 icon="mdi-bank-off"
-                :size="!isMobile ? 'large' : 'x-large'"
+                :size="!isMobile ? 'default' : 'x-large'"
               ></v-icon>
             </template>
             <v-list-item-title>
@@ -398,7 +398,7 @@
           v-else
         >
           <template v-slot:prepend>
-            <BankLogo :logo-url="account.bank?.logo_url" class="mr-2" />
+            <BankLogo :logo-url="account.bank?.logo_url" :size="20" class="mr-1" />
           </template>
           <v-list-item-title>
             <span class="font-italic">
@@ -465,3 +465,12 @@
   } = useAccounts();
   const add_account_link = ref("/accounts/add");
 </script>
+
+<style>
+.accounts-menu .v-list-item__prepend .v-list-item__spacer {
+  width: 8px !important;
+}
+.accounts-menu .v-list-group__items .v-list-item {
+  padding-inline-start: calc(14px + var(--child-indent, 0px)) !important;
+}
+</style>

--- a/frontend/src/components/PlanningMenu.vue
+++ b/frontend/src/components/PlanningMenu.vue
@@ -1,5 +1,6 @@
 <template>
   <v-list
+    class="planning-menu"
     density="compact"
     nav
     :bg-color="smAndDown ? 'background' : 'surface'"
@@ -19,7 +20,7 @@
       <template v-slot:prepend>
         <v-icon
           :icon="planning_item.icon"
-          :size="!isMobile ? 'large' : 'x-large'"
+          :size="!isMobile ? 'default' : 'x-large'"
         ></v-icon>
       </template>
       <v-list-item-title>
@@ -30,6 +31,12 @@
     </v-list-item>
   </v-list>
 </template>
+
+<style>
+.planning-menu .v-list-item__prepend .v-list-item__spacer {
+  width: 8px !important;
+}
+</style>
 <script setup>
   import { ref, computed } from "vue";
   import { useRouter } from "vue-router";

--- a/frontend/src/components/TransactionTableWidget.vue
+++ b/frontend/src/components/TransactionTableWidget.vue
@@ -165,7 +165,7 @@
         no-data-text="No transactions!"
         loading-text="Loading transactions..."
         disable-sort
-        :show-select="props.variant === 'account' && authStore.isFullAccess"
+        :show-select="props.variant === 'account' && authStore.isFullAccess && mdAndUp"
         fixed-footer
         striped="odd"
         density="compact"
@@ -263,6 +263,7 @@
             <v-pagination
               v-model="localPage"
               :length="localPageTotal"
+              :total-visible="smAndDown ? 5 : 7"
               @update:model-value="onPageChange"
             ></v-pagination>
           </div>

--- a/frontend/src/views/AccountDetailView.vue
+++ b/frontend/src/views/AccountDetailView.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div style="overflow-x: hidden">
     <v-row class="pa-1 ga-1" no-gutters>
       <v-col class="rounded">
         <AccountHeaderWidget

--- a/frontend/src/views/LogsView.vue
+++ b/frontend/src/views/LogsView.vue
@@ -70,18 +70,22 @@
 
     <!-- Log table -->
     <v-sheet border rounded>
-      <v-data-table
+      <v-data-table-server
         :headers="headers"
         :items="entries"
+        :items-length="logPage?.total ?? 0"
         :loading="isLoading"
+        v-model:page="currentPage"
+        :items-per-page="100"
+        :items-per-page-options="[]"
         density="compact"
+        striped="odd"
+        :header-props="{ class: 'font-weight-bold bg-secondary' }"
         no-data-text="No log entries found"
-        :items-per-page="-1"
-        hide-default-footer
         @click:row="(_, { item }) => openDetail(item)"
       >
         <template v-slot:item.timestamp="{ item }">
-          <span class="text-caption text-no-wrap">{{ item.timestamp }}</span>
+          <span class="text-caption text-no-wrap">{{ formatLogTimestamp(item.timestamp) }}</span>
         </template>
         <template v-slot:item.level="{ item }">
           <v-chip :color="levelColor(item.level)" size="x-small" label>
@@ -93,23 +97,8 @@
             truncate(item.message)
           }}</span>
         </template>
-      </v-data-table>
+      </v-data-table-server>
     </v-sheet>
-
-    <!-- Pagination -->
-    <v-row class="mt-2" v-if="logPage">
-      <v-col class="d-flex justify-center">
-        <v-pagination
-          v-model="currentPage"
-          :length="logPage.pages"
-          :total-visible="7"
-          density="compact"
-        ></v-pagination>
-      </v-col>
-      <v-col cols="auto" class="d-flex align-center text-caption text-medium-emphasis">
-        {{ logPage.total }} entries
-      </v-col>
-    </v-row>
 
     <!-- Detail dialog -->
     <v-dialog v-model="detailDialog" max-width="800">
@@ -118,7 +107,7 @@
           <v-chip :color="levelColor(selectedEntry.level)" size="small" label>
             {{ selectedEntry.level }}
           </v-chip>
-          <span class="text-caption text-medium-emphasis">{{ selectedEntry.timestamp }}</span>
+          <span class="text-caption text-medium-emphasis">{{ formatLogTimestamp(selectedEntry.timestamp) }}</span>
         </v-card-title>
         <v-card-text>
           <pre class="text-caption pa-3 bg-surface-variant rounded" style="white-space: pre-wrap; overflow-x: auto">{{
@@ -126,6 +115,12 @@
           }}</pre>
         </v-card-text>
         <v-card-actions>
+          <v-btn
+            :prepend-icon="copied ? 'mdi-check' : 'mdi-content-copy'"
+            :color="copied ? 'success' : undefined"
+            variant="text"
+            @click="copyEntry"
+          >{{ copied ? 'Copied!' : 'Copy' }}</v-btn>
           <v-spacer></v-spacer>
           <v-btn @click="detailDialog = false">Close</v-btn>
         </v-card-actions>
@@ -148,6 +143,7 @@
   const isDownloading = ref(false);
   const detailDialog = ref(false);
   const selectedEntry = ref(null);
+  const copied = ref(false);
 
   const levelOptions = [
     { label: "DEBUG", value: "DEBUG" },
@@ -197,7 +193,40 @@
 
   function openDetail(entry) {
     selectedEntry.value = entry;
+    copied.value = false;
     detailDialog.value = true;
+  }
+
+  function formatLogTimestamp(ts) {
+    if (!ts) return ts;
+    // Backend format: "2026-05-21 14:32:45,123" — not directly parseable by Date
+    const normalized = ts.replace(" ", "T").replace(",", ".") + "Z";
+    const d = new Date(normalized);
+    return isNaN(d) ? ts : d.toLocaleString();
+  }
+
+  async function copyEntry() {
+    if (!selectedEntry.value) return;
+    const text = `[${formatLogTimestamp(selectedEntry.value.timestamp)}] ${selectedEntry.value.level}\n${selectedEntry.value.message}`;
+    try {
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(text);
+      } else {
+        // Fallback for non-secure contexts (HTTP)
+        const el = document.createElement("textarea");
+        el.value = text;
+        el.style.position = "fixed";
+        el.style.opacity = "0";
+        document.body.appendChild(el);
+        el.select();
+        document.execCommand("copy");
+        document.body.removeChild(el);
+      }
+      copied.value = true;
+      setTimeout(() => (copied.value = false), 2000);
+    } catch {
+      // copy failed silently
+    }
   }
 
   async function handleDownloadBundle() {


### PR DESCRIPTION
## Summary

Recovers fixes that were committed to `fix/forecast-cache-key-and-backup-timezone` after PR #136 merged but were never carried forward into a new PR.

- **AccountDetailView**: `overflow-x: hidden` on root div — prevents AccountHeaderWidget from causing horizontal overflow on mobile, which was cutting off the right side of the transaction table
- **TransactionTableWidget**: hide `show-select` checkbox column on mobile (`&& mdAndUp`); limit `v-pagination` to 5 visible pages on mobile so it doesn't force the table wider than the viewport
- **AccountsMenu**: desktop group header icons downsized (`large` → `default`) to reduce excess whitespace; child account indent via CSS variable (44px) instead of `pl-6` class; `BankLogo` size 20px with tighter margin; `.accounts-menu` wrapper with scoped CSS to narrow the Vuetify prepend spacer to 8px
- **PlanningMenu**: same icon size and spacer narrowing as AccountsMenu
- **LogsView**: switch from `v-data-table` + separate `v-pagination` to `v-data-table-server` with built-in pagination footer; format log timestamps from UTC backend format to local time via `formatLogTimestamp`; add Copy button in detail dialog with clipboard fallback; striped rows + bold header styling

## Test plan

- [ ] Mobile: open account detail view — no horizontal overflow, transaction table fills width
- [ ] Mobile: transaction table — no checkbox column, pagination shows 5 pages max
- [ ] Desktop: accounts sidebar — icons are slightly smaller, child accounts indent correctly under parent
- [ ] Logs page — timestamps show in local time, pagination works, Copy button in detail dialog copies to clipboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)