### PR TITLE
fix: align WebSocket broadcast keys with full frontend invalidation set

### DIFF
--- a/backend/accounts/signals.py
+++ b/backend/accounts/signals.py
@@ -37,7 +37,7 @@ def update_cache_on_save(sender, instance, **kwargs):
     if instance.parent_account_id:
         delete_pattern(account_financials(instance.parent_account_id))
         delete_pattern(account_combined_transactions(instance.parent_account_id))
-    broadcast_invalidate(["accounts"])
+    broadcast_invalidate(["accounts", "account_forecast", "tag_graph", "retirement_forecast"])
 
 
 @receiver(post_delete, sender=Account)
@@ -49,7 +49,7 @@ def update_cache_on_delete(sender, instance, **kwargs):
         Q(source_account_id=instance.id) | Q(destination_account_id=instance.id)
     ).delete()
     delete_pattern(account_all(instance.id))
-    broadcast_invalidate(["accounts"])
+    broadcast_invalidate(["accounts", "account_forecast", "tag_graph", "retirement_forecast"])
 
 
 @receiver(pre_save, sender=Account)

--- a/backend/reminders/signals.py
+++ b/backend/reminders/signals.py
@@ -11,6 +11,9 @@ from core.cache.keys import (
     account_combined_transactions,
     account_reminder_transactions,
 )
+from core.broadcast import broadcast_invalidate
+
+_REMINDER_BROADCAST_KEYS = ["reminders", "accounts", "account_forecast", "tag_graph"]
 
 
 @receiver(post_save, sender=Reminder)
@@ -29,6 +32,7 @@ def update_and_invalidate_cache_on_save(sender, instance, **kwargs):
         delete_pattern(
             account_combined_transactions(instance.reminder_destination_account.id)
         )
+    broadcast_invalidate(_REMINDER_BROADCAST_KEYS)
 
 
 @receiver(post_delete, sender=Reminder)
@@ -63,3 +67,4 @@ def update_and_invalidate_cache_on_delete(sender, instance, **kwargs):
             "transactions.tasks.update_interest_forecast_cache",
             dest.id,
         )
+    broadcast_invalidate(_REMINDER_BROADCAST_KEYS)

--- a/backend/transactions/signals.py
+++ b/backend/transactions/signals.py
@@ -7,6 +7,14 @@ from core.cache.keys import account_all
 from core.broadcast import broadcast_invalidate
 
 
+_TRANSACTION_BROADCAST_KEYS = [
+    "transactions", "accounts", "account_forecast",
+    "tag_graph", "tag_graph_items", "calculator",
+    "expense_graph", "pay_graph", "budgets",
+    "retirement_forecast", "retirement_transactions",
+]
+
+
 def _refresh_account(account_id):
     delete_pattern(account_all(account_id))
     async_task("transactions.tasks.update_cc_forecast_cache", account_id)
@@ -18,7 +26,7 @@ def update_forecast_cache_on_save(sender, instance, **kwargs):
     _refresh_account(instance.source_account_id)
     if instance.destination_account_id is not None:
         _refresh_account(instance.destination_account_id)
-    broadcast_invalidate(["transactions"])
+    broadcast_invalidate(_TRANSACTION_BROADCAST_KEYS)
 
 
 @receiver(post_delete, sender=Transaction)
@@ -26,7 +34,7 @@ def update_forecast_cache_on_delete(sender, instance, **kwargs):
     _refresh_account(instance.source_account_id)
     if instance.destination_account_id is not None:
         _refresh_account(instance.destination_account_id)
-    broadcast_invalidate(["transactions"])
+    broadcast_invalidate(_TRANSACTION_BROADCAST_KEYS)
 
 
 @receiver(post_delete, sender=TransactionImage)

--- a/backend/transactions/tasks.py
+++ b/backend/transactions/tasks.py
@@ -805,7 +805,7 @@ def update_reminder_cache(reminder_id):
         if reminder.reminder_destination_account is not None:
             delete_pattern(account_all_transactions(reminder.reminder_destination_account.id))
             update_cc_forecast_cache(reminder.reminder_destination_account.id)
-        broadcast_invalidate(["reminders", "accounts"])
+        broadcast_invalidate(["reminders", "accounts", "account_forecast", "tag_graph"])
     except Exception as e:
         task_logger.warning("There was an error creating cache")
         error_logger.warning(f"{str(e)}")


### PR DESCRIPTION
## Summary
Audited every `broadcast_invalidate` call against what the local browser's `invalidateQueries` does for the same action. Three gaps fixed:

| Signal/task | Was broadcasting | Now broadcasts |
|---|---|---|
| `accounts/signals` save | `accounts` | `accounts`, `account_forecast`, `tag_graph`, `retirement_forecast` |
| `accounts/signals` delete | `accounts` | `accounts`, `account_forecast`, `tag_graph`, `retirement_forecast` |
| `reminders/signals` save | *(nothing)* | `reminders`, `accounts`, `account_forecast`, `tag_graph` |
| `reminders/signals` delete | *(nothing)* | `reminders`, `accounts`, `account_forecast`, `tag_graph` |
| `update_reminder_cache` task | `reminders`, `accounts` | `reminders`, `accounts`, `account_forecast`, `tag_graph` |
| `transactions/signals` save/delete | `transactions` only | Full 11-key set (committed separately) |

## Test plan
- [ ] Add a transaction in browser A → all widgets (accounts, forecast, budget, graphs) update in browser B
- [ ] Edit/create a reminder in browser A → reminder list, account forecast, tag graph update in browser B
- [ ] Edit an account in browser A → account balances, forecast graph, retirement forecast update in browser B

🤖 Generated with [Claude Code](https://claude.com/claude-code)