### PR TITLE
fix: add websockets for uvicorn WebSocket support

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,7 @@
 Django==5.2
 gunicorn==26.0.0
 uvicorn[standard]==0.34.2
+websockets==15.0.1
 daphne==4.2.0
 channels==4.2.2
 channels-redis==4.2.1


### PR DESCRIPTION
## Summary
- Adds `websockets==15.0.1` explicitly to `requirements.txt`

## Root cause
`uvicorn[standard]` installs `websockets` as an extra, but pip skips extras when `uvicorn` is already present as a transitive dependency (from `channels`). Result: uvicorn workers boot without WebSocket support, log "No supported WebSocket library detected", and return 404 for all `/ws/sync/` upgrade requests.

Adding `websockets` directly bypasses the extras resolution issue.

## Test plan
- [ ] `/ws/sync/` connects without "Unsupported upgrade request" warnings
- [ ] Real-time sync works — change in one browser tab reflects in another

🤖 Generated with [Claude Code](https://claude.com/claude-code)