### PR TITLE
fix: show fetching state on reminders table during background refetch

### DIFF
--- a/frontend/src/components/RemindersWidget.vue
+++ b/frontend/src/components/RemindersWidget.vue
@@ -14,7 +14,7 @@
         :headers="displayHeaders"
         :items="reminders ? reminders : []"
         :items-length="reminders ? reminders.length : 0"
-        :loading="isLoading"
+        :loading="isFetching"
         item-value="id"
         v-model:items-per-page="itemsPerPage"
         :items-per-page-options="[
@@ -281,7 +281,7 @@
   const showDeleteDialog = ref(false);
   const reminderAddFormDialog = ref(false);
   const reminderEditFormDialog = ref(false);
-  const { reminders, isLoading, removeReminder } = useReminders();
+  const { reminders, isLoading, isFetching, removeReminder } = useReminders();
   const page = ref(1);
   const itemsPerPage = computed(() => {
     if (props.variant === "full") {

--- a/frontend/src/composables/remindersComposable.js
+++ b/frontend/src/composables/remindersComposable.js
@@ -77,7 +77,7 @@ async function addReminderTrans(reminderTransObject) {
 
 export function useReminders() {
   const queryClient = useQueryClient();
-  const { data: reminders, isLoading } = useQuery({
+  const { data: reminders, isLoading, isFetching } = useQuery({
     queryKey: ["reminders"],
     queryFn: () => getRemindersFunction(),
     select: response => response,
@@ -153,6 +153,7 @@ export function useReminders() {
 
   return {
     isLoading,
+    isFetching,
     reminders,
     removeReminder,
     addReminder,


### PR DESCRIPTION
## Summary
- Exports `isFetching` from `useReminders` composable
- Changes `:loading` binding on the `v-data-table` in `RemindersWidget` from `isLoading` to `isFetching`

## Root cause
`isLoading` is only `true` on the very first fetch (before any data exists). Once data is cached, background refetches — including those triggered by WebSocket invalidations — leave `isLoading` as `false`, so the table shows stale data with no visual indication that a refresh is in progress.

`isFetching` is `true` on every fetch, including background refetches, matching the behavior of the transactions table.

## Test plan
- [ ] Edit a reminder in another browser — the reminders table shows the Vuetify loading bar while refreshing instead of silently swapping in new data

🤖 Generated with [Claude Code](https://claude.com/claude-code)