### PR TITLE
fix: combined chip display and reminder conversion race condition

### DIFF
--- a/frontend/src/components/AccountForecastWidget.vue
+++ b/frontend/src/components/AccountForecastWidget.vue
@@ -261,6 +261,7 @@
         tooltip: { enabled: false },
       },
       yaxis: {
+        min: min,
         labels: {
           formatter: val =>
             val != null

--- a/frontend/src/components/AccountsMenu.vue
+++ b/frontend/src/components/AccountsMenu.vue
@@ -67,10 +67,8 @@
             <BankLogo :logo-url="account.bank?.logo_url" :size="20" class="mr-1" />
           </template>
           <v-list-item-title>
-            <span :class="isMobile ? 'text-subtitle-1 font-weight-bold' : ''">
-              {{ account.account_name }}
-              <v-chip v-if="account.is_parent_account" size="x-small" color="secondary" label class="ml-1">combined</v-chip>
-            </span>
+            <span :class="isMobile ? 'text-subtitle-1 font-weight-bold' : ''">{{ account.account_name }}</span>
+            <v-chip v-if="account.is_parent_account" size="x-small" color="secondary" variant="tonal" label class="ml-1">combined</v-chip>
           </v-list-item-title>
           <v-list-item-subtitle>
             <span
@@ -134,10 +132,8 @@
             <BankLogo :logo-url="account.bank?.logo_url" :size="20" class="mr-1" />
           </template>
           <v-list-item-title>
-            <span :class="isMobile ? 'text-subtitle-1 font-weight-bold' : ''">
-              {{ account.account_name }}
-              <v-chip v-if="account.is_parent_account" size="x-small" color="secondary" label class="ml-1">combined</v-chip>
-            </span>
+            <span :class="isMobile ? 'text-subtitle-1 font-weight-bold' : ''">{{ account.account_name }}</span>
+            <v-chip v-if="account.is_parent_account" size="x-small" color="secondary" variant="tonal" label class="ml-1">combined</v-chip>
           </v-list-item-title>
           <v-list-item-subtitle>
             <span
@@ -201,10 +197,8 @@
             <BankLogo :logo-url="account.bank?.logo_url" :size="20" class="mr-1" />
           </template>
           <v-list-item-title>
-            <span :class="isMobile ? 'text-subtitle-1 font-weight-bold' : ''">
-              {{ account.account_name }}
-              <v-chip v-if="account.is_parent_account" size="x-small" color="secondary" label class="ml-1">combined</v-chip>
-            </span>
+            <span :class="isMobile ? 'text-subtitle-1 font-weight-bold' : ''">{{ account.account_name }}</span>
+            <v-chip v-if="account.is_parent_account" size="x-small" color="secondary" variant="tonal" label class="ml-1">combined</v-chip>
           </v-list-item-title>
           <v-list-item-subtitle>
             <span
@@ -268,10 +262,8 @@
             <BankLogo :logo-url="account.bank?.logo_url" :size="20" class="mr-1" />
           </template>
           <v-list-item-title>
-            <span :class="isMobile ? 'text-subtitle-1 font-weight-bold' : ''">
-              {{ account.account_name }}
-              <v-chip v-if="account.is_parent_account" size="x-small" color="secondary" label class="ml-1">combined</v-chip>
-            </span>
+            <span :class="isMobile ? 'text-subtitle-1 font-weight-bold' : ''">{{ account.account_name }}</span>
+            <v-chip v-if="account.is_parent_account" size="x-small" color="secondary" variant="tonal" label class="ml-1">combined</v-chip>
           </v-list-item-title>
           <v-list-item-subtitle>
             <span
@@ -335,10 +327,8 @@
             <BankLogo :logo-url="account.bank?.logo_url" :size="20" class="mr-1" />
           </template>
           <v-list-item-title>
-            <span :class="isMobile ? 'text-subtitle-1 font-weight-bold' : ''">
-              {{ account.account_name }}
-              <v-chip v-if="account.is_parent_account" size="x-small" color="secondary" label class="ml-1">combined</v-chip>
-            </span>
+            <span :class="isMobile ? 'text-subtitle-1 font-weight-bold' : ''">{{ account.account_name }}</span>
+            <v-chip v-if="account.is_parent_account" size="x-small" color="secondary" variant="tonal" label class="ml-1">combined</v-chip>
           </v-list-item-title>
           <v-list-item-subtitle>
             <span
@@ -472,5 +462,8 @@
 }
 .accounts-menu .v-list-group__items .v-list-item {
   padding-inline-start: calc(14px + var(--child-indent, 0px)) !important;
+}
+.accounts-menu .v-list-item-title {
+  overflow: visible;
 }
 </style>

--- a/frontend/src/components/TransactionTableWidget.vue
+++ b/frontend/src/components/TransactionTableWidget.vue
@@ -1032,7 +1032,9 @@
   };
 
   const clickClearTransaction = async (transactions, reminderTransactions) => {
-    clearTransaction(transactions);
+    if (transactions.length > 0) {
+      clearTransaction(transactions);
+    }
     open.value = false;
     selected_all.value = [];
     reminderTransactions.forEach(transaction => {

--- a/frontend/src/composables/remindersComposable.js
+++ b/frontend/src/composables/remindersComposable.js
@@ -125,6 +125,13 @@ export function useReminders() {
       queryClient.invalidateQueries({ queryKey: ["account_forecast"] });
       queryClient.invalidateQueries({ queryKey: ["tag_graph"] });
       queryClient.invalidateQueries({ queryKey: ["reminders"] });
+      // Delayed refetch ensures the async reminder cache rebuild (django-q2 worker)
+      // has completed before the UI shows the final state.
+      setTimeout(() => {
+        queryClient.invalidateQueries({ queryKey: ["transactions"] });
+        queryClient.invalidateQueries({ queryKey: ["account_forecast"] });
+        queryClient.invalidateQueries({ queryKey: ["accounts"] });
+      }, 3500);
     },
   });
 


### PR DESCRIPTION
## Summary

### Bug 1: "Combined" chip blank in desktop account menu
- `v-chip` nested inside `<span>` inside `v-list-item-title` — Vuetify's `overflow: hidden` on the title clips the chip vertically, hiding its text
- Fix: move chip out of the inner `<span>` (sibling level), add `variant="tonal"` for predictable text/background rendering, and add `overflow: visible` CSS to the title in the accounts-menu context

### Bug 2: Reminder conversion temporarily shows both virtual and real transaction
- Root cause: `clickClearTransaction` always called `clearTransaction(transactions)` even when `transactions = []` (only a reminder was selected). The empty `clearTransaction` call completed first and its `onSuccess` triggered an early refetch **before** `addReminderTransaction` had finished rebuilding `ReminderCacheTransaction`. At that moment the DB already had the new real transaction (Transaction post_save cleared the Redis cache) but `ReminderCacheTransaction` still had the old virtual entry — so the backend returned both.
- Fix 1: Guard `clearTransaction` to only fire when there are actual real transactions to clear
- Fix 2: Add 3.5s delayed refetch in `addReminderTransMutation.onSuccess` (matching the `scheduleForecastRefetch` pattern used by all other transaction mutations) to catch any async reminder cache rebuild from the django-q2 worker

### Bug 3: Account forecast y-axis doesn't anchor to \$0
- When all balances are positive (e.g. \$7K–\$10K checking account), ApexCharts auto-scaled to the data range, making small fluctuations look dramatic
- `min` was already computed as `Math.min(0, allValues)` for the gradient color-stop logic — wired it into `yaxis.min` so \$0 is always the baseline

## Test plan
- [ ] Parent account in desktop menu shows "combined" chip with visible text
- [ ] Select a reminder virtual transaction → click clear → verify only the real transaction shows (no duplicate virtual)
- [ ] Select both a real transaction and a reminder → clear both → verify both convert correctly
- [ ] Account forecast for a positive-balance account shows y-axis starting at \$0

🤖 Generated with [Claude Code](https://claude.com/claude-code)