### PR TITLE
feat: add Patreon announcement workflow

### DIFF
--- a/.github/workflows/announce_patreon.yml
+++ b/.github/workflows/announce_patreon.yml
@@ -1,0 +1,61 @@
+name: Announce on Patreon
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to announce (e.g. v1.3.0)"
+        required: true
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+env:
+  VERSION: ${{ github.event.release.tag_name || inputs.tag }}
+  IS_PRERELEASE: ${{ github.event.release.prerelease || 'false' }}
+
+jobs:
+  patreon:
+    if: github.repository != 'Novanglus96/LenoreTemplate'
+    runs-on: self-hosted
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Skip pre-releases
+        id: check_prerelease
+        run: |
+          if [ "$IS_PRERELEASE" = "true" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Pre-release detected, skipping Patreon post."
+          elif echo "$VERSION" | grep -qE "(alpha|beta|rc)"; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Pre-release tag detected, skipping Patreon post."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Get release notes
+        if: steps.check_prerelease.outputs.skip == 'false'
+        id: release_notes
+        uses: actions/github-script@v7
+        with:
+          result-encoding: string
+          script: |
+            const release = await github.rest.repos.getLatestRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+            return release.data.body || "No changelog found.";
+
+      - name: Post to Patreon
+        if: steps.check_prerelease.outputs.skip == 'false'
+        env:
+          COMMIT_TAG: ${{ github.event.release.tag_name || inputs.tag }}
+          RELEASE_NOTES: ${{ steps.release_notes.outputs.result }}
+          PATREON_ACCESS_TOKEN: ${{ secrets.PATREON_ACCESS_TOKEN }}
+          PATREON_CAMPAIGN_ID: ${{ secrets.PATREON_CAMPAIGN_ID }}
+        run: python scripts/post_to_patreon.py

--- a/scripts/patreon_post_template.html
+++ b/scripts/patreon_post_template.html
@@ -1,0 +1,25 @@
+<p><strong>LenoreFin v{version}</strong> has just been released!</p>
+
+<p>For anyone new to it: <strong>LenoreFin</strong> began as a simple Excel spreadsheet I used to manage my family's budget. But over time, I realized no existing tools gave me the control, flexibility, and privacy I wanted. So I built <strong>LenoreFin</strong> — a personal finance tracker that puts you in charge.</p>
+
+<p>Designed for self-hosting, <strong>LenoreFin</strong> keeps your financial data completely local, with no third-party syncing or hidden services.</p>
+
+<h3>Key Features</h3>
+<ul>
+  <li><strong>Budgets</strong> - Set up budgets for things like groceries to track expenses over time.</li>
+  <li><strong>Cash Flow</strong> - See where your money has been and where it's going.</li>
+  <li><strong>Retirement Planning</strong> - Plan for retirement with contribution and growth projections.</li>
+  <li><strong>Reminders</strong> - Set up recurring transactions as reminders for bills.</li>
+  <li><strong>Account Forecasts</strong> - Predict what your account balances will look like months or years from now.</li>
+</ul>
+
+<h3>What's new in v{version}</h3>
+<pre>{changelog}</pre>
+
+<h3>Links</h3>
+<ul>
+  <li><strong>GitHub:</strong> <a href="https://github.com/Novanglus96/LenoreFin">https://github.com/Novanglus96/LenoreFin</a></li>
+  <li><strong>Support LenoreApps:</strong> <a href="https://www.patreon.com/c/Novanglus">Patreon</a> | <a href="https://buymeacoffee.com/novanglus">Buy Me a Coffee</a></li>
+</ul>
+
+<p>Thank you for your support! 🎉</p>

--- a/scripts/post_to_patreon.py
+++ b/scripts/post_to_patreon.py
@@ -1,0 +1,63 @@
+import os
+import re
+import sys
+from pathlib import Path
+import requests
+
+
+def get_version(tag):
+    match = re.match(r"v?(\d+\.\d+\.\d+.*)", tag)
+    return match.group(1) if match else tag.lstrip("v")
+
+
+def main():
+    tag = os.environ["COMMIT_TAG"]
+    version = get_version(tag)
+    changelog = os.environ["RELEASE_NOTES"]
+    access_token = os.environ["PATREON_ACCESS_TOKEN"]
+    campaign_id = os.environ["PATREON_CAMPAIGN_ID"]
+
+    template = Path("scripts/patreon_post_template.html").read_text()
+    content = template.format(version=version, changelog=changelog)
+
+    title = f"LenoreFin v{version} Released!"
+
+    response = requests.post(
+        "https://www.patreon.com/api/oauth2/v2/posts",
+        headers={
+            "Authorization": f"Bearer {access_token}",
+            "Content-Type": "application/vnd.api+json",
+        },
+        json={
+            "data": {
+                "type": "post",
+                "attributes": {
+                    "title": title,
+                    "content": content,
+                    "post_type": "text_only",
+                    "is_paid": False,
+                    "publish_status": "published",
+                },
+                "relationships": {
+                    "campaign": {
+                        "data": {
+                            "type": "campaign",
+                            "id": campaign_id,
+                        }
+                    }
+                },
+            }
+        },
+    )
+
+    if response.status_code in (200, 201):
+        data = response.json()
+        post_id = data.get("data", {}).get("id", "unknown")
+        print(f"✅ Posted to Patreon (post id: {post_id})")
+    else:
+        print(f"❌ Patreon API error {response.status_code}: {response.text}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds `announce_patreon.yml` workflow triggered on stable GitHub releases (skips alpha/beta/rc pre-releases)
- Adds `scripts/post_to_patreon.py` — posts to Patreon campaign feed via API v2
- Adds `scripts/patreon_post_template.html` — LenoreFin-specific HTML post template

## Required secrets
Add these to the LenoreFin GitHub repository secrets:
- `PATREON_ACCESS_TOKEN` — creator access token (generate at patreon.com/portal → API)
- `PATREON_CAMPAIGN_ID` — numeric campaign ID from the Patreon API or campaign URL

## Test plan
- [ ] Add secrets to repo
- [ ] Use `workflow_dispatch` with a stable tag to verify post appears on Patreon feed
- [ ] Verify pre-release tags (alpha/beta/rc) are skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)