### PR TITLE
fix: restore UserAdmin fieldsets by correcting MRO in RestrictedUserAdmin

### DIFF
--- a/backend/administration/admin.py
+++ b/backend/administration/admin.py
@@ -66,7 +66,7 @@ class DescriptionHistoryAdmin(UnfoldImportExportModelAdmin):
     ordering = ["id"]
 
 
-class RestrictedUserAdmin(ModelAdmin, UserAdmin):
+class RestrictedUserAdmin(UserAdmin, ModelAdmin):
     """
     Readonly-group users can only view and change their own profile.
     Full Access users and superusers retain normal UserAdmin behaviour.


### PR DESCRIPTION
## Summary
- Add-user form in Django admin rendered blank after the Unfold migration
- Root cause: `RestrictedUserAdmin(ModelAdmin, UserAdmin)` — Unfold's `ModelAdmin` comes first in the MRO, shadowing `UserAdmin.add_fieldsets` (which defines the username/password fields for new user creation)
- Fix: swap to `RestrictedUserAdmin(UserAdmin, ModelAdmin)` so Django's `UserAdmin` fieldsets are resolved first; Unfold styling still applies via the MRO chain

## Test plan
- [ ] Open Django admin → Users → Add user — form should show username + password fields
- [ ] Confirm existing user edit form still works
- [ ] Confirm readonly-group users still only see their own profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)