### PR TITLE
feat: highlight lowest post-today balance on account forecast chart

### DIFF
--- a/frontend/src/components/AccountForecastWidget.vue
+++ b/frontend/src/components/AccountForecastWidget.vue
@@ -10,6 +10,20 @@
       <span class="text-subtitle-2 text-primary" v-else>
         Cash Flow (Last 14 Days + {{ timeFrame.title }})
       </span>
+      <v-tooltip location="bottom" text="Highlight lowest balance after today">
+        <template v-slot:activator="{ props: tipProps }">
+          <v-btn
+            :icon="showMinHighlight ? 'mdi-flag' : 'mdi-flag-outline'"
+            flat
+            size="small"
+            :color="showMinHighlight ? 'error' : undefined"
+            variant="plain"
+            :disabled="isActive"
+            v-bind="tipProps"
+            @click="toggleMinHighlight"
+          ></v-btn>
+        </template>
+      </v-tooltip>
       <v-menu location="right">
         <template v-slot:activator="{ props }">
           <v-btn
@@ -82,6 +96,13 @@
   const emit = defineEmits(["changeTime"]);
   const chips = ref(props.end_integer);
 
+  const lsKey = `forecast_min_highlight_${props.account?.[0] ?? "default"}`;
+  const showMinHighlight = ref(localStorage.getItem(lsKey) === "true");
+  function toggleMinHighlight() {
+    showMinHighlight.value = !showMinHighlight.value;
+    localStorage.setItem(lsKey, showMinHighlight.value);
+  }
+
   const { isLoading, account_forecast, isFetching } = useAccountForecasts(
     props.account,
     props.start_integer,
@@ -105,6 +126,35 @@
         y: ds.data?.[i] != null ? Number(ds.data[i]) : null,
       })),
     }));
+  });
+
+  const minPostTodayPoint = computed(() => {
+    if (!showMinHighlight.value) return null;
+    const raw = account_forecast.value;
+    if (!raw?.labels?.length || !raw?.datasets?.[0]?.data?.length) return null;
+
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
+    const labels = raw.labels;
+    const data = raw.datasets[0].data;
+
+    let minVal = Infinity;
+    let minLabel = null;
+
+    labels.forEach((label, i) => {
+      // Labels are formatted as e.g. "May 21, '26" — parse by replacing abbreviated year
+      const d = new Date(label.replace(/'/g, "20"));
+      if (d >= today && data[i] != null) {
+        const val = Number(data[i]);
+        if (val < minVal) {
+          minVal = val;
+          minLabel = label;
+        }
+      }
+    });
+
+    return minLabel !== null ? { x: minLabel, y: minVal } : null;
   });
 
   const chartOptions = computed(() => {
@@ -179,6 +229,27 @@
           borderWidth: 1,
           strokeDashArray: 0,
         }],
+        points: minPostTodayPoint.value ? [{
+          x: minPostTodayPoint.value.x,
+          y: minPostTodayPoint.value.y,
+          marker: {
+            size: 6,
+            fillColor: "#f44336",
+            strokeColor: "#fff",
+            strokeWidth: 2,
+          },
+          label: {
+            text: new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(minPostTodayPoint.value.y),
+            borderColor: "#f44336",
+            offsetY: -12,
+            style: {
+              color: "#fff",
+              background: "#f44336",
+              fontSize: "10px",
+              padding: { top: 3, bottom: 3, left: 5, right: 5 },
+            },
+          },
+        }] : [],
       },
       xaxis: {
         type: "category",

--- a/frontend/src/components/AccountForecastWidget.vue
+++ b/frontend/src/components/AccountForecastWidget.vue
@@ -145,7 +145,7 @@
     labels.forEach((label, i) => {
       // Labels are formatted as e.g. "May 21, '26" — parse by replacing abbreviated year
       const d = new Date(label.replace(/'/g, "20"));
-      if (d >= today && data[i] != null) {
+      if (d > today && data[i] != null) {
         const val = Number(data[i]);
         if (val < minVal) {
           minVal = val;


### PR DESCRIPTION
## Summary

- Adds a flag icon toggle button to the forecast widget header (next to the cog)
- Off by default; persisted per account in localStorage so each account remembers its setting independently
- When enabled, marks the lowest balance point occurring strictly after today with a red dot marker and a currency label annotation
- Reacts automatically when the timeframe chip changes

## Test plan

- [ ] Flag icon appears in forecast widget header (outline when off, solid red when on)
- [ ] Toggle on — red dot and label appear at the lowest future balance point
- [ ] Toggle off — annotation disappears
- [ ] Today's balance is excluded — only strictly future dates are considered
- [ ] Switching timeframes updates the highlighted point correctly
- [ ] Setting persists per account across page navigation (localStorage)
- [ ] Different accounts remember their own setting independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)