### PR TITLE
fix: coordinate version banner reload with service worker lifecycle

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -89,8 +89,25 @@
   const route = useRoute();
   const showNav = computed(() => route.name !== "login");
 
-  const reloadPage = () => {
-    window.location.reload();
+  const reloadPage = async () => {
+    if (!("serviceWorker" in navigator)) {
+      window.location.reload();
+      return;
+    }
+    const registration = await navigator.serviceWorker.getRegistration();
+    const pending = registration?.waiting || registration?.installing;
+    if (pending) {
+      // New SW is ready but hasn't taken control yet — activate it then reload
+      navigator.serviceWorker.addEventListener(
+        "controllerchange",
+        () => window.location.reload(),
+        { once: true },
+      );
+      pending.postMessage({ type: "SKIP_WAITING" });
+    } else {
+      // SW already up to date, just reload
+      window.location.reload();
+    }
   };
   const mainstore = useMainStore();
   const { prefetchOptions } = useOptions();


### PR DESCRIPTION
## Summary

The version mismatch banner required multiple refreshes to clear because `window.location.reload()` could fire while the new service worker was still installing. The old SW would serve the old cached JS bundle, `VITE_APP_VERSION` would still be stale, and the banner would reappear.

The fix coordinates the reload with the SW lifecycle:
1. Check for a pending SW (`waiting` or `installing`)
2. If found: send `SKIP_WAITING`, listen for `controllerchange`, then reload — guaranteeing the new SW is in control before the page loads fresh assets
3. If no pending SW: the new SW is already active, reload immediately as before

## Test plan

- [ ] Deploy a version change to alpha
- [ ] Open app — version banner appears
- [ ] Click Refresh — banner clears in a single reload
- [ ] No repeated refresh prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)