### PR TITLE
fix: add Apple PWA meta tags for mobile install prompt

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,12 @@
     <meta charset="UTF-8" />
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#06966a" />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <meta name="apple-mobile-web-app-title" content="LenoreFin" />
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <title>LenoreFin</title>
   </head>
   <body>


### PR DESCRIPTION
## Summary
- Adds missing Apple-specific PWA meta tags to `frontend/index.html`
- Adds `apple-touch-icon` link pointing to the existing `public/apple-touch-icon.png`
- Adds explicit `theme-color` meta tag (vite-plugin-pwa injects the manifest link at build time but does NOT inject Apple meta tags)

## Tags added
- `mobile-web-app-capable` — Android Chrome install eligibility
- `apple-mobile-web-app-capable` — iOS "Add to Home Screen" eligibility
- `apple-mobile-web-app-status-bar-style` — iOS status bar appearance
- `apple-mobile-web-app-title` — Home screen icon label on iOS
- `apple-touch-icon` — iOS home screen icon
- `theme-color` — Browser chrome color (explicit fallback)

## Test plan
- [ ] Build and deploy to staging/prod
- [ ] Open on iOS Safari → Share → verify "Add to Home Screen" option appears
- [ ] Open on Android Chrome → verify install prompt appears in browser bar
- [ ] Confirm installed app shows correct icon and title

🤖 Generated with [Claude Code](https://claude.com/claude-code)