### PR TITLE
feat: add WebSocket real-time sync via Django Channels

### DIFF
--- a/backend/accounts/signals.py
+++ b/backend/accounts/signals.py
@@ -12,6 +12,7 @@ from core.cache.keys import (
     account_combined_transactions,
     account_all,
 )
+from core.broadcast import broadcast_invalidate
 
 
 @receiver(post_save, sender=Account)
@@ -36,6 +37,7 @@ def update_cache_on_save(sender, instance, **kwargs):
     if instance.parent_account_id:
         delete_pattern(account_financials(instance.parent_account_id))
         delete_pattern(account_combined_transactions(instance.parent_account_id))
+    broadcast_invalidate(["accounts"])
 
 
 @receiver(post_delete, sender=Account)
@@ -47,6 +49,7 @@ def update_cache_on_delete(sender, instance, **kwargs):
         Q(source_account_id=instance.id) | Q(destination_account_id=instance.id)
     ).delete()
     delete_pattern(account_all(instance.id))
+    broadcast_invalidate(["accounts"])
 
 
 @receiver(pre_save, sender=Account)

--- a/backend/backend/asgi.py
+++ b/backend/backend/asgi.py
@@ -1,16 +1,17 @@
-"""
-ASGI config for backend project.
-
-It exposes the ASGI callable as a module-level variable named ``application``.
-
-For more information on this file, see
-https://docs.djangoproject.com/en/4.2/howto/deployment/asgi/
-"""
-
 import os
 
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "backend.settings")
+
 from django.core.asgi import get_asgi_application
+from channels.routing import ProtocolTypeRouter, URLRouter
+from channels.auth import AuthMiddlewareStack
+from core.routing import websocket_urlpatterns
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'backend.settings')
-
-application = get_asgi_application()
+application = ProtocolTypeRouter(
+    {
+        "http": get_asgi_application(),
+        "websocket": AuthMiddlewareStack(
+            URLRouter(websocket_urlpatterns)
+        ),
+    }
+)

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -61,6 +61,8 @@ INSTALLED_APPS = [
     "dbbackup",
     "ninja",
     "django_q",
+    "daphne",
+    "channels",
 ]
 
 MIDDLEWARE = [
@@ -93,6 +95,18 @@ TEMPLATES = [
 ]
 
 WSGI_APPLICATION = "backend.wsgi.application"
+ASGI_APPLICATION = "backend.asgi.application"
+
+CHANNEL_LAYERS = {
+    "default": {
+        "BACKEND": "channels_redis.core.RedisChannelLayer",
+        "CONFIG": {
+            "hosts": [("redis", int(os.environ.get("REDIS_PORT", 6379)))],
+            "capacity": 100,
+            "expiry": 60,
+        },
+    }
+}
 
 
 # Database

--- a/backend/core/broadcast.py
+++ b/backend/core/broadcast.py
@@ -1,0 +1,18 @@
+from asgiref.sync import async_to_sync
+from channels.layers import get_channel_layer
+import logging
+
+error_logger = logging.getLogger("error")
+
+
+def broadcast_invalidate(keys: list, group: str = "global"):
+    channel_layer = get_channel_layer()
+    if channel_layer is None:
+        return
+    try:
+        async_to_sync(channel_layer.group_send)(
+            group,
+            {"type": "sync.invalidate", "keys": keys},
+        )
+    except Exception as e:
+        error_logger.warning(f"WebSocket broadcast failed: {e}")

--- a/backend/core/consumers.py
+++ b/backend/core/consumers.py
@@ -1,0 +1,28 @@
+import json
+from channels.generic.websocket import AsyncWebsocketConsumer
+
+
+class SyncConsumer(AsyncWebsocketConsumer):
+    async def connect(self):
+        user = self.scope["user"]
+        if not user.is_authenticated:
+            await self.close()
+            return
+        await self.channel_layer.group_add("global", self.channel_name)
+        await self.channel_layer.group_add(f"user_{user.pk}", self.channel_name)
+        await self.accept()
+
+    async def disconnect(self, close_code):
+        user = self.scope.get("user")
+        await self.channel_layer.group_discard("global", self.channel_name)
+        if user and user.is_authenticated:
+            await self.channel_layer.group_discard(f"user_{user.pk}", self.channel_name)
+
+    async def receive(self, text_data=None, bytes_data=None):
+        pass
+
+    async def sync_invalidate(self, event):
+        await self.send(text_data=json.dumps({
+            "type": "invalidate",
+            "keys": event["keys"],
+        }))

--- a/backend/core/routing.py
+++ b/backend/core/routing.py
@@ -1,0 +1,6 @@
+from django.urls import path
+from core.consumers import SyncConsumer
+
+websocket_urlpatterns = [
+    path("ws/sync/", SyncConsumer.as_asgi()),
+]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,8 @@
 Django==5.2
 gunicorn==26.0.0
+daphne==4.2.0
+channels==4.2.2
+channels-redis==4.2.1
 psycopg2-binary==2.9.12
 markdown==3.10.2
 django-filter==25.1

--- a/backend/transactions/signals.py
+++ b/backend/transactions/signals.py
@@ -4,6 +4,7 @@ from transactions.models import Transaction, TransactionImage
 from django_q.tasks import async_task
 from core.cache.helpers import delete_pattern
 from core.cache.keys import account_all
+from core.broadcast import broadcast_invalidate
 
 
 def _refresh_account(account_id):
@@ -17,6 +18,7 @@ def update_forecast_cache_on_save(sender, instance, **kwargs):
     _refresh_account(instance.source_account_id)
     if instance.destination_account_id is not None:
         _refresh_account(instance.destination_account_id)
+    broadcast_invalidate(["transactions"])
 
 
 @receiver(post_delete, sender=Transaction)
@@ -24,6 +26,7 @@ def update_forecast_cache_on_delete(sender, instance, **kwargs):
     _refresh_account(instance.source_account_id)
     if instance.destination_account_id is not None:
         _refresh_account(instance.destination_account_id)
+    broadcast_invalidate(["transactions"])
 
 
 @receiver(post_delete, sender=TransactionImage)

--- a/backend/transactions/tasks.py
+++ b/backend/transactions/tasks.py
@@ -5,6 +5,7 @@ Description: Contains task definitions to be scheduuled.
 Author: John Adams <johnmadams96@gmail.com>
 Date: February 15, 2024
 """
+from core.broadcast import broadcast_invalidate
 
 from transactions.models import (
     Transaction,
@@ -804,6 +805,7 @@ def update_reminder_cache(reminder_id):
         if reminder.reminder_destination_account is not None:
             delete_pattern(account_all_transactions(reminder.reminder_destination_account.id))
             update_cc_forecast_cache(reminder.reminder_destination_account.id)
+        broadcast_invalidate(["reminders", "accounts"])
     except Exception as e:
         task_logger.warning("There was an error creating cache")
         error_logger.warning(f"{str(e)}")
@@ -1005,6 +1007,7 @@ def update_interest_forecast_cache(account_id):
             ).delete()
             create_transactions(transactions_to_create, 'forecast')
         delete_pattern(account_all(account_id))
+        broadcast_invalidate(["accounts"])
     except Exception as e:
         error_logger.exception(
             f"Error calculating interest forecast for account {account_id}: {e}"
@@ -1241,6 +1244,7 @@ def update_cc_forecast_cache(account_id):
         delete_pattern(account_all(account_id))
         if funding_account:
             delete_pattern(account_all(funding_account.id))
+        broadcast_invalidate(["accounts"])
     except Exception as e:
         error_logger.exception(f"Error calculating CC forecast for account {account_id}: {e}")
 

--- a/backend/transactions/tests/api/test_transaction_api.py
+++ b/backend/transactions/tests/api/test_transaction_api.py
@@ -82,7 +82,6 @@ def test_clear_transaction(api_client, test_transaction, test_cleared_transactio
 # --- Transaction filter tests ---
 
 def _list(api_client, account_id, **extra):
-    today = current_date()
     params = (
         f"view_type=1&account={account_id}&maxdays=14&forecast=false"
         f"&page=1&page_size=60"

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -74,11 +74,13 @@
   import { useBackendReady } from "@/composables/useBackendReady";
   import { useOnlineStatus } from "@/composables/useOnlineStatus";
   import { useQueryClient } from "@tanstack/vue-query";
+  import { useRealtimeSync } from "@/composables/useRealtimeSync";
   import LogoLoader from "./components/LogoLoader.vue";
 
   const { backendReady } = useBackendReady();
   const queryClient = useQueryClient();
   const { isOnline } = useOnlineStatus();
+  useRealtimeSync();
   const showOfflineBanner = computed(() => !isOnline.value);
 
   watch(isOnline, online => {

--- a/frontend/src/composables/useRealtimeSync.js
+++ b/frontend/src/composables/useRealtimeSync.js
@@ -1,0 +1,55 @@
+import { ref, onMounted, onUnmounted } from "vue";
+import { useQueryClient } from "@tanstack/vue-query";
+
+export function useRealtimeSync() {
+  const queryClient = useQueryClient();
+  const connected = ref(false);
+  let ws = null;
+  let reconnectTimer = null;
+
+  function connect() {
+    const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+    ws = new WebSocket(`${protocol}//${window.location.host}/ws/sync/`);
+
+    ws.onopen = () => {
+      connected.value = true;
+      if (reconnectTimer) {
+        clearTimeout(reconnectTimer);
+        reconnectTimer = null;
+      }
+    };
+
+    ws.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        if (data.type === "invalidate" && Array.isArray(data.keys)) {
+          data.keys.forEach((key) =>
+            queryClient.invalidateQueries({ queryKey: [key] })
+          );
+        }
+      } catch {
+        // ignore malformed messages
+      }
+    };
+
+    ws.onclose = () => {
+      connected.value = false;
+      // reconnect with backoff — 3 seconds
+      reconnectTimer = setTimeout(connect, 3000);
+    };
+
+    ws.onerror = () => ws.close();
+  }
+
+  onMounted(connect);
+
+  onUnmounted(() => {
+    if (reconnectTimer) clearTimeout(reconnectTimer);
+    if (ws) {
+      ws.onclose = null; // prevent reconnect loop on intentional unmount
+      ws.close();
+    }
+  });
+
+  return { connected };
+}

--- a/nginx/app.conf
+++ b/nginx/app.conf
@@ -16,6 +16,17 @@ server {
         try_files $uri $uri/ /index.html;
     }
 
+    # WebSocket — real-time sync
+    location /ws/ {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_read_timeout 86400;
+    }
+
     # Django API
     location /api/ {
         proxy_pass http://127.0.0.1:8000;

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -14,8 +14,8 @@ stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 
-[program:gunicorn]
-command=gunicorn backend.wsgi:application --bind 127.0.0.1:8000 --workers 3
+[program:daphne]
+command=daphne -b 127.0.0.1 -p 8000 backend.asgi:application
 directory=/home/app/web
 autostart=true
 autorestart=true


### PR DESCRIPTION
## Summary

- Adds `daphne`, `channels`, `channels-redis` to requirements
- Switches ASGI server from gunicorn (WSGI) → daphne (ASGI) in supervisord
- `SyncConsumer` handles WebSocket connections — each client joins a `global` group and a `user_{id}` group
- `broadcast_invalidate(keys)` helper sends lightweight invalidation messages to all connected clients
- Broadcasts fire **after** cache rebuilds complete (Option A) — accounts/interest/CC forecasts broadcast `["accounts"]` at end of django-q2 tasks; reminders broadcast `["reminders", "accounts"]`; transaction saves broadcast `["transactions"]` immediately (the row is in DB)
- nginx `/ws/` proxy block with WebSocket upgrade headers
- Frontend `useRealtimeSync` composable auto-connects on mount, reconnects on close (3s backoff), and calls `queryClient.invalidateQueries({ queryKey: [key] })` for each key received — zero manual polling needed

## Required infrastructure
- Redis must be running (already in docker-compose) — channel layer uses the same Redis instance as cache
- No new env vars needed

## Test plan
- [ ] Open app in two browser tabs — add a transaction in one, verify the other updates automatically
- [ ] Edit an account setting — verify account list refreshes in other tabs
- [ ] Save a reminder — verify reminder list and account balance refresh in other tabs
- [ ] Disconnect Redis and verify the broadcast helper fails silently (logged warning, no crash)
- [ ] Verify WebSocket reconnects after a server restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)