### PR TITLE
fix: convert note_text to TextField and remove frontend 254-char limit

### DIFF
--- a/backend/planning/migrations/0008_note_text_to_textfield.py
+++ b/backend/planning/migrations/0008_note_text_to_textfield.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("planning", "0007_rename_current_start_budget_next_start"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="note",
+            name="note_text",
+            field=models.TextField(),
+        ),
+    ]

--- a/backend/planning/models.py
+++ b/backend/planning/models.py
@@ -88,11 +88,11 @@ class Note(models.Model):
     Model representing a note used to add notes relevant to planning.
 
     Fields:
-    - note_text (CharField): The text of the note, limited to 254 characters
+    - note_text (TextField): The text of the note, unlimited length.
     - note_date (DateField): the date this note was added, defaults to today.
     """
 
-    note_text = models.CharField(max_length=254)
+    note_text = models.TextField()
     note_date = models.DateField(default=current_date)
 
     def __str__(self):

--- a/frontend/src/components/NoteForm.vue
+++ b/frontend/src/components/NoteForm.vue
@@ -34,7 +34,6 @@
                     :rows="11"
                     no-resize
                     :error-messages="note_text.errorMessage.value"
-                    :counter="254"
                   ></v-textarea>
                 </v-col>
               </v-row>
@@ -63,9 +62,9 @@
   const { handleSubmit } = useForm({
     validationSchema: {
       note_text(value) {
-        if (value?.length >= 2 && value?.length <= 254) return true;
+        if (value?.length >= 2) return true;
 
-        return "Note needs to be at least 2 characters, and less than 254.";
+        return "Note must be at least 2 characters.";
       },
       note_date(value) {
         if (value) return true;


### PR DESCRIPTION
## Summary
- Converts `Note.note_text` from `CharField(max_length=254)` to `TextField()` (no length limit)
- Adds migration `0008_note_text_to_textfield.py`
- Removes `:counter="254"` from the note textarea in `NoteForm.vue`
- Updates validation to only enforce the 2-character minimum (no upper bound)
- Updates model docstring to reflect the new field type

## Test plan
- [ ] Run `python manage.py migrate` — migration applies cleanly
- [ ] Add a note longer than 254 characters — saves successfully
- [ ] Edit an existing note — no regression
- [ ] Short note (< 2 chars) still shows validation error

🤖 Generated with [Claude Code](https://claude.com/claude-code)