### PR TITLE
feat: add account favorites with FAVORITES section and header toggle

### DIFF
--- a/backend/accounts/api/schemas/account.py
+++ b/backend/accounts/api/schemas/account.py
@@ -66,6 +66,7 @@ class AccountOut(Schema):
     due_day: Optional[int] = 15
     pay_day: Optional[int] = 15
     interest_deposit_day: Optional[int] = None
+    is_favorite: bool = False
     is_parent_account: bool = False
     parent_account_id: Optional[int] = None
     interest_child_account_id: Optional[int] = None
@@ -101,6 +102,7 @@ class AccountUpdate(Schema):
     interest_deposit_day: Optional[int] = None
     parent_account_id: Optional[int] = None
     interest_child_account_id: Optional[int] = None
+    is_favorite: Optional[bool] = None
 
 
 class AccountQuery(Schema):

--- a/backend/accounts/api/views/account.py
+++ b/backend/accounts/api/views/account.py
@@ -195,6 +195,32 @@ def update_account(request, account_id: int, payload: AccountUpdate):
         raise HttpError(500, f"Record update error: {str(e)}")
 
 
+@account_router.post("/toggle-favorite/{account_id}", auth=FullAccessAuth())
+def toggle_favorite(request, account_id: int):
+    """
+    The function `toggle_favorite` flips the is_favorite flag on an account.
+
+    Args:
+        request (HttpRequest): The HTTP request object.
+        account_id (int): the id of the account to toggle.
+
+    Returns:
+        is_favorite: the new value of is_favorite
+    """
+    try:
+        account = get_object_or_404(Account, id=account_id)
+        account.is_favorite = not account.is_favorite
+        account.save()
+        api_logger.info(
+            f"Account favorite toggled : {account.account_name} -> {account.is_favorite}"
+        )
+        return {"is_favorite": account.is_favorite}
+    except Exception as e:
+        api_logger.error("Account favorite not toggled")
+        error_logger.exception(f"{str(e)}")
+        raise HttpError(500, f"Toggle error: {str(e)}")
+
+
 @account_router.delete("/delete/{account_id}", auth=FullAccessAuth())
 def delete_account(request, account_id: int):
     """

--- a/backend/accounts/dto.py
+++ b/backend/accounts/dto.py
@@ -53,6 +53,7 @@ class DomainAccount:
     due_day: Optional[int] = 15
     pay_day: Optional[int] = 15
     interest_deposit_day: Optional[int] = None
+    is_favorite: bool = False
     is_parent_account: bool = False
     parent_account_id: Optional[int] = None
     interest_child_account_id: Optional[int] = None

--- a/backend/accounts/mappers.py
+++ b/backend/accounts/mappers.py
@@ -77,6 +77,7 @@ def domain_account_to_schema(
             due_day=account.due_day,
             pay_day=account.pay_day,
             interest_deposit_day=account.interest_deposit_day,
+            is_favorite=account.is_favorite,
             is_parent_account=account.is_parent_account,
             parent_account_id=account.parent_account_id,
             interest_child_account_id=account.interest_child_account_id,

--- a/backend/accounts/migrations/0020_account_is_favorite.py
+++ b/backend/accounts/migrations/0020_account_is_favorite.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("accounts", "0019_populate_bank_logo_urls"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="account",
+            name="is_favorite",
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/backend/accounts/models.py
+++ b/backend/accounts/models.py
@@ -137,6 +137,7 @@ class Account(models.Model):
     due_day = models.IntegerField(default=15)
     pay_day = models.IntegerField(default=15)
     interest_deposit_day = models.IntegerField(null=True, blank=True, default=None)
+    is_favorite = models.BooleanField(default=False)
     parent_account = models.ForeignKey(
         "self",
         null=True,

--- a/backend/accounts/services/account_financials.py
+++ b/backend/accounts/services/account_financials.py
@@ -119,6 +119,7 @@ def get_account_financials(account_id: int, today: date | None = None):
         due_day=account.due_day,
         pay_day=account.pay_day,
         interest_deposit_day=account.interest_deposit_day,
+        is_favorite=account.is_favorite,
         is_parent_account=is_parent,
         parent_account_id=account.parent_account_id,
         interest_child_account_id=account.interest_child_account_id,

--- a/frontend/src/components/AccountHeaderWidget.vue
+++ b/frontend/src/components/AccountHeaderWidget.vue
@@ -79,6 +79,25 @@
                   @update-dialog="updateEditDialog"
                 />
                 <v-tooltip
+                  :text="account.is_favorite ? 'Remove from Favorites' : 'Add to Favorites'"
+                  location="top"
+                  v-if="authStore.isFullAccess"
+                >
+                  <template v-slot:activator="{ props }">
+                    <v-btn
+                      :icon="account.is_favorite ? 'mdi-star' : 'mdi-star-outline'"
+                      :color="account.is_favorite ? 'amber' : undefined"
+                      flat
+                      variant="text"
+                      @click="toggleFavorite(account.id)"
+                      v-bind="props"
+                      size="small"
+                      class="mx-0"
+                      :disabled="!isOnline"
+                    />
+                  </template>
+                </v-tooltip>
+                <v-tooltip
                   :text="account.active ? 'Delete Account' : 'Enable Account'"
                   location="top"
                   v-if="authStore.isFullAccess"
@@ -377,7 +396,7 @@
 </template>
 <script setup>
   import { defineProps, ref } from "vue";
-  import { useAccountByID } from "@/composables/accountsComposable";
+  import { useAccountByID, useAccounts } from "@/composables/accountsComposable";
   import EditAccountForm from "./EditAccountForm.vue";
   import AdjustBalanceForm from "./AdjustBalanceForm.vue";
   import DeleteAccountForm from "./DeleteAccountForm.vue";
@@ -401,6 +420,7 @@
   });
 
   const { account } = useAccountByID(props.account);
+  const { toggleFavorite } = useAccounts();
 
   const updateAdjBalDialog = value => {
     adjBalDialog.value = value;

--- a/frontend/src/components/AccountHeaderWidget.vue
+++ b/frontend/src/components/AccountHeaderWidget.vue
@@ -47,7 +47,7 @@
                   aria-hidden="true"
                 />
                 <v-chip v-if="account.is_parent_account" size="x-small" color="secondary" label class="mr-1">combined</v-chip>
-                <!-- Desktop: tooltip + inline action buttons -->
+                <!-- Desktop: tooltip triggers edit on click -->
                 <v-tooltip text="Edit Account" location="top" v-if="authStore.isFullAccess && !smAndDown">
                   <template v-slot:activator="{ props }">
                     <span
@@ -67,16 +67,8 @@
                     </span>
                   </template>
                 </v-tooltip>
-                <!-- Mobile: tap name to open action drawer -->
-                <span
-                  class="mx-1"
-                  v-if="authStore.isFullAccess && smAndDown"
-                  @click="actionDrawer = true"
-                  tabindex="0"
-                  @keydown.enter="actionDrawer = true"
-                  role="button"
-                  aria-pressed="false"
-                >
+                <!-- Mobile full-access: plain name text (chevron is the toggle) -->
+                <span class="mx-1 flex-grow-1" v-if="authStore.isFullAccess && smAndDown">
                   {{
                     account.active
                       ? account.account_name
@@ -122,9 +114,7 @@
                 >
                   <template v-slot:activator="{ props }">
                     <v-btn
-                      :icon="
-                        account.active ? 'mdi-delete' : 'mdi-delete-restore'
-                      "
+                      :icon="account.active ? 'mdi-delete' : 'mdi-delete-restore'"
                       flat
                       variant="text"
                       @click="deleteDialog = true"
@@ -135,49 +125,64 @@
                     />
                   </template>
                 </v-tooltip>
+                <!-- Mobile chevron toggle -->
+                <v-btn
+                  v-if="authStore.isFullAccess && smAndDown"
+                  :icon="actionDrawer ? 'mdi-chevron-up' : 'mdi-chevron-down'"
+                  flat
+                  variant="text"
+                  size="small"
+                  class="mx-0"
+                  @click="actionDrawer = !actionDrawer"
+                />
                 <DeleteAccountForm
                   v-model="deleteDialog"
                   :account="account"
                   @update-dialog="updateDeleteDialog"
                 />
-                <!-- Mobile action bottom sheet -->
-                <v-bottom-sheet v-model="actionDrawer" v-if="authStore.isFullAccess && smAndDown">
-                  <v-card>
-                    <v-card-title class="text-center text-body-1 pt-4 pb-2">
-                      {{ account.account_name }}
-                    </v-card-title>
-                    <v-card-text class="d-flex justify-center ga-4 pb-6">
-                      <v-btn
-                        variant="tonal"
-                        color="primary"
-                        prepend-icon="mdi-pencil"
-                        @click="actionDrawer = false; editDialog = true"
-                        :disabled="!isOnline"
-                      >
-                        Edit
-                      </v-btn>
-                      <v-btn
-                        variant="tonal"
-                        :color="account.is_favorite ? 'amber' : 'default'"
-                        :prepend-icon="account.is_favorite ? 'mdi-star' : 'mdi-star-outline'"
-                        @click="toggleFavorite(account.id); actionDrawer = false"
-                        :disabled="!isOnline"
-                      >
-                        {{ account.is_favorite ? 'Unfavorite' : 'Favorite' }}
-                      </v-btn>
-                      <v-btn
-                        variant="tonal"
-                        color="error"
-                        :prepend-icon="account.active ? 'mdi-delete' : 'mdi-delete-restore'"
-                        @click="actionDrawer = false; deleteDialog = true"
-                        :disabled="!isOnline"
-                      >
-                        {{ account.active ? 'Delete' : 'Enable' }}
-                      </v-btn>
-                    </v-card-text>
-                  </v-card>
-                </v-bottom-sheet>
               </v-card>
+              <!-- Mobile inline action expand panel -->
+              <v-expand-transition>
+                <v-card
+                  v-if="actionDrawer && authStore.isFullAccess && smAndDown"
+                  class="mx-1 mt-0 bg-primary-lighten-1"
+                  variant="outlined"
+                  rounded="0 0 4 4"
+                >
+                  <v-card-text class="d-flex justify-center ga-3 py-2 px-2">
+                    <v-btn
+                      variant="tonal"
+                      color="primary"
+                      prepend-icon="mdi-pencil"
+                      size="small"
+                      @click="actionDrawer = false; editDialog = true"
+                      :disabled="!isOnline"
+                    >
+                      Edit
+                    </v-btn>
+                    <v-btn
+                      variant="tonal"
+                      :color="account.is_favorite ? 'amber' : undefined"
+                      :prepend-icon="account.is_favorite ? 'mdi-star' : 'mdi-star-outline'"
+                      size="small"
+                      @click="toggleFavorite(account.id)"
+                      :disabled="!isOnline"
+                    >
+                      {{ account.is_favorite ? 'Unfavorite' : 'Favorite' }}
+                    </v-btn>
+                    <v-btn
+                      variant="tonal"
+                      color="error"
+                      :prepend-icon="account.active ? 'mdi-delete' : 'mdi-delete-restore'"
+                      size="small"
+                      @click="actionDrawer = false; deleteDialog = true"
+                      :disabled="!isOnline"
+                    >
+                      {{ account.active ? 'Delete' : 'Enable' }}
+                    </v-btn>
+                  </v-card-text>
+                </v-card>
+              </v-expand-transition>
             </v-col>
             <v-col cols="2" v-if="!smAndDown"></v-col>
           </v-row>

--- a/frontend/src/components/AccountHeaderWidget.vue
+++ b/frontend/src/components/AccountHeaderWidget.vue
@@ -47,7 +47,8 @@
                   aria-hidden="true"
                 />
                 <v-chip v-if="account.is_parent_account" size="x-small" color="secondary" label class="mr-1">combined</v-chip>
-                <v-tooltip text="Edit Account" location="top" v-if="authStore.isFullAccess">
+                <!-- Desktop: tooltip + inline action buttons -->
+                <v-tooltip text="Edit Account" location="top" v-if="authStore.isFullAccess && !smAndDown">
                   <template v-slot:activator="{ props }">
                     <span
                       class="mx-1"
@@ -66,7 +67,23 @@
                     </span>
                   </template>
                 </v-tooltip>
-                <span class="mx-1" v-else>
+                <!-- Mobile: tap name to open action drawer -->
+                <span
+                  class="mx-1"
+                  v-if="authStore.isFullAccess && smAndDown"
+                  @click="actionDrawer = true"
+                  tabindex="0"
+                  @keydown.enter="actionDrawer = true"
+                  role="button"
+                  aria-pressed="false"
+                >
+                  {{
+                    account.active
+                      ? account.account_name
+                      : account.account_name + " (Inactive)"
+                  }}
+                </span>
+                <span class="mx-1" v-if="!authStore.isFullAccess">
                   {{
                     account.active
                       ? account.account_name
@@ -78,10 +95,11 @@
                   :account="account"
                   @update-dialog="updateEditDialog"
                 />
+                <!-- Desktop inline action buttons -->
                 <v-tooltip
                   :text="account.is_favorite ? 'Remove from Favorites' : 'Add to Favorites'"
                   location="top"
-                  v-if="authStore.isFullAccess"
+                  v-if="authStore.isFullAccess && !smAndDown"
                 >
                   <template v-slot:activator="{ props }">
                     <v-btn
@@ -100,7 +118,7 @@
                 <v-tooltip
                   :text="account.active ? 'Delete Account' : 'Enable Account'"
                   location="top"
-                  v-if="authStore.isFullAccess"
+                  v-if="authStore.isFullAccess && !smAndDown"
                 >
                   <template v-slot:activator="{ props }">
                     <v-btn
@@ -122,6 +140,43 @@
                   :account="account"
                   @update-dialog="updateDeleteDialog"
                 />
+                <!-- Mobile action bottom sheet -->
+                <v-bottom-sheet v-model="actionDrawer" v-if="authStore.isFullAccess && smAndDown">
+                  <v-card>
+                    <v-card-title class="text-center text-body-1 pt-4 pb-2">
+                      {{ account.account_name }}
+                    </v-card-title>
+                    <v-card-text class="d-flex justify-center ga-4 pb-6">
+                      <v-btn
+                        variant="tonal"
+                        color="primary"
+                        prepend-icon="mdi-pencil"
+                        @click="actionDrawer = false; editDialog = true"
+                        :disabled="!isOnline"
+                      >
+                        Edit
+                      </v-btn>
+                      <v-btn
+                        variant="tonal"
+                        :color="account.is_favorite ? 'amber' : 'default'"
+                        :prepend-icon="account.is_favorite ? 'mdi-star' : 'mdi-star-outline'"
+                        @click="toggleFavorite(account.id); actionDrawer = false"
+                        :disabled="!isOnline"
+                      >
+                        {{ account.is_favorite ? 'Unfavorite' : 'Favorite' }}
+                      </v-btn>
+                      <v-btn
+                        variant="tonal"
+                        color="error"
+                        :prepend-icon="account.active ? 'mdi-delete' : 'mdi-delete-restore'"
+                        @click="actionDrawer = false; deleteDialog = true"
+                        :disabled="!isOnline"
+                      >
+                        {{ account.active ? 'Delete' : 'Enable' }}
+                      </v-btn>
+                    </v-card-text>
+                  </v-card>
+                </v-bottom-sheet>
               </v-card>
             </v-col>
             <v-col cols="2" v-if="!smAndDown"></v-col>
@@ -412,6 +467,7 @@
   const adjBalDialog = ref(false);
   const editDialog = ref(false);
   const deleteDialog = ref(false);
+  const actionDrawer = ref(false);
   const showMore = ref(false);
   const showRewardGraph = ref(false);
 

--- a/frontend/src/components/AccountHeaderWidget.vue
+++ b/frontend/src/components/AccountHeaderWidget.vue
@@ -46,7 +46,11 @@
                   class="mr-1"
                   aria-hidden="true"
                 />
-                <v-chip v-if="account.is_parent_account" size="x-small" color="secondary" label class="mr-1">combined</v-chip>
+                <v-tooltip v-if="account.is_parent_account" text="Combined account" location="top">
+                  <template v-slot:activator="{ props }">
+                    <v-icon icon="mdi-layers" color="secondary" size="small" class="mr-1" v-bind="props" />
+                  </template>
+                </v-tooltip>
                 <!-- Desktop: tooltip triggers edit on click -->
                 <v-tooltip text="Edit Account" location="top" v-if="authStore.isFullAccess && !smAndDown">
                   <template v-slot:activator="{ props }">

--- a/frontend/src/components/AccountHeaderWidget.vue
+++ b/frontend/src/components/AccountHeaderWidget.vue
@@ -145,7 +145,7 @@
               <v-expand-transition>
                 <v-card
                   v-if="actionDrawer && authStore.isFullAccess && smAndDown"
-                  class="mx-1 mt-0 bg-primary-lighten-1"
+                  class="mx-1 mt-0 bg-primary-darken-2"
                   variant="outlined"
                   rounded="0 0 4 4"
                 >

--- a/frontend/src/components/AccountsMenu.vue
+++ b/frontend/src/components/AccountsMenu.vue
@@ -21,12 +21,13 @@
       density="compact"
       nav
       :bg-color="smAndDown ? 'background' : 'surface'"
+      v-model:opened="openedGroups"
     >
       <!-- Favorites section -->
       <v-list-group
         collapse-icon="mdi-chevron-up"
         expand-icon="mdi-chevron-down"
-        v-model="groupActive"
+
         value="favorites"
         v-if="favoriteAccounts.length > 0"
       >
@@ -82,7 +83,7 @@
       <v-list-group
         collapse-icon="mdi-chevron-up"
         expand-icon="mdi-chevron-down"
-        v-model="groupActive"
+
         value="checking"
       >
         <template v-slot:activator="{ props }">
@@ -147,7 +148,7 @@
       <v-list-group
         collapse-icon="mdi-chevron-up"
         expand-icon="mdi-chevron-down"
-        v-model="groupActive"
+
         value="savings"
       >
         <template v-slot:activator="{ props }">
@@ -212,7 +213,7 @@
       <v-list-group
         collapse-icon="mdi-chevron-up"
         expand-icon="mdi-chevron-down"
-        v-model="groupActive"
+
         value="cc"
       >
         <template v-slot:activator="{ props }">
@@ -277,7 +278,7 @@
       <v-list-group
         collapse-icon="mdi-chevron-up"
         expand-icon="mdi-chevron-down"
-        v-model="groupActive"
+
         value="investment"
       >
         <template v-slot:activator="{ props }">
@@ -342,7 +343,7 @@
       <v-list-group
         collapse-icon="mdi-chevron-up"
         expand-icon="mdi-chevron-down"
-        v-model="groupActive"
+
         value="loan"
       >
         <template v-slot:activator="{ props }">
@@ -407,7 +408,7 @@
       <v-list-group
         collapse-icon="mdi-chevron-up"
         expand-icon="mdi-chevron-down"
-        v-model="groupActive"
+
         value="inactive"
       >
         <template v-slot:activator="{ props }">
@@ -477,7 +478,7 @@
 
   const transactions_store = useTransactionsStore();
   const router = useRouter();
-  const groupActive = ref(null);
+  const openedGroups = ref([]);
 
   const sortForMenu = accounts => {
     if (!accounts) return []
@@ -517,8 +518,8 @@
   );
 
   watch(favoriteAccounts, val => {
-    if (val && val.length > 0 && groupActive.value === null) {
-      groupActive.value = "favorites";
+    if (val && val.length > 0 && !openedGroups.value.includes("favorites")) {
+      openedGroups.value = ["favorites"];
     }
   }, { immediate: true });
 

--- a/frontend/src/components/AccountsMenu.vue
+++ b/frontend/src/components/AccountsMenu.vue
@@ -22,6 +22,63 @@
       nav
       :bg-color="smAndDown ? 'background' : 'surface'"
     >
+      <!-- Favorites section -->
+      <v-list-group
+        collapse-icon="mdi-chevron-up"
+        expand-icon="mdi-chevron-down"
+        v-model="groupActive"
+        value="favorites"
+        v-if="favoriteAccounts.length > 0"
+      >
+        <template v-slot:activator="{ props }">
+          <v-list-item color="amber" base-color="amber" v-bind="props">
+            <template v-slot:prepend>
+              <v-icon
+                icon="mdi-star"
+                :size="!isMobile ? 'default' : 'x-large'"
+              ></v-icon>
+            </template>
+            <v-list-item-title>
+              <span :class="isMobile ? 'text-h6' : ''">FAVORITES</span>
+            </v-list-item-title>
+            <v-list-item-subtitle>
+              <span :class="isMobile ? 'text-subtitle-1' : ''">
+                {{ favoriteAccounts.length }}
+                {{ favoriteAccounts.length == 1 ? "account" : "accounts" }}
+              </span>
+            </v-list-item-subtitle>
+          </v-list-item>
+        </template>
+        <v-list-item
+          v-for="(account, i) in favoriteAccounts"
+          :key="i"
+          color="accent"
+          @click="setAccount(account.id, False)"
+        >
+          <template v-slot:prepend>
+            <BankLogo :logo-url="account.bank?.logo_url" :size="20" class="mr-1" />
+          </template>
+          <v-list-item-title>
+            <span :class="isMobile ? 'text-subtitle-1 font-weight-bold' : ''">{{ account.account_name }}</span>
+            <v-chip v-if="account.is_parent_account" size="x-small" color="secondary" variant="tonal" label class="ml-1">combined</v-chip>
+          </v-list-item-title>
+          <v-list-item-subtitle>
+            <span
+              :class="
+                account.balance >= 0
+                  ? 'text-success font-weight-bold'
+                  : 'text-error font-weight-bold'
+              "
+            >
+              <NumberFlow
+                :value="account.balance"
+                :format="{ style: 'currency', currency: 'USD' }"
+              />
+            </span>
+          </v-list-item-subtitle>
+        </v-list-item>
+      </v-list-group>
+      <v-divider v-if="favoriteAccounts.length > 0"></v-divider>
       <v-list-group
         collapse-icon="mdi-chevron-up"
         expand-icon="mdi-chevron-down"
@@ -84,14 +141,6 @@
               />
             </span>
           </v-list-item-subtitle>
-          <template v-slot:append v-if="authStore.isFullAccess">
-            <v-icon
-              :icon="account.is_favorite ? 'mdi-star' : 'mdi-star-outline'"
-              :color="account.is_favorite ? 'amber' : undefined"
-              size="small"
-              @click.stop="toggleFavorite(account.id)"
-            ></v-icon>
-          </template>
         </v-list-item>
       </v-list-group>
       <v-divider></v-divider>
@@ -157,14 +206,6 @@
               />
             </span>
           </v-list-item-subtitle>
-          <template v-slot:append v-if="authStore.isFullAccess">
-            <v-icon
-              :icon="account.is_favorite ? 'mdi-star' : 'mdi-star-outline'"
-              :color="account.is_favorite ? 'amber' : undefined"
-              size="small"
-              @click.stop="toggleFavorite(account.id)"
-            ></v-icon>
-          </template>
         </v-list-item>
       </v-list-group>
       <v-divider></v-divider>
@@ -230,14 +271,6 @@
               />
             </span>
           </v-list-item-subtitle>
-          <template v-slot:append v-if="authStore.isFullAccess">
-            <v-icon
-              :icon="account.is_favorite ? 'mdi-star' : 'mdi-star-outline'"
-              :color="account.is_favorite ? 'amber' : undefined"
-              size="small"
-              @click.stop="toggleFavorite(account.id)"
-            ></v-icon>
-          </template>
         </v-list-item>
       </v-list-group>
       <v-divider></v-divider>
@@ -303,14 +336,6 @@
               />
             </span>
           </v-list-item-subtitle>
-          <template v-slot:append v-if="authStore.isFullAccess">
-            <v-icon
-              :icon="account.is_favorite ? 'mdi-star' : 'mdi-star-outline'"
-              :color="account.is_favorite ? 'amber' : undefined"
-              size="small"
-              @click.stop="toggleFavorite(account.id)"
-            ></v-icon>
-          </template>
         </v-list-item>
       </v-list-group>
       <v-divider></v-divider>
@@ -376,14 +401,6 @@
               />
             </span>
           </v-list-item-subtitle>
-          <template v-slot:append v-if="authStore.isFullAccess">
-            <v-icon
-              :icon="account.is_favorite ? 'mdi-star' : 'mdi-star-outline'"
-              :color="account.is_favorite ? 'amber' : undefined"
-              size="small"
-              @click.stop="toggleFavorite(account.id)"
-            ></v-icon>
-          </template>
         </v-list-item>
       </v-list-group>
       <v-divider></v-divider>
@@ -444,7 +461,7 @@
 </template>
 <script setup>
   import { useAccounts } from "@/composables/accountsComposable";
-  import { ref } from "vue";
+  import { ref, computed } from "vue";
   import { useRouter } from "vue-router";
   import { useTransactionsStore } from "@/stores/transactions";
   import NumberFlow from "@number-flow/vue";
@@ -467,20 +484,13 @@
     const parents = accounts.filter(a => a.is_parent_account)
     const children = accounts.filter(a => a.parent_account_id !== null)
     const standalone = accounts.filter(a => !a.is_parent_account && a.parent_account_id === null)
-    const addGroup = (parentList) => {
-      const result = []
-      for (const parent of parentList) {
-        result.push(parent)
-        result.push(...children.filter(c => c.parent_account_id === parent.id))
-      }
-      return result
+    const result = []
+    for (const parent of parents) {
+      result.push(parent)
+      result.push(...children.filter(c => c.parent_account_id === parent.id))
     }
-    return [
-      ...addGroup(parents.filter(a => a.is_favorite)),
-      ...standalone.filter(a => a.is_favorite),
-      ...addGroup(parents.filter(a => !a.is_favorite)),
-      ...standalone.filter(a => !a.is_favorite),
-    ]
+    result.push(...standalone)
+    return result
   }
 
   const setAccount = (account, forecast) => {
@@ -493,14 +503,19 @@
   };
 
   const {
+    accounts,
     checking_accounts,
     cc_accounts,
     savings_accounts,
     investment_accounts,
     loan_accounts,
     inactive_accounts,
-    toggleFavorite,
   } = useAccounts();
+
+  const favoriteAccounts = computed(() =>
+    (accounts.value ?? []).filter(a => a.is_favorite)
+  );
+
   const add_account_link = ref("/accounts/add");
 </script>
 

--- a/frontend/src/components/AccountsMenu.vue
+++ b/frontend/src/components/AccountsMenu.vue
@@ -461,7 +461,7 @@
 </template>
 <script setup>
   import { useAccounts } from "@/composables/accountsComposable";
-  import { ref, computed } from "vue";
+  import { ref, computed, watch } from "vue";
   import { useRouter } from "vue-router";
   import { useTransactionsStore } from "@/stores/transactions";
   import NumberFlow from "@number-flow/vue";
@@ -515,6 +515,12 @@
   const favoriteAccounts = computed(() =>
     (accounts.value ?? []).filter(a => a.is_favorite)
   );
+
+  watch(favoriteAccounts, val => {
+    if (val && val.length > 0 && groupActive.value === null) {
+      groupActive.value = "favorites";
+    }
+  }, { immediate: true });
 
   const add_account_link = ref("/accounts/add");
 </script>

--- a/frontend/src/components/AccountsMenu.vue
+++ b/frontend/src/components/AccountsMenu.vue
@@ -84,6 +84,14 @@
               />
             </span>
           </v-list-item-subtitle>
+          <template v-slot:append v-if="authStore.isFullAccess">
+            <v-icon
+              :icon="account.is_favorite ? 'mdi-star' : 'mdi-star-outline'"
+              :color="account.is_favorite ? 'amber' : undefined"
+              size="small"
+              @click.stop="toggleFavorite(account.id)"
+            ></v-icon>
+          </template>
         </v-list-item>
       </v-list-group>
       <v-divider></v-divider>
@@ -149,6 +157,14 @@
               />
             </span>
           </v-list-item-subtitle>
+          <template v-slot:append v-if="authStore.isFullAccess">
+            <v-icon
+              :icon="account.is_favorite ? 'mdi-star' : 'mdi-star-outline'"
+              :color="account.is_favorite ? 'amber' : undefined"
+              size="small"
+              @click.stop="toggleFavorite(account.id)"
+            ></v-icon>
+          </template>
         </v-list-item>
       </v-list-group>
       <v-divider></v-divider>
@@ -214,6 +230,14 @@
               />
             </span>
           </v-list-item-subtitle>
+          <template v-slot:append v-if="authStore.isFullAccess">
+            <v-icon
+              :icon="account.is_favorite ? 'mdi-star' : 'mdi-star-outline'"
+              :color="account.is_favorite ? 'amber' : undefined"
+              size="small"
+              @click.stop="toggleFavorite(account.id)"
+            ></v-icon>
+          </template>
         </v-list-item>
       </v-list-group>
       <v-divider></v-divider>
@@ -279,6 +303,14 @@
               />
             </span>
           </v-list-item-subtitle>
+          <template v-slot:append v-if="authStore.isFullAccess">
+            <v-icon
+              :icon="account.is_favorite ? 'mdi-star' : 'mdi-star-outline'"
+              :color="account.is_favorite ? 'amber' : undefined"
+              size="small"
+              @click.stop="toggleFavorite(account.id)"
+            ></v-icon>
+          </template>
         </v-list-item>
       </v-list-group>
       <v-divider></v-divider>
@@ -344,6 +376,14 @@
               />
             </span>
           </v-list-item-subtitle>
+          <template v-slot:append v-if="authStore.isFullAccess">
+            <v-icon
+              :icon="account.is_favorite ? 'mdi-star' : 'mdi-star-outline'"
+              :color="account.is_favorite ? 'amber' : undefined"
+              size="small"
+              @click.stop="toggleFavorite(account.id)"
+            ></v-icon>
+          </template>
         </v-list-item>
       </v-list-group>
       <v-divider></v-divider>
@@ -427,13 +467,20 @@
     const parents = accounts.filter(a => a.is_parent_account)
     const children = accounts.filter(a => a.parent_account_id !== null)
     const standalone = accounts.filter(a => !a.is_parent_account && a.parent_account_id === null)
-    const result = []
-    for (const parent of parents) {
-      result.push(parent)
-      result.push(...children.filter(c => c.parent_account_id === parent.id))
+    const addGroup = (parentList) => {
+      const result = []
+      for (const parent of parentList) {
+        result.push(parent)
+        result.push(...children.filter(c => c.parent_account_id === parent.id))
+      }
+      return result
     }
-    result.push(...standalone)
-    return result
+    return [
+      ...addGroup(parents.filter(a => a.is_favorite)),
+      ...standalone.filter(a => a.is_favorite),
+      ...addGroup(parents.filter(a => !a.is_favorite)),
+      ...standalone.filter(a => !a.is_favorite),
+    ]
   }
 
   const setAccount = (account, forecast) => {
@@ -452,6 +499,7 @@
     investment_accounts,
     loan_accounts,
     inactive_accounts,
+    toggleFavorite,
   } = useAccounts();
   const add_account_link = ref("/accounts/add");
 </script>

--- a/frontend/src/components/AccountsMenu.vue
+++ b/frontend/src/components/AccountsMenu.vue
@@ -61,7 +61,11 @@
           </template>
           <v-list-item-title>
             <span :class="isMobile ? 'text-subtitle-1 font-weight-bold' : ''">{{ account.account_name }}</span>
-            <v-chip v-if="account.is_parent_account" size="x-small" color="secondary" variant="tonal" label class="ml-1">combined</v-chip>
+            <v-tooltip v-if="account.is_parent_account" text="Combined account" location="top">
+              <template v-slot:activator="{ props }">
+                <v-icon icon="mdi-layers" color="secondary" size="x-small" class="ml-1" v-bind="props" />
+              </template>
+            </v-tooltip>
           </v-list-item-title>
           <v-list-item-subtitle>
             <span
@@ -126,7 +130,11 @@
           </template>
           <v-list-item-title>
             <span :class="isMobile ? 'text-subtitle-1 font-weight-bold' : ''">{{ account.account_name }}</span>
-            <v-chip v-if="account.is_parent_account" size="x-small" color="secondary" variant="tonal" label class="ml-1">combined</v-chip>
+            <v-tooltip v-if="account.is_parent_account" text="Combined account" location="top">
+              <template v-slot:activator="{ props }">
+                <v-icon icon="mdi-layers" color="secondary" size="x-small" class="ml-1" v-bind="props" />
+              </template>
+            </v-tooltip>
           </v-list-item-title>
           <v-list-item-subtitle>
             <span
@@ -191,7 +199,11 @@
           </template>
           <v-list-item-title>
             <span :class="isMobile ? 'text-subtitle-1 font-weight-bold' : ''">{{ account.account_name }}</span>
-            <v-chip v-if="account.is_parent_account" size="x-small" color="secondary" variant="tonal" label class="ml-1">combined</v-chip>
+            <v-tooltip v-if="account.is_parent_account" text="Combined account" location="top">
+              <template v-slot:activator="{ props }">
+                <v-icon icon="mdi-layers" color="secondary" size="x-small" class="ml-1" v-bind="props" />
+              </template>
+            </v-tooltip>
           </v-list-item-title>
           <v-list-item-subtitle>
             <span
@@ -256,7 +268,11 @@
           </template>
           <v-list-item-title>
             <span :class="isMobile ? 'text-subtitle-1 font-weight-bold' : ''">{{ account.account_name }}</span>
-            <v-chip v-if="account.is_parent_account" size="x-small" color="secondary" variant="tonal" label class="ml-1">combined</v-chip>
+            <v-tooltip v-if="account.is_parent_account" text="Combined account" location="top">
+              <template v-slot:activator="{ props }">
+                <v-icon icon="mdi-layers" color="secondary" size="x-small" class="ml-1" v-bind="props" />
+              </template>
+            </v-tooltip>
           </v-list-item-title>
           <v-list-item-subtitle>
             <span
@@ -321,7 +337,11 @@
           </template>
           <v-list-item-title>
             <span :class="isMobile ? 'text-subtitle-1 font-weight-bold' : ''">{{ account.account_name }}</span>
-            <v-chip v-if="account.is_parent_account" size="x-small" color="secondary" variant="tonal" label class="ml-1">combined</v-chip>
+            <v-tooltip v-if="account.is_parent_account" text="Combined account" location="top">
+              <template v-slot:activator="{ props }">
+                <v-icon icon="mdi-layers" color="secondary" size="x-small" class="ml-1" v-bind="props" />
+              </template>
+            </v-tooltip>
           </v-list-item-title>
           <v-list-item-subtitle>
             <span
@@ -386,7 +406,11 @@
           </template>
           <v-list-item-title>
             <span :class="isMobile ? 'text-subtitle-1 font-weight-bold' : ''">{{ account.account_name }}</span>
-            <v-chip v-if="account.is_parent_account" size="x-small" color="secondary" variant="tonal" label class="ml-1">combined</v-chip>
+            <v-tooltip v-if="account.is_parent_account" text="Combined account" location="top">
+              <template v-slot:activator="{ props }">
+                <v-icon icon="mdi-layers" color="secondary" size="x-small" class="ml-1" v-bind="props" />
+              </template>
+            </v-tooltip>
           </v-list-item-title>
           <v-list-item-subtitle>
             <span

--- a/frontend/src/composables/accountsComposable.js
+++ b/frontend/src/composables/accountsComposable.js
@@ -72,6 +72,17 @@ async function deleteAccountFunction(deletedAccount) {
   }
 }
 
+async function toggleFavoriteFunction(account_id) {
+  try {
+    const response = await apiClient.post(
+      "/accounts/toggle-favorite/" + account_id,
+    );
+    return response.data;
+  } catch (error) {
+    handleApiError(error, "Favorite not toggled: ");
+  }
+}
+
 async function updateAccountFunction(updatedAccount) {
   const updated = { ...updatedAccount };
   if ("open_date" in updatedAccount)
@@ -151,8 +162,19 @@ export function useAccounts(inactive) {
     },
   });
 
+  const toggleFavoriteMutation = useMutation({
+    mutationFn: toggleFavoriteFunction,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["accounts"] });
+    },
+  });
+
   async function addAccount(newAccount) {
     createAccountMutation.mutate(newAccount);
+  }
+
+  async function toggleFavorite(account_id) {
+    toggleFavoriteMutation.mutate(account_id);
   }
 
   return {
@@ -171,6 +193,7 @@ export function useAccounts(inactive) {
     inactive_accounts,
     inactive_isLoading,
     addAccount,
+    toggleFavorite,
   };
 }
 


### PR DESCRIPTION
## Summary
- Adds \`is_favorite\` boolean field to the \`Account\` model (default \`False\`) with migration \`0020\`
- New \`POST /accounts/toggle-favorite/{id}\` endpoint flips the flag and returns the new value
- \`is_favorite\` added to \`AccountOut\` (exposed to frontend) and \`AccountUpdate\` schemas
- Frontend: **FAVORITES** list group at the top of the account menu (amber, mdi-star header) shows all favorited accounts across all account types for quick access
- Star toggle button added to **AccountHeaderWidget** (account detail header) — amber mdi-star when favorited, mdi-star-outline otherwise; full-access users only
- \`toggleFavorite\` mutation in \`accountsComposable\` invalidates \`["accounts"]\` on success, updating the menu immediately

## Test plan
- [ ] Run \`python manage.py migrate\` — migration applies cleanly
- [ ] Open an account detail view — star button appears next to delete button (full-access only)
- [ ] Click star on an account — turns amber; account appears in FAVORITES section at top of menu
- [ ] Click star again — unfavorited; account removed from FAVORITES section
- [ ] FAVORITES section hidden when no accounts are favorited
- [ ] Multiple accounts favorited — all appear together in FAVORITES section
- [ ] Readonly user — star button not shown in header
- [ ] Favorited accounts still appear in their normal type group below FAVORITES

🤖 Generated with [Claude Code](https://claude.com/claude-code)