### PR TITLE
fix: remove unused isLoading from RemindersWidget

### DIFF
--- a/frontend/src/components/RemindersWidget.vue
+++ b/frontend/src/components/RemindersWidget.vue
@@ -281,7 +281,7 @@
   const showDeleteDialog = ref(false);
   const reminderAddFormDialog = ref(false);
   const reminderEditFormDialog = ref(false);
-  const { reminders, isLoading, isFetching, removeReminder } = useReminders();
+  const { reminders, isFetching, removeReminder } = useReminders();
   const page = ref(1);
   const itemsPerPage = computed(() => {
     if (props.variant === "full") {


### PR DESCRIPTION
## Summary
Removes `isLoading` from the `useReminders()` destructure in `RemindersWidget.vue`.

## Root cause
Build CI failed with ESLint `no-unused-vars`: `isLoading` was left in the destructure after PR #172 switched `:loading="isLoading"` to `:loading="isFetching"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)