### PR TITLE
chore: fix Reddit announcement script to parse version tag

### DIFF
--- a/scripts/post_to_reddit.py
+++ b/scripts/post_to_reddit.py
@@ -1,4 +1,5 @@
 import os
+import re
 from pathlib import Path
 import praw
 
@@ -8,14 +9,25 @@ FLAIR_ID_MAP = {
 }
 
 
+def get_release_type(tag):
+    match = re.match(r"v?(\d+)\.(\d+)\.(\d+)", tag)
+    if not match:
+        return None
+    minor, patch = int(match.group(2)), int(match.group(3))
+    if patch != 0:
+        return None
+    return "major" if minor == 0 else "minor"
+
+
 def main():
-    tag = os.environ["COMMIT_TAG"].lower()
-    version = Path("scripts/version.txt").read_text().strip()
+    tag = os.environ["COMMIT_TAG"]
+    version = tag.lstrip("v")
     changelog = os.environ["RELEASE_NOTES"]
 
-    flair_id = FLAIR_ID_MAP.get(tag)
+    release_type = get_release_type(tag)
+    flair_id = FLAIR_ID_MAP.get(release_type) if release_type else None
     if not flair_id:
-        print(f"⚠️ Unknown tag '{tag}', skipping Reddit post.")
+        print(f"⚠️ '{tag}' is a patch release or unrecognized format, skipping Reddit post.")
         return
 
     reddit = praw.Reddit(


### PR DESCRIPTION
## Summary
- `post_to_reddit.py` received `COMMIT_TAG="v1.4.0"` but looked up `FLAIR_ID_MAP.get("v1.4.0")` → `None` → skipped post
- Added `get_release_type()` that parses `vX.Y.Z`: minor=0 → "major", minor>0 → "minor", patch>0 → None (skip)
- Derive version from tag directly (`tag.lstrip("v")`) instead of stale `scripts/version.txt`

Using `chore:` prefix so no new release is triggered — this is a script fix only.

## After merge
Manually trigger the **Announce on Reddit** workflow via workflow_dispatch with `tag: v1.4.0` to backfill the missed v1.4.0 announcement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)