### PR TITLE
fix: suppress flake8 E402 on deferred imports in asgi.py

### DIFF
--- a/backend/backend/asgi.py
+++ b/backend/backend/asgi.py
@@ -2,10 +2,10 @@ import os
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "backend.settings")
 
-from django.core.asgi import get_asgi_application
-from channels.routing import ProtocolTypeRouter, URLRouter
-from channels.auth import AuthMiddlewareStack
-from core.routing import websocket_urlpatterns
+from django.core.asgi import get_asgi_application  # noqa: E402
+from channels.routing import ProtocolTypeRouter, URLRouter  # noqa: E402
+from channels.auth import AuthMiddlewareStack  # noqa: E402
+from core.routing import websocket_urlpatterns  # noqa: E402
 
 application = ProtocolTypeRouter(
     {


### PR DESCRIPTION
## Summary

The Dockerfile runs `flake8 --ignore=E501,F401,E203,E701,W503` and flags E402 (module level import not at top of file) on `asgi.py`. The `os.environ.setdefault` call must precede Django/Channels imports — this is the standard Django ASGI pattern. Added `# noqa: E402` to suppress the false-positive.

Fixes the Build & Publish CI failure on alpha after #166 merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)