### PR TITLE
fix: move daphne to first position in INSTALLED_APPS

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -37,6 +37,7 @@ ALLOWED_HOSTS = os.environ.get("DJANGO_ALLOWED_HOSTS").split(" ")
 # Application definition
 
 INSTALLED_APPS = [
+    "daphne",
     "import_export",
     "unfold",
     "unfold.contrib.filters",
@@ -61,7 +62,6 @@ INSTALLED_APPS = [
     "dbbackup",
     "ninja",
     "django_q",
-    "daphne",
     "channels",
 ]
 


### PR DESCRIPTION
## Summary
- Moves `"daphne"` from the end of `INSTALLED_APPS` to the very first position
- Fixes `daphne.E001`: daphne must be listed before `django.contrib.staticfiles`
- The qcluster worker was crash-looping on every startup because Django's system check fails when this order is wrong

## Test plan
- [ ] Deploy to alpha and confirm qcluster no longer crash-loops
- [ ] Verify WebSocket real-time sync still works (make a change in one browser, confirm other client updates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)