### PR TITLE
fix: combined chip display, reminder conversion race, and forecast y-axis scale

### DIFF
--- a/frontend/src/components/AccountForecastWidget.vue
+++ b/frontend/src/components/AccountForecastWidget.vue
@@ -261,6 +261,7 @@
         tooltip: { enabled: false },
       },
       yaxis: {
+        min: min,
         labels: {
           formatter: val =>
             val != null

--- a/frontend/src/components/AccountsMenu.vue
+++ b/frontend/src/components/AccountsMenu.vue
@@ -67,10 +67,8 @@
             <BankLogo :logo-url="account.bank?.logo_url" :size="20" class="mr-1" />
           </template>
           <v-list-item-title>
-            <span :class="isMobile ? 'text-subtitle-1 font-weight-bold' : ''">
-              {{ account.account_name }}
-              <v-chip v-if="account.is_parent_account" size="x-small" color="secondary" label class="ml-1">combined</v-chip>
-            </span>
+            <span :class="isMobile ? 'text-subtitle-1 font-weight-bold' : ''">{{ account.account_name }}</span>
+            <v-chip v-if="account.is_parent_account" size="x-small" color="secondary" variant="tonal" label class="ml-1">combined</v-chip>
           </v-list-item-title>
           <v-list-item-subtitle>
             <span
@@ -134,10 +132,8 @@
             <BankLogo :logo-url="account.bank?.logo_url" :size="20" class="mr-1" />
           </template>
           <v-list-item-title>
-            <span :class="isMobile ? 'text-subtitle-1 font-weight-bold' : ''">
-              {{ account.account_name }}
-              <v-chip v-if="account.is_parent_account" size="x-small" color="secondary" label class="ml-1">combined</v-chip>
-            </span>
+            <span :class="isMobile ? 'text-subtitle-1 font-weight-bold' : ''">{{ account.account_name }}</span>
+            <v-chip v-if="account.is_parent_account" size="x-small" color="secondary" variant="tonal" label class="ml-1">combined</v-chip>
           </v-list-item-title>
           <v-list-item-subtitle>
             <span
@@ -201,10 +197,8 @@
             <BankLogo :logo-url="account.bank?.logo_url" :size="20" class="mr-1" />
           </template>
           <v-list-item-title>
-            <span :class="isMobile ? 'text-subtitle-1 font-weight-bold' : ''">
-              {{ account.account_name }}
-              <v-chip v-if="account.is_parent_account" size="x-small" color="secondary" label class="ml-1">combined</v-chip>
-            </span>
+            <span :class="isMobile ? 'text-subtitle-1 font-weight-bold' : ''">{{ account.account_name }}</span>
+            <v-chip v-if="account.is_parent_account" size="x-small" color="secondary" variant="tonal" label class="ml-1">combined</v-chip>
           </v-list-item-title>
           <v-list-item-subtitle>
             <span
@@ -268,10 +262,8 @@
             <BankLogo :logo-url="account.bank?.logo_url" :size="20" class="mr-1" />
           </template>
           <v-list-item-title>
-            <span :class="isMobile ? 'text-subtitle-1 font-weight-bold' : ''">
-              {{ account.account_name }}
-              <v-chip v-if="account.is_parent_account" size="x-small" color="secondary" label class="ml-1">combined</v-chip>
-            </span>
+            <span :class="isMobile ? 'text-subtitle-1 font-weight-bold' : ''">{{ account.account_name }}</span>
+            <v-chip v-if="account.is_parent_account" size="x-small" color="secondary" variant="tonal" label class="ml-1">combined</v-chip>
           </v-list-item-title>
           <v-list-item-subtitle>
             <span
@@ -335,10 +327,8 @@
             <BankLogo :logo-url="account.bank?.logo_url" :size="20" class="mr-1" />
           </template>
           <v-list-item-title>
-            <span :class="isMobile ? 'text-subtitle-1 font-weight-bold' : ''">
-              {{ account.account_name }}
-              <v-chip v-if="account.is_parent_account" size="x-small" color="secondary" label class="ml-1">combined</v-chip>
-            </span>
+            <span :class="isMobile ? 'text-subtitle-1 font-weight-bold' : ''">{{ account.account_name }}</span>
+            <v-chip v-if="account.is_parent_account" size="x-small" color="secondary" variant="tonal" label class="ml-1">combined</v-chip>
           </v-list-item-title>
           <v-list-item-subtitle>
             <span
@@ -472,5 +462,8 @@
 }
 .accounts-menu .v-list-group__items .v-list-item {
   padding-inline-start: calc(14px + var(--child-indent, 0px)) !important;
+}
+.accounts-menu .v-list-item-title {
+  overflow: visible;
 }
 </style>

--- a/frontend/src/components/TransactionTableWidget.vue
+++ b/frontend/src/components/TransactionTableWidget.vue
@@ -1032,7 +1032,9 @@
   };
 
   const clickClearTransaction = async (transactions, reminderTransactions) => {
-    clearTransaction(transactions);
+    if (transactions.length > 0) {
+      clearTransaction(transactions);
+    }
     open.value = false;
     selected_all.value = [];
     reminderTransactions.forEach(transaction => {

--- a/frontend/src/composables/remindersComposable.js
+++ b/frontend/src/composables/remindersComposable.js
@@ -125,6 +125,13 @@ export function useReminders() {
       queryClient.invalidateQueries({ queryKey: ["account_forecast"] });
       queryClient.invalidateQueries({ queryKey: ["tag_graph"] });
       queryClient.invalidateQueries({ queryKey: ["reminders"] });
+      // Delayed refetch ensures the async reminder cache rebuild (django-q2 worker)
+      // has completed before the UI shows the final state.
+      setTimeout(() => {
+        queryClient.invalidateQueries({ queryKey: ["transactions"] });
+        queryClient.invalidateQueries({ queryKey: ["account_forecast"] });
+        queryClient.invalidateQueries({ queryKey: ["accounts"] });
+      }, 3500);
     },
   });
 


### PR DESCRIPTION
## Summary

Cherry-pick of fixes from #148 (merged to alpha as v1.4.0-alpha.47) targeting main for v1.4.2.

### Bug 1: "Combined" chip blank in desktop account menu
- `v-chip` nested inside `<span>` inside `v-list-item-title` — Vuetify's `overflow: hidden` clips the chip vertically, hiding its text
- Fix: move chip outside the inner `<span>`, add `variant="tonal"`, add `overflow: visible` CSS in accounts-menu context

### Bug 2: Reminder conversion temporarily shows both virtual and real transaction
- `clickClearTransaction` always called `clearTransaction([])` even when only a reminder was selected — the empty mutation completed first and its `onSuccess` triggered a refetch before `addReminderTransaction` finished rebuilding `ReminderCacheTransaction`, returning both entries simultaneously
- Fix: guard `clearTransaction` to only fire when there are real transactions; add 3.5s delayed refetch to `addReminderTransMutation.onSuccess` matching the pattern used by all other mutations

### Bug 3: Account forecast y-axis doesn't anchor to \$0
- Auto-scaling made small balance fluctuations look dramatic for accounts that never go negative
- `min` was already computed as `Math.min(0, allValues)` for gradient logic — wired into `yaxis.min`

## Test plan
- [ ] Parent account in desktop menu shows "combined" chip with visible text
- [ ] Select a reminder virtual transaction → click clear → only real transaction shows
- [ ] Account forecast for a positive-balance account shows y-axis starting at \$0

🤖 Generated with [Claude Code](https://claude.com/claude-code)