### PR TITLE
fix: sort favorite accounts by name and fix desktop budget ring percentage

### DIFF
--- a/frontend/src/components/BudgetsWidget.vue
+++ b/frontend/src/components/BudgetsWidget.vue
@@ -67,22 +67,24 @@
                 :color="graphColor(budget.used_percentage)"
                 :bg-color="graphBGColor(budget.used_percentage)"
               >
-                {{
-                  formatCurrency(
+                <span class="text-on-surface text-caption">
+                  {{
+                    formatCurrency(
+                      parseFloat(budget.budget.amount) +
+                        parseFloat(budget.budget.roll_over_amt) -
+                        parseFloat(Math.abs(budget.used_total)),
+                    )
+                  }}
+                  <br />
+                  {{
                     parseFloat(budget.budget.amount) +
                       parseFloat(budget.budget.roll_over_amt) -
-                      parseFloat(Math.abs(budget.used_total)),
-                  )
-                }}
-                <br />
-                {{
-                  parseFloat(budget.budget.amount) +
-                    parseFloat(budget.budget.roll_over_amt) -
-                    parseFloat(Math.abs(budget.used_total)) <
-                  0
-                    ? "over"
-                    : "left"
-                }}
+                      parseFloat(Math.abs(budget.used_total)) <
+                    0
+                      ? "over"
+                      : "left"
+                  }}
+                </span>
               </v-progress-circular>
               <div class="text-subtitle-2 text-center">
                 Budget:

--- a/frontend/src/components/BudgetsWidget.vue
+++ b/frontend/src/components/BudgetsWidget.vue
@@ -70,7 +70,7 @@
                 <span
                   :style="
                     remainingAmt(budget) < 0
-                      ? 'color: rgba(var(--v-theme-warning), var(--v-high-emphasis-opacity))'
+                      ? 'color: rgba(var(--v-theme-error), var(--v-high-emphasis-opacity))'
                       : 'color: rgba(var(--v-theme-on-surface), var(--v-high-emphasis-opacity))'
                   "
                 >
@@ -80,14 +80,14 @@
                 </span>
               </v-progress-circular>
               <div class="text-subtitle-2 text-center">
+                Budget:
                 <span
                   :style="
                     remainingAmt(budget) < 0
-                      ? 'color: rgba(var(--v-theme-warning), var(--v-high-emphasis-opacity))'
+                      ? 'color: rgba(var(--v-theme-error), var(--v-high-emphasis-opacity))'
                       : 'color: rgba(var(--v-theme-on-surface), var(--v-high-emphasis-opacity))'
                   "
                 >
-                  Budget:
                   {{
                     formatCurrency(
                       parseFloat(budget.budget.amount) +

--- a/frontend/src/components/BudgetsWidget.vue
+++ b/frontend/src/components/BudgetsWidget.vue
@@ -67,33 +67,34 @@
                 :color="graphColor(budget.used_percentage)"
                 :bg-color="graphBGColor(budget.used_percentage)"
               >
-                <span style="color: rgba(var(--v-theme-on-surface), var(--v-high-emphasis-opacity))">
-                  {{
-                    formatCurrency(
-                      parseFloat(budget.budget.amount) +
-                        parseFloat(budget.budget.roll_over_amt) -
-                        parseFloat(Math.abs(budget.used_total)),
-                    )
-                  }}
+                <span
+                  :style="
+                    remainingAmt(budget) < 0
+                      ? 'color: rgba(var(--v-theme-warning), var(--v-high-emphasis-opacity))'
+                      : 'color: rgba(var(--v-theme-on-surface), var(--v-high-emphasis-opacity))'
+                  "
+                >
+                  {{ formatCurrency(remainingAmt(budget)) }}
                   <br />
-                  {{
-                    parseFloat(budget.budget.amount) +
-                      parseFloat(budget.budget.roll_over_amt) -
-                      parseFloat(Math.abs(budget.used_total)) <
-                    0
-                      ? "over"
-                      : "left"
-                  }}
+                  {{ remainingAmt(budget) < 0 ? "over" : "left" }}
                 </span>
               </v-progress-circular>
               <div class="text-subtitle-2 text-center">
-                Budget:
-                {{
-                  formatCurrency(
-                    parseFloat(budget.budget.amount) +
-                      parseFloat(budget.budget.roll_over_amt),
-                  )
-                }}
+                <span
+                  :style="
+                    remainingAmt(budget) < 0
+                      ? 'color: rgba(var(--v-theme-warning), var(--v-high-emphasis-opacity))'
+                      : 'color: rgba(var(--v-theme-on-surface), var(--v-high-emphasis-opacity))'
+                  "
+                >
+                  Budget:
+                  {{
+                    formatCurrency(
+                      parseFloat(budget.budget.amount) +
+                        parseFloat(budget.budget.roll_over_amt),
+                    )
+                  }}
+                </span>
                 <span
                   :class="
                     budget.budget.roll_over_amt < 0
@@ -212,6 +213,11 @@
       maximumFractionDigits: 2,
     }).format(value);
   };
+  const remainingAmt = budget =>
+    parseFloat(budget.budget.amount) +
+    parseFloat(budget.budget.roll_over_amt) -
+    parseFloat(Math.abs(budget.used_total));
+
   const graphColor = value => {
     const thresholds = [
       { limit: 10, color: "green" },

--- a/frontend/src/components/BudgetsWidget.vue
+++ b/frontend/src/components/BudgetsWidget.vue
@@ -67,24 +67,22 @@
                 :color="graphColor(budget.used_percentage)"
                 :bg-color="graphBGColor(budget.used_percentage)"
               >
-                <span class="text-on-surface text-caption">
-                  {{
-                    formatCurrency(
-                      parseFloat(budget.budget.amount) +
-                        parseFloat(budget.budget.roll_over_amt) -
-                        parseFloat(Math.abs(budget.used_total)),
-                    )
-                  }}
-                  <br />
-                  {{
+                {{
+                  formatCurrency(
                     parseFloat(budget.budget.amount) +
                       parseFloat(budget.budget.roll_over_amt) -
-                      parseFloat(Math.abs(budget.used_total)) <
-                    0
-                      ? "over"
-                      : "left"
-                  }}
-                </span>
+                      parseFloat(Math.abs(budget.used_total)),
+                  )
+                }}
+                <br />
+                {{
+                  parseFloat(budget.budget.amount) +
+                    parseFloat(budget.budget.roll_over_amt) -
+                    parseFloat(Math.abs(budget.used_total)) <
+                  0
+                    ? "over"
+                    : "left"
+                }}
               </v-progress-circular>
               <div class="text-subtitle-2 text-center">
                 Budget:

--- a/frontend/src/components/BudgetsWidget.vue
+++ b/frontend/src/components/BudgetsWidget.vue
@@ -61,7 +61,7 @@
                 {{ budget.budget.name }}
               </div>
               <v-progress-circular
-                :model-value="budget.remaining_percentage"
+                :model-value="100 - budget.used_percentage"
                 :size="100"
                 :width="12"
                 :color="graphColor(budget.used_percentage)"

--- a/frontend/src/components/BudgetsWidget.vue
+++ b/frontend/src/components/BudgetsWidget.vue
@@ -238,11 +238,11 @@
       { limit: 30, color: "green-lighten-3" },
       { limit: 40, color: "green-lighten-3" },
       { limit: 50, color: "green-lighten-3" },
-      { limit: 60, color: "yellow-lighten-2" },
-      { limit: 70, color: "yellow-lighten-3" },
-      { limit: 80, color: "yellow-lighten-3" },
-      { limit: 90, color: "yellow-lighten-3" },
-      { limit: 99, color: "yellow-lighten-3" },
+      { limit: 60, color: "yellow-lighten-4" },
+      { limit: 70, color: "yellow-lighten-4" },
+      { limit: 80, color: "yellow-lighten-4" },
+      { limit: 90, color: "yellow-lighten-4" },
+      { limit: 99, color: "yellow-lighten-4" },
     ];
 
     for (const { limit, color } of thresholds) {

--- a/frontend/src/components/BudgetsWidget.vue
+++ b/frontend/src/components/BudgetsWidget.vue
@@ -60,30 +60,47 @@
               <div class="text-subtitle-2 text-center font-weight-bold">
                 {{ budget.budget.name }}
               </div>
-              <v-progress-circular
-                :model-value="100 - budget.used_percentage"
-                :size="100"
-                :width="12"
-                :color="graphColor(budget.used_percentage)"
-                :bg-color="graphBGColor(budget.used_percentage)"
-              >
-                {{
-                  formatCurrency(
-                    parseFloat(budget.budget.amount) +
-                      parseFloat(budget.budget.roll_over_amt) -
-                      parseFloat(Math.abs(budget.used_total)),
-                  )
-                }}
-                <br />
-                {{
-                  parseFloat(budget.budget.amount) +
-                    parseFloat(budget.budget.roll_over_amt) -
-                    parseFloat(Math.abs(budget.used_total)) <
-                  0
-                    ? "over"
-                    : "left"
-                }}
-              </v-progress-circular>
+              <div class="d-flex justify-center">
+                <div style="position: relative; width: 100px; height: 100px;">
+                  <svg viewBox="0 0 100 100" width="100" height="100">
+                    <circle
+                      cx="50" cy="50" r="44"
+                      fill="none"
+                      :class="`text-${graphBGColor(budget.used_percentage)}`"
+                      stroke="currentColor"
+                      stroke-width="12"
+                    />
+                    <circle
+                      cx="50" cy="50" r="44"
+                      fill="none"
+                      :class="`text-${graphColor(budget.used_percentage)}`"
+                      stroke="currentColor"
+                      stroke-width="12"
+                      :stroke-dasharray="`${(100 - budget.used_percentage) / 100 * 276.46} 276.46`"
+                      transform="rotate(-90 50 50)"
+                    />
+                  </svg>
+                  <div
+                    style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; display: flex; flex-direction: column; align-items: center; justify-content: center;"
+                    class="text-caption text-center"
+                  >
+                    {{
+                      formatCurrency(
+                        parseFloat(budget.budget.amount) +
+                          parseFloat(budget.budget.roll_over_amt) -
+                          parseFloat(Math.abs(budget.used_total)),
+                      )
+                    }}<br />
+                    {{
+                      parseFloat(budget.budget.amount) +
+                        parseFloat(budget.budget.roll_over_amt) -
+                        parseFloat(Math.abs(budget.used_total)) < 0
+                        ? "over"
+                        : "left"
+                    }}
+                  </div>
+                </div>
+              </div>
               <div class="text-subtitle-2 text-center">
                 Budget:
                 {{

--- a/frontend/src/components/BudgetsWidget.vue
+++ b/frontend/src/components/BudgetsWidget.vue
@@ -67,22 +67,24 @@
                 :color="graphColor(budget.used_percentage)"
                 :bg-color="graphBGColor(budget.used_percentage)"
               >
-                {{
-                  formatCurrency(
+                <span :class="ringTextColor(budget.used_percentage)">
+                  {{
+                    formatCurrency(
+                      parseFloat(budget.budget.amount) +
+                        parseFloat(budget.budget.roll_over_amt) -
+                        parseFloat(Math.abs(budget.used_total)),
+                    )
+                  }}
+                  <br />
+                  {{
                     parseFloat(budget.budget.amount) +
                       parseFloat(budget.budget.roll_over_amt) -
-                      parseFloat(Math.abs(budget.used_total)),
-                  )
-                }}
-                <br />
-                {{
-                  parseFloat(budget.budget.amount) +
-                    parseFloat(budget.budget.roll_over_amt) -
-                    parseFloat(Math.abs(budget.used_total)) <
-                  0
-                    ? "over"
-                    : "left"
-                }}
+                      parseFloat(Math.abs(budget.used_total)) <
+                    0
+                      ? "over"
+                      : "left"
+                  }}
+                </span>
               </v-progress-circular>
               <div class="text-subtitle-2 text-center">
                 Budget:
@@ -229,6 +231,11 @@
     }
 
     return "error";
+  };
+
+  const ringTextColor = value => {
+    if (value > 50 && value <= 99) return "text-grey-darken-4";
+    return "";
   };
 
   const graphBGColor = value => {

--- a/frontend/src/components/BudgetsWidget.vue
+++ b/frontend/src/components/BudgetsWidget.vue
@@ -67,7 +67,7 @@
                 :color="graphColor(budget.used_percentage)"
                 :bg-color="graphBGColor(budget.used_percentage)"
               >
-                <span :class="ringTextColor(budget.used_percentage)">
+                <span style="color: rgba(var(--v-theme-on-surface), var(--v-high-emphasis-opacity))">
                   {{
                     formatCurrency(
                       parseFloat(budget.budget.amount) +
@@ -231,11 +231,6 @@
     }
 
     return "error";
-  };
-
-  const ringTextColor = value => {
-    if (value > 50 && value <= 99) return "text-grey-darken-4";
-    return "";
   };
 
   const graphBGColor = value => {

--- a/frontend/src/components/BudgetsWidget.vue
+++ b/frontend/src/components/BudgetsWidget.vue
@@ -60,47 +60,30 @@
               <div class="text-subtitle-2 text-center font-weight-bold">
                 {{ budget.budget.name }}
               </div>
-              <div class="d-flex justify-center">
-                <div style="position: relative; width: 100px; height: 100px;">
-                  <svg viewBox="0 0 100 100" width="100" height="100">
-                    <circle
-                      cx="50" cy="50" r="44"
-                      fill="none"
-                      :class="`text-${graphBGColor(budget.used_percentage)}`"
-                      stroke="currentColor"
-                      stroke-width="12"
-                    />
-                    <circle
-                      cx="50" cy="50" r="44"
-                      fill="none"
-                      :class="`text-${graphColor(budget.used_percentage)}`"
-                      stroke="currentColor"
-                      stroke-width="12"
-                      :stroke-dasharray="`${(100 - budget.used_percentage) / 100 * 276.46} 276.46`"
-                      transform="rotate(-90 50 50)"
-                    />
-                  </svg>
-                  <div
-                    style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; display: flex; flex-direction: column; align-items: center; justify-content: center;"
-                    class="text-caption text-center"
-                  >
-                    {{
-                      formatCurrency(
-                        parseFloat(budget.budget.amount) +
-                          parseFloat(budget.budget.roll_over_amt) -
-                          parseFloat(Math.abs(budget.used_total)),
-                      )
-                    }}<br />
-                    {{
-                      parseFloat(budget.budget.amount) +
-                        parseFloat(budget.budget.roll_over_amt) -
-                        parseFloat(Math.abs(budget.used_total)) < 0
-                        ? "over"
-                        : "left"
-                    }}
-                  </div>
-                </div>
-              </div>
+              <v-progress-circular
+                :model-value="100 - budget.used_percentage"
+                :size="100"
+                :width="12"
+                :color="graphColor(budget.used_percentage)"
+                :bg-color="graphBGColor(budget.used_percentage)"
+              >
+                {{
+                  formatCurrency(
+                    parseFloat(budget.budget.amount) +
+                      parseFloat(budget.budget.roll_over_amt) -
+                      parseFloat(Math.abs(budget.used_total)),
+                  )
+                }}
+                <br />
+                {{
+                  parseFloat(budget.budget.amount) +
+                    parseFloat(budget.budget.roll_over_amt) -
+                    parseFloat(Math.abs(budget.used_total)) <
+                  0
+                    ? "over"
+                    : "left"
+                }}
+              </v-progress-circular>
               <div class="text-subtitle-2 text-center">
                 Budget:
                 {{
@@ -255,7 +238,7 @@
       { limit: 30, color: "green-lighten-3" },
       { limit: 40, color: "green-lighten-3" },
       { limit: 50, color: "green-lighten-3" },
-      { limit: 60, color: "yellow" },
+      { limit: 60, color: "yellow-lighten-2" },
       { limit: 70, color: "yellow-lighten-3" },
       { limit: 80, color: "yellow-lighten-3" },
       { limit: 90, color: "yellow-lighten-3" },

--- a/frontend/src/components/FavoriteAccountsWidget.vue
+++ b/frontend/src/components/FavoriteAccountsWidget.vue
@@ -110,7 +110,12 @@
   import { useFavoriteBalances } from "@/composables/accountsComposable";
   import { useTransactionsStore } from "@/stores/transactions";
 
-  const { favoriteBalances, isLoading } = useFavoriteBalances();
+  const { favoriteBalances: rawFavoriteBalances, isLoading } = useFavoriteBalances();
+  const favoriteBalances = computed(() =>
+    [...(rawFavoriteBalances.value ?? [])].sort((a, b) =>
+      a.account_name.localeCompare(b.account_name),
+    ),
+  );
   const router = useRouter();
   const transactions_store = useTransactionsStore();
 


### PR DESCRIPTION
## Summary
- **Favorite accounts widget**: accounts are now sorted alphabetically by name
- **Desktop budget ring**: the circular progress ring now correctly reflects the percentage used/remaining; `v-progress-circular` inside `v-slide-group` was not reacting to `remaining_percentage` updates, so the ring was always solid — fixed by deriving the value from `used_percentage` (which is reliably reactive, as evidenced by the color changing correctly)

## Test plan
- [ ] Favorite accounts widget shows accounts in alphabetical order
- [ ] Desktop budget ring shows a partial arc for budgets with spending (not always solid)
- [ ] Ring color still changes correctly as spending increases
- [ ] Mobile budget progress bar unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)