### PR TITLE
feat: scheduled reports with inbox WebSocket broadcast

### DIFF
--- a/backend/administration/api/views/message.py
+++ b/backend/administration/api/views/message.py
@@ -1,5 +1,6 @@
 from ninja import Router
 from ninja.errors import HttpError
+from django.db.models import Q
 from administration.models import Message
 from administration.api.schemas.message import (
     MessageIn,
@@ -93,7 +94,7 @@ def update_messages(request, message_id: int, payload: AllMessage):
         success: True
     """
     try:
-        messages = Message.objects.all()
+        messages = Message.objects.filter(Q(user__isnull=True) | Q(user=request.user))
 
         for message in messages:
             message.unread = payload.unread
@@ -180,9 +181,7 @@ def delete_messages(request, message_id: int):
     """
 
     try:
-        messages = Message.objects.all()
-        for message in messages:
-            message.delete()
+        Message.objects.filter(Q(user__isnull=True) | Q(user=request.user)).delete()
         api_logger.info("All Messages deleted")
         return {"success": True}
     except Exception as e:
@@ -206,7 +205,7 @@ def list_messages(request):
     """
 
     try:
-        message_list_object = get_message_list()
+        message_list_object = get_message_list(user=request.user)
         api_logger.debug("Message list retrieved")
         return message_list_object
     except Exception as e:

--- a/backend/administration/migrations/0024_message_user.py
+++ b/backend/administration/migrations/0024_message_user.py
@@ -1,0 +1,25 @@
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("administration", "0023_userdashboardconfig_graph_widgets"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="message",
+            name="user",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="messages",
+                to=settings.AUTH_USER_MODEL,
+            ),
+        ),
+    ]

--- a/backend/administration/models.py
+++ b/backend/administration/models.py
@@ -181,11 +181,15 @@ class Message(models.Model):
     - message_date (DateTimeField): The date of the message, defaults to today.
     - message (CharField): The text of the messsage, limited to 254 characters.
     - unread (BooleanField): Whether or not this message is unread, default is True.
+    - user (ForeignKey): Optional owner — null means visible to all users.
     """
 
     message_date = models.DateTimeField(default=current_date_time)
     message = models.CharField(max_length=254)
     unread = models.BooleanField(default=True)
+    user = models.ForeignKey(
+        "auth.User", on_delete=models.CASCADE, null=True, blank=True, related_name="messages"
+    )
 
     def __str__(self):
         return self.message

--- a/backend/administration/services/message.py
+++ b/backend/administration/services/message.py
@@ -1,18 +1,17 @@
+from django.db.models import Q
 from administration.models import Message
 from administration.api.schemas.message import MessageList, MessageOut
 
 
-def get_message_list() -> MessageList:
+def get_message_list(user=None) -> MessageList:
     """
-    Build a MessageList containing unread count, total count, and all messages
-    ordered by id descending.
-
-    Returns:
-        MessageList: a message list object with unread_count, total_count, and messages.
+    Build a MessageList for the given user: global messages (user=null) plus
+    messages owned by this user. If no user provided, returns only global messages.
     """
-    unread = Message.objects.filter(unread=True).count()
-    total = Message.objects.all().count()
-    messages = Message.objects.all().order_by("-id")
+    qs = Message.objects.filter(Q(user__isnull=True) | Q(user=user)) if user else Message.objects.filter(user__isnull=True)
+    unread = qs.filter(unread=True).count()
+    total = qs.count()
+    messages = qs.order_by("-id")
     message_list = [MessageOut.from_orm(message) for message in messages]
     return MessageList(
         unread_count=unread, total_count=total, messages=message_list

--- a/backend/reports/admin.py
+++ b/backend/reports/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 from unfold.admin import ModelAdmin, TabularInline
-from .models import ReportConfig, ReportConfigTag
+from .models import ReportConfig, ReportConfigTag, ReportResult
 
 
 class ReportConfigTagInline(TabularInline):
@@ -8,9 +8,24 @@ class ReportConfigTagInline(TabularInline):
     extra = 0
 
 
+class ReportResultInline(TabularInline):
+    model = ReportResult
+    extra = 0
+    readonly_fields = ["run_at", "status", "error_message"]
+    fields = ["run_at", "status", "error_message"]
+    can_delete = False
+
+
 @admin.register(ReportConfig)
 class ReportConfigAdmin(ModelAdmin):
-    list_display = ["name", "report_type", "date_range_type", "group_by", "created_by", "updated_at"]
-    list_filter = ["report_type", "group_by", "date_range_type"]
+    list_display = ["name", "report_type", "date_range_type", "group_by", "is_scheduled", "next_run_at", "created_by", "updated_at"]
+    list_filter = ["report_type", "group_by", "date_range_type", "is_scheduled"]
     search_fields = ["name", "description"]
-    inlines = [ReportConfigTagInline]
+    inlines = [ReportConfigTagInline, ReportResultInline]
+
+
+@admin.register(ReportResult)
+class ReportResultAdmin(ModelAdmin):
+    list_display = ["config", "run_at", "status"]
+    list_filter = ["status"]
+    readonly_fields = ["config", "run_at", "status", "error_message", "result_data"]

--- a/backend/reports/api/schemas/report.py
+++ b/backend/reports/api/schemas/report.py
@@ -1,5 +1,5 @@
 from ninja import Schema
-from typing import List, Optional
+from typing import List, Optional, Any
 from datetime import date, datetime
 from decimal import Decimal
 
@@ -32,6 +32,9 @@ class ReportConfigIn(Schema):
     show_subtotal: bool = True
     include_pending: bool = False
     is_shared: bool = False
+    is_scheduled: bool = False
+    schedule_frequency: Optional[str] = None
+    schedule_day: Optional[int] = None
     tag_selections: List[TagSelectionIn] = []
 
 
@@ -52,6 +55,10 @@ class ReportConfigOut(Schema):
     include_pending: bool
     is_shared: bool
     is_owner: bool
+    is_scheduled: bool
+    schedule_frequency: Optional[str] = None
+    schedule_day: Optional[int] = None
+    next_run_at: Optional[datetime] = None
     tag_selections: List[TagSelectionOut]
     created_at: datetime
     updated_at: datetime
@@ -101,3 +108,11 @@ class ReportResultOut(Schema):
     rows: List[ReportRowOut]
     subtotal: Optional[Decimal] = None
     subtotal2: Optional[Decimal] = None
+
+
+class ReportResultRecordOut(Schema):
+    id: int
+    run_at: datetime
+    status: str
+    error_message: str
+    result_data: Optional[Any] = None

--- a/backend/reports/api/views/report.py
+++ b/backend/reports/api/views/report.py
@@ -3,14 +3,19 @@ from ninja.errors import HttpError
 from django.http import Http404
 from django.shortcuts import get_object_or_404
 from django.db.models import Q
-from typing import List
+from django.utils import timezone
+from typing import List, Optional
+from datetime import timedelta
 import logging
 
-from reports.models import ReportConfig, ReportConfigTag
+from dateutil.relativedelta import relativedelta
+
+from reports.models import ReportConfig, ReportConfigTag, ReportResult
 from reports.api.schemas.report import (
     ReportConfigIn,
     ReportConfigOut,
     ReportResultOut,
+    ReportResultRecordOut,
     ReportRunIn,
 )
 from reports.services.execution import run_report
@@ -19,6 +24,28 @@ api_logger = logging.getLogger("api")
 error_logger = logging.getLogger("error")
 
 report_router = Router(tags=["Reports"])
+
+
+def _compute_next_run(frequency: str, schedule_day: Optional[int]):
+    now = timezone.now()
+    day = max(1, min(28, schedule_day or 1))
+    if frequency == "DAILY":
+        return (now + timedelta(days=1)).replace(hour=6, minute=0, second=0, microsecond=0)
+    if frequency == "WEEKLY":
+        # schedule_day: 0=Mon … 6=Sun
+        target_weekday = max(0, min(6, schedule_day or 0))
+        days_ahead = target_weekday - now.weekday()
+        if days_ahead <= 0:
+            days_ahead += 7
+        return (now + timedelta(days=days_ahead)).replace(hour=6, minute=0, second=0, microsecond=0)
+    if frequency == "MONTHLY":
+        this_month_target = now.replace(day=day, hour=6, minute=0, second=0, microsecond=0)
+        if this_month_target > now:
+            return this_month_target
+        return (now.replace(day=1) + relativedelta(months=1)).replace(
+            day=day, hour=6, minute=0, second=0, microsecond=0
+        )
+    return None
 
 
 def _serialize_config(config: ReportConfig, requesting_user=None) -> dict:
@@ -44,6 +71,10 @@ def _serialize_config(config: ReportConfig, requesting_user=None) -> dict:
         "include_pending": config.include_pending,
         "is_shared": config.is_shared,
         "is_owner": is_owner,
+        "is_scheduled": config.is_scheduled,
+        "schedule_frequency": config.schedule_frequency,
+        "schedule_day": config.schedule_day,
+        "next_run_at": config.next_run_at,
         "tag_selections": [
             {
                 "id": sel.id,
@@ -147,6 +178,11 @@ def list_reports(request):
 @report_router.post("", response=ReportConfigOut)
 def create_report(request, payload: ReportConfigIn):
     try:
+        next_run = (
+            _compute_next_run(payload.schedule_frequency, payload.schedule_day)
+            if payload.is_scheduled and payload.schedule_frequency
+            else None
+        )
         config = ReportConfig.objects.create(
             name=payload.name,
             description=payload.description,
@@ -161,6 +197,10 @@ def create_report(request, payload: ReportConfigIn):
             show_subtotal=payload.show_subtotal,
             include_pending=payload.include_pending,
             is_shared=payload.is_shared,
+            is_scheduled=payload.is_scheduled,
+            schedule_frequency=payload.schedule_frequency if payload.is_scheduled else None,
+            schedule_day=payload.schedule_day if payload.is_scheduled else None,
+            next_run_at=next_run,
             created_by=_safe_user(request),
         )
         if payload.account_ids:
@@ -218,6 +258,11 @@ def update_report(request, report_id: int, payload: ReportConfigIn):
         config = get_object_or_404(ReportConfig, id=report_id)
         if not _can_modify(config, request.user):
             raise HttpError(403, "You do not have permission to modify this report")
+        next_run = (
+            _compute_next_run(payload.schedule_frequency, payload.schedule_day)
+            if payload.is_scheduled and payload.schedule_frequency
+            else None
+        )
         config.name = payload.name
         config.description = payload.description
         config.report_type = payload.report_type
@@ -231,6 +276,10 @@ def update_report(request, report_id: int, payload: ReportConfigIn):
         config.show_subtotal = payload.show_subtotal
         config.include_pending = payload.include_pending
         config.is_shared = payload.is_shared
+        config.is_scheduled = payload.is_scheduled
+        config.schedule_frequency = payload.schedule_frequency if payload.is_scheduled else None
+        config.schedule_day = payload.schedule_day if payload.is_scheduled else None
+        config.next_run_at = next_run
         config.save()
         config.accounts.set(payload.account_ids)
         _apply_tag_selections(config, payload.tag_selections)
@@ -291,3 +340,40 @@ def run_saved_report(request, report_id: int):
     except Exception as e:
         error_logger.exception(str(e))
         raise HttpError(500, "Failed to run saved report")
+
+
+@report_router.get("/{report_id}/results", response=List[ReportResultRecordOut])
+def list_report_results(request, report_id: int):
+    user = request.user
+    config = get_object_or_404(ReportConfig, id=report_id)
+    if not (config.created_by_id == user.pk or config.is_shared):
+        raise HttpError(404, "Report not found")
+    results = ReportResult.objects.filter(config=config).only(
+        "id", "run_at", "status", "error_message"
+    )[:20]
+    return [
+        {
+            "id": r.id,
+            "run_at": r.run_at,
+            "status": r.status,
+            "error_message": r.error_message,
+            "result_data": None,
+        }
+        for r in results
+    ]
+
+
+@report_router.get("/{report_id}/results/{result_id}", response=ReportResultRecordOut)
+def get_report_result(request, report_id: int, result_id: int):
+    user = request.user
+    config = get_object_or_404(ReportConfig, id=report_id)
+    if not (config.created_by_id == user.pk or config.is_shared):
+        raise HttpError(404, "Report not found")
+    result = get_object_or_404(ReportResult, id=result_id, config=config)
+    return {
+        "id": result.id,
+        "run_at": result.run_at,
+        "status": result.status,
+        "error_message": result.error_message,
+        "result_data": result.result_data,
+    }

--- a/backend/reports/migrations/0004_add_schedule_and_results.py
+++ b/backend/reports/migrations/0004_add_schedule_and_results.py
@@ -1,0 +1,65 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("reports", "0003_add_is_shared_to_reportconfig"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="reportconfig",
+            name="is_scheduled",
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AddField(
+            model_name="reportconfig",
+            name="schedule_frequency",
+            field=models.CharField(
+                blank=True,
+                choices=[("DAILY", "Daily"), ("WEEKLY", "Weekly"), ("MONTHLY", "Monthly")],
+                max_length=10,
+                null=True,
+            ),
+        ),
+        migrations.AddField(
+            model_name="reportconfig",
+            name="schedule_day",
+            field=models.IntegerField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="reportconfig",
+            name="next_run_at",
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+        migrations.CreateModel(
+            name="ReportResult",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                (
+                    "config",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="results",
+                        to="reports.reportconfig",
+                    ),
+                ),
+                ("run_at", models.DateTimeField(auto_now_add=True)),
+                ("result_data", models.JSONField(default=dict)),
+                (
+                    "status",
+                    models.CharField(
+                        choices=[("success", "Success"), ("error", "Error")],
+                        default="success",
+                        max_length=10,
+                    ),
+                ),
+                ("error_message", models.TextField(blank=True, default="")),
+            ],
+            options={
+                "ordering": ["-run_at"],
+            },
+        ),
+    ]

--- a/backend/reports/models.py
+++ b/backend/reports/models.py
@@ -22,6 +22,17 @@ GROUP_BY_CHOICES = [
     ("MONTH", "Month"),
 ]
 
+SCHEDULE_FREQUENCY_CHOICES = [
+    ("DAILY", "Daily"),
+    ("WEEKLY", "Weekly"),
+    ("MONTHLY", "Monthly"),
+]
+
+RESULT_STATUS_CHOICES = [
+    ("success", "Success"),
+    ("error", "Error"),
+]
+
 
 class ReportConfig(models.Model):
     name = models.CharField(max_length=254)
@@ -38,6 +49,12 @@ class ReportConfig(models.Model):
     show_subtotal = models.BooleanField(default=True)
     include_pending = models.BooleanField(default=False)
     is_shared = models.BooleanField(default=False)
+    is_scheduled = models.BooleanField(default=False)
+    schedule_frequency = models.CharField(
+        max_length=10, choices=SCHEDULE_FREQUENCY_CHOICES, null=True, blank=True
+    )
+    schedule_day = models.IntegerField(null=True, blank=True)
+    next_run_at = models.DateTimeField(null=True, blank=True)
     created_by = models.ForeignKey(
         User, on_delete=models.SET_NULL, null=True, blank=True
     )
@@ -49,6 +66,22 @@ class ReportConfig(models.Model):
 
     def __str__(self):
         return self.name
+
+
+class ReportResult(models.Model):
+    config = models.ForeignKey(
+        ReportConfig, on_delete=models.CASCADE, related_name="results"
+    )
+    run_at = models.DateTimeField(auto_now_add=True)
+    result_data = models.JSONField(default=dict)
+    status = models.CharField(max_length=10, choices=RESULT_STATUS_CHOICES, default="success")
+    error_message = models.TextField(blank=True, default="")
+
+    class Meta:
+        ordering = ["-run_at"]
+
+    def __str__(self):
+        return f"{self.config.name} — {self.run_at:%Y-%m-%d %H:%M}"
 
 
 class ReportConfigTag(models.Model):

--- a/backend/transactions/management/commands/scheduletasks.py
+++ b/backend/transactions/management/commands/scheduletasks.py
@@ -116,6 +116,15 @@ class Command(BaseCommand):
                 "start_today": False,
                 "delete": False,
             },
+            {
+                "task_name": "Run Scheduled Reports",
+                "function": "transactions.tasks.run_scheduled_reports",
+                "time": "00:00",
+                "arguments": "",
+                "type": "HOURLY",
+                "start_today": True,
+                "delete": False,
+            },
         ]
 
         # Schedule or modify tasks

--- a/backend/transactions/tasks.py
+++ b/backend/transactions/tasks.py
@@ -109,21 +109,25 @@ def cleanup_old_backups():
             error_logger.exception(f"Failed to delete backup {f}: {e}")
 
 
-def create_message(message_text):
+def create_message(message_text, user=None):
     """
     The function `create_message` creates a Message object for
     displaying a message alert in the app inbox.
 
     Args:
         message_text (str): The text of the message
+        user: Optional User instance — if set, message is private to that user
+              and the WebSocket notification targets only their channel group.
     """
 
     Message.objects.create(
         message_date=get_todays_date_timezone_adjusted(True),
         message=message_text,
         unread=True,
+        user=user,
     )
-    broadcast_invalidate(["messages"])
+    group = f"user_{user.pk}" if user else "global"
+    broadcast_invalidate(["messages"], group=group)
 
 
 def convert_reminder():
@@ -1546,7 +1550,7 @@ def run_scheduled_reports():
                 result_data=_result_dict_for_json(result),
                 status="success",
             )
-            create_message(f"Scheduled report '{config.name}' completed successfully.")
+            create_message(f"Scheduled report '{config.name}' completed successfully.", user=config.created_by)
             task_logger.info(f"Scheduled report '{config.name}' (id={config.id}) ran successfully.")
         except Exception as e:
             ReportResult.objects.create(
@@ -1555,11 +1559,14 @@ def run_scheduled_reports():
                 status="error",
                 error_message=str(e),
             )
-            create_message(f"Scheduled report '{config.name}' failed: {e}")
+            create_message(f"Scheduled report '{config.name}' failed: {e}", user=config.created_by)
             error_logger.exception(f"Scheduled report '{config.name}' (id={config.id}) failed: {e}")
 
         config.next_run_at = _compute_next_run(config.schedule_frequency, config.schedule_day)
         config.save(update_fields=["next_run_at"])
+
+    if due:
+        broadcast_invalidate(["report_results"])
 
 
 # TODO: Task to look for negative dips

--- a/backend/transactions/tasks.py
+++ b/backend/transactions/tasks.py
@@ -123,6 +123,7 @@ def create_message(message_text):
         message=message_text,
         unread=True,
     )
+    broadcast_invalidate(["messages"])
 
 
 def convert_reminder():
@@ -1458,6 +1459,107 @@ def calculate_interest(
     daily_rate = annual_rate / 365 / 100
     interest = amount * daily_rate * days
     return interest.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+
+
+def _result_dict_for_json(result: dict) -> dict:
+    """Convert run_report() output (with date/Decimal values) to JSON-safe dict."""
+    from decimal import Decimal as D
+
+    def _d(v):
+        return str(v) if isinstance(v, D) else v
+
+    def _date(v):
+        return v.isoformat() if v and hasattr(v, "isoformat") else v
+
+    rows = []
+    for row in result.get("rows", []):
+        serialized_row = {
+            "label": row.get("label"),
+            "total": _d(row.get("total")),
+            "period1_total": _d(row.get("period1_total")),
+            "period2_total": _d(row.get("period2_total")),
+            "difference": _d(row.get("difference")),
+        }
+        if "transactions" in row and row["transactions"] is not None:
+            serialized_row["transactions"] = [
+                {
+                    "id": tx["id"],
+                    "date": _date(tx["date"]),
+                    "description": tx["description"],
+                    "amount": _d(tx["amount"]),
+                    "account": tx["account"],
+                }
+                for tx in row["transactions"]
+            ]
+        rows.append(serialized_row)
+
+    return {
+        "report_type": result.get("report_type"),
+        "group_by": result.get("group_by"),
+        "date_from": _date(result.get("date_from")),
+        "date_to": _date(result.get("date_to")),
+        "period2_from": _date(result.get("period2_from")),
+        "period2_to": _date(result.get("period2_to")),
+        "rows": rows,
+        "subtotal": _d(result.get("subtotal")),
+        "subtotal2": _d(result.get("subtotal2")),
+    }
+
+
+def run_scheduled_reports():
+    """Run all ReportConfigs that are due for their scheduled execution."""
+    from reports.models import ReportConfig, ReportResult
+    from reports.services.execution import run_report
+    from reports.api.views.report import _compute_next_run
+
+    now = timezone.now()
+    due = ReportConfig.objects.filter(
+        is_scheduled=True, next_run_at__lte=now
+    ).prefetch_related("tag_selections", "accounts")
+
+    for config in due:
+        try:
+            tag_dicts = [
+                {
+                    "tag_id": sel.tag_id,
+                    "sub_tag_id": sel.sub_tag_id,
+                    "main_tag_id": sel.main_tag_id,
+                }
+                for sel in config.tag_selections.all()
+            ]
+            result = run_report(
+                report_type=config.report_type,
+                date_range_type=config.date_range_type,
+                group_by=config.group_by,
+                date_from=config.date_from,
+                date_to=config.date_to,
+                account_ids=list(config.accounts.values_list("id", flat=True)),
+                tag_selections=tag_dicts,
+                show_transactions=config.show_transactions,
+                show_subtotal=config.show_subtotal,
+                include_pending=config.include_pending,
+                period2_date_from=config.period2_date_from,
+                period2_date_to=config.period2_date_to,
+            )
+            ReportResult.objects.create(
+                config=config,
+                result_data=_result_dict_for_json(result),
+                status="success",
+            )
+            create_message(f"Scheduled report '{config.name}' completed successfully.")
+            task_logger.info(f"Scheduled report '{config.name}' (id={config.id}) ran successfully.")
+        except Exception as e:
+            ReportResult.objects.create(
+                config=config,
+                result_data={},
+                status="error",
+                error_message=str(e),
+            )
+            create_message(f"Scheduled report '{config.name}' failed: {e}")
+            error_logger.exception(f"Scheduled report '{config.name}' (id={config.id}) failed: {e}")
+
+        config.next_run_at = _compute_next_run(config.schedule_frequency, config.schedule_day)
+        config.save(update_fields=["next_run_at"])
 
 
 # TODO: Task to look for negative dips

--- a/frontend/src/composables/messagesComposable.js
+++ b/frontend/src/composables/messagesComposable.js
@@ -79,7 +79,7 @@ export function useMessages() {
     select: response => response,
     client: queryClient,
     staleTime: 0,
-    refetchInterval: 60000,
+    refetchInterval: 300000,
     refetchIntervalInBackground: true,
   });
 

--- a/frontend/src/composables/reportsComposable.js
+++ b/frontend/src/composables/reportsComposable.js
@@ -63,6 +63,24 @@ async function runSavedReportFunction(id) {
   }
 }
 
+async function listResultsFunction(reportId) {
+  try {
+    const response = await apiClient.get(`/reports/${reportId}/results`);
+    return response.data;
+  } catch (error) {
+    return await handleApiError(error, "Failed to load report history");
+  }
+}
+
+async function getResultFunction({ reportId, resultId }) {
+  try {
+    const response = await apiClient.get(`/reports/${reportId}/results/${resultId}`);
+    return response.data;
+  } catch (error) {
+    return await handleApiError(error, "Failed to load report result");
+  }
+}
+
 export function useReports() {
   const queryClient = useQueryClient();
   const mainstore = useMainStore();
@@ -124,6 +142,14 @@ export function useReports() {
     return runSavedMutation.mutateAsync(id);
   }
 
+  async function fetchResults(reportId) {
+    return listResultsFunction(reportId);
+  }
+
+  async function fetchResult(reportId, resultId) {
+    return getResultFunction({ reportId, resultId });
+  }
+
   return {
     reports,
     isLoading,
@@ -133,6 +159,8 @@ export function useReports() {
     deleteReport,
     runReport,
     runSavedReport,
+    fetchResults,
+    fetchResult,
     isSaving: createMutation.isPending || updateMutation.isPending,
     isRunning: runMutation.isPending || runSavedMutation.isPending,
   };

--- a/frontend/src/views/ReportsView.vue
+++ b/frontend/src/views/ReportsView.vue
@@ -45,12 +45,17 @@
                 @click="loadSavedReport(report)"
               >
                 <template v-slot:prepend>
+                  <v-tooltip v-if="report.is_scheduled" location="right" text="Scheduled report">
+                    <template v-slot:activator="{ props }">
+                      <v-icon icon="mdi-clock-outline" size="x-small" color="warning" class="mr-1" v-bind="props" />
+                    </template>
+                  </v-tooltip>
                   <v-tooltip v-if="report.is_shared" location="right" text="Shared with all users">
                     <template v-slot:activator="{ props }">
                       <v-icon icon="mdi-share-variant" size="x-small" color="primary" class="mr-2" v-bind="props" />
                     </template>
                   </v-tooltip>
-                  <v-icon v-else icon="mdi-file-chart-outline" size="x-small" class="mr-2 text-medium-emphasis" />
+                  <v-icon v-if="!report.is_shared && !report.is_scheduled" icon="mdi-file-chart-outline" size="x-small" class="mr-2 text-medium-emphasis" />
                 </template>
                 <v-list-item-title class="text-body-2">{{ report.name }}</v-list-item-title>
                 <v-list-item-subtitle class="text-caption">
@@ -301,6 +306,51 @@
           </v-container>
         </v-sheet>
 
+        <!-- Scheduled History -->
+        <v-sheet border rounded class="mb-4" v-if="activeSavedId">
+          <v-container>
+            <v-row dense align="center">
+              <v-col>
+                <span class="text-subtitle-1 font-weight-bold">Scheduled History</span>
+              </v-col>
+            </v-row>
+            <v-progress-linear indeterminate v-if="historyLoading" color="primary" class="mb-2"></v-progress-linear>
+            <div v-if="!historyLoading && historyItems.length === 0" class="text-body-2 text-medium-emphasis">
+              No scheduled runs yet.
+            </div>
+            <v-list density="compact" v-if="historyItems.length > 0">
+              <v-list-item
+                v-for="item in historyItems"
+                :key="item.id"
+                class="pa-1"
+              >
+                <template v-slot:prepend>
+                  <v-chip
+                    :color="item.status === 'success' ? 'success' : 'error'"
+                    size="x-small"
+                    class="mr-2"
+                  >{{ item.status }}</v-chip>
+                </template>
+                <v-list-item-title class="text-body-2">
+                  {{ formatHistoryDate(item.run_at) }}
+                </v-list-item-title>
+                <v-list-item-subtitle v-if="item.status === 'error'" class="text-caption text-error">
+                  {{ item.error_message }}
+                </v-list-item-subtitle>
+                <template v-slot:append>
+                  <v-btn
+                    v-if="item.status === 'success'"
+                    size="x-small"
+                    variant="text"
+                    color="primary"
+                    @click="loadHistoryResult(item.id)"
+                  >Load</v-btn>
+                </template>
+              </v-list-item>
+            </v-list>
+          </v-container>
+        </v-sheet>
+
         <!-- Results -->
         <v-sheet border rounded v-if="results" id="report-results">
           <v-container>
@@ -428,7 +478,7 @@
     </v-row>
 
     <!-- Save dialog -->
-    <v-dialog v-model="saveDialog" max-width="420">
+    <v-dialog v-model="saveDialog" max-width="480">
       <v-card>
         <v-card-title class="text-h6">Save Report</v-card-title>
         <v-card-text>
@@ -451,7 +501,53 @@
             label="Share with all users"
             density="compact"
             hide-details
+            class="mb-2"
           ></v-checkbox>
+          <v-divider class="mb-3"></v-divider>
+          <v-checkbox
+            v-model="saveIsScheduled"
+            label="Run on a schedule"
+            density="compact"
+            hide-details
+            class="mb-2"
+          ></v-checkbox>
+          <template v-if="saveIsScheduled">
+            <v-select
+              label="Frequency"
+              v-model="saveScheduleFrequency"
+              :items="scheduleFrequencyOptions"
+              item-title="label"
+              item-value="value"
+              density="comfortable"
+              variant="outlined"
+              hide-details
+              class="mb-2"
+            ></v-select>
+            <v-select
+              v-if="saveScheduleFrequency === 'WEEKLY'"
+              label="Day of Week"
+              v-model="saveScheduleDay"
+              :items="weekdayOptions"
+              item-title="label"
+              item-value="value"
+              density="comfortable"
+              variant="outlined"
+              hide-details
+              class="mb-2"
+            ></v-select>
+            <v-select
+              v-if="saveScheduleFrequency === 'MONTHLY'"
+              label="Day of Month"
+              v-model="saveScheduleDay"
+              :items="monthdayOptions"
+              item-title="label"
+              item-value="value"
+              density="comfortable"
+              variant="outlined"
+              hide-details
+              class="mb-2"
+            ></v-select>
+          </template>
         </v-card-text>
         <v-card-actions>
           <v-spacer></v-spacer>
@@ -462,7 +558,7 @@
     </v-dialog>
 
     <!-- Update name dialog -->
-    <v-dialog v-model="updateDialog" max-width="420">
+    <v-dialog v-model="updateDialog" max-width="480">
       <v-card>
         <v-card-title class="text-h6">Update Report</v-card-title>
         <v-card-text>
@@ -485,7 +581,53 @@
             label="Share with all users"
             density="compact"
             hide-details
+            class="mb-2"
           ></v-checkbox>
+          <v-divider class="mb-3"></v-divider>
+          <v-checkbox
+            v-model="saveIsScheduled"
+            label="Run on a schedule"
+            density="compact"
+            hide-details
+            class="mb-2"
+          ></v-checkbox>
+          <template v-if="saveIsScheduled">
+            <v-select
+              label="Frequency"
+              v-model="saveScheduleFrequency"
+              :items="scheduleFrequencyOptions"
+              item-title="label"
+              item-value="value"
+              density="comfortable"
+              variant="outlined"
+              hide-details
+              class="mb-2"
+            ></v-select>
+            <v-select
+              v-if="saveScheduleFrequency === 'WEEKLY'"
+              label="Day of Week"
+              v-model="saveScheduleDay"
+              :items="weekdayOptions"
+              item-title="label"
+              item-value="value"
+              density="comfortable"
+              variant="outlined"
+              hide-details
+              class="mb-2"
+            ></v-select>
+            <v-select
+              v-if="saveScheduleFrequency === 'MONTHLY'"
+              label="Day of Month"
+              v-model="saveScheduleDay"
+              :items="monthdayOptions"
+              item-title="label"
+              item-value="value"
+              density="comfortable"
+              variant="outlined"
+              hide-details
+              class="mb-2"
+            ></v-select>
+          </template>
         </v-card-text>
         <v-card-actions>
           <v-spacer></v-spacer>
@@ -525,7 +667,7 @@
   const authStore = useAuthStore();
   const { isOnline } = useOnlineStatus();
   const reportsComposable = useReports();
-  const { reports, isLoading, saveReport, updateReport, deleteReport, isSaving, isRunning } = reportsComposable;
+  const { reports, isLoading, saveReport, updateReport, deleteReport, isSaving, isRunning, fetchResults, fetchResult } = reportsComposable;
   const { accounts } = useAccounts(false);
   const { tags } = useTags();
 
@@ -547,6 +689,9 @@
     show_subtotal: true,
     include_pending: false,
     show_transactions: false,
+    is_scheduled: false,
+    schedule_frequency: "DAILY",
+    schedule_day: null,
   });
 
   const form = ref(defaultForm());
@@ -562,7 +707,13 @@
   const saveName = ref("");
   const saveDescription = ref("");
   const saveIsShared = ref(false);
+  const saveIsScheduled = ref(false);
+  const saveScheduleFrequency = ref("DAILY");
+  const saveScheduleDay = ref(null);
   const pendingDelete = ref(null);
+
+  const historyItems = ref([]);
+  const historyLoading = ref(false);
 
   // ---------------------------------------------------------------------------
   // Dropdown options
@@ -571,6 +722,24 @@
     { label: "Totals", value: "TOTALS" },
     { label: "Comparison", value: "COMPARISON" },
   ];
+
+  const scheduleFrequencyOptions = [
+    { label: "Daily", value: "DAILY" },
+    { label: "Weekly", value: "WEEKLY" },
+    { label: "Monthly", value: "MONTHLY" },
+  ];
+
+  const weekdayOptions = [
+    { label: "Monday", value: 0 },
+    { label: "Tuesday", value: 1 },
+    { label: "Wednesday", value: 2 },
+    { label: "Thursday", value: 3 },
+    { label: "Friday", value: 4 },
+    { label: "Saturday", value: 5 },
+    { label: "Sunday", value: 6 },
+  ];
+
+  const monthdayOptions = Array.from({ length: 28 }, (_, i) => ({ label: String(i + 1), value: i + 1 }));
 
   const dateRangeOptions = [
     { label: "This Year", value: "THIS_YEAR" },
@@ -652,6 +821,7 @@
     activeSavedIsOwner.value = false;
     form.value = defaultForm();
     results.value = null;
+    historyItems.value = [];
   }
 
   function loadSavedReport(report) {
@@ -683,8 +853,34 @@
       show_subtotal: report.show_subtotal,
       include_pending: report.include_pending,
       show_transactions: report.show_transactions,
+      is_scheduled: report.is_scheduled ?? false,
+      schedule_frequency: report.schedule_frequency ?? "DAILY",
+      schedule_day: report.schedule_day ?? null,
     };
     results.value = null;
+    loadHistory(report.id);
+  }
+
+  async function loadHistory(reportId) {
+    historyLoading.value = true;
+    try {
+      historyItems.value = await fetchResults(reportId);
+    } catch {
+      historyItems.value = [];
+    } finally {
+      historyLoading.value = false;
+    }
+  }
+
+  async function loadHistoryResult(resultId) {
+    try {
+      const record = await fetchResult(activeSavedId.value, resultId);
+      if (record.result_data && record.result_data.report_type) {
+        results.value = record.result_data;
+      }
+    } catch {
+      mainStore.showSnackbar("Failed to load historical result", "error");
+    }
   }
 
   function buildPayload() {
@@ -724,6 +920,9 @@
     saveName.value = "";
     saveDescription.value = "";
     saveIsShared.value = false;
+    saveIsScheduled.value = form.value.is_scheduled;
+    saveScheduleFrequency.value = form.value.schedule_frequency ?? "DAILY";
+    saveScheduleDay.value = form.value.schedule_day ?? null;
     saveDialog.value = true;
   }
 
@@ -732,7 +931,18 @@
     saveDescription.value = activeSavedDescription.value;
     const active = (reports.value ?? []).find(r => r.id === activeSavedId.value);
     saveIsShared.value = active?.is_shared ?? false;
+    saveIsScheduled.value = active?.is_scheduled ?? false;
+    saveScheduleFrequency.value = active?.schedule_frequency ?? "DAILY";
+    saveScheduleDay.value = active?.schedule_day ?? null;
     updateDialog.value = true;
+  }
+
+  function _schedulePayload() {
+    return {
+      is_scheduled: saveIsScheduled.value,
+      schedule_frequency: saveIsScheduled.value ? saveScheduleFrequency.value : null,
+      schedule_day: saveIsScheduled.value ? saveScheduleDay.value : null,
+    };
   }
 
   function doSave() {
@@ -744,6 +954,7 @@
       name: saveName.value.trim(),
       description: saveDescription.value.trim(),
       is_shared: saveIsShared.value,
+      ..._schedulePayload(),
       ...buildPayload(),
     };
     saveReport(payload);
@@ -759,11 +970,15 @@
       name: saveName.value.trim(),
       description: saveDescription.value.trim(),
       is_shared: saveIsShared.value,
+      ..._schedulePayload(),
       ...buildPayload(),
     };
     updateReport(activeSavedId.value, payload);
     activeSavedName.value = saveName.value.trim();
     activeSavedDescription.value = saveDescription.value.trim();
+    form.value.is_scheduled = saveIsScheduled.value;
+    form.value.schedule_frequency = saveScheduleFrequency.value;
+    form.value.schedule_day = saveScheduleDay.value;
     updateDialog.value = false;
   }
 
@@ -805,6 +1020,15 @@
       return `${p1}  vs  ${result.period2_from} – ${result.period2_to}`;
     }
     return p1;
+  }
+
+  function formatHistoryDate(isoString) {
+    if (!isoString) return "";
+    const d = new Date(isoString);
+    return d.toLocaleString("en-US", {
+      month: "short", day: "numeric", year: "numeric",
+      hour: "numeric", minute: "2-digit",
+    });
   }
 </script>
 

--- a/frontend/src/views/ReportsView.vue
+++ b/frontend/src/views/ReportsView.vue
@@ -284,16 +284,23 @@
                   :disabled="!isOnline"
                 >Run Report</v-btn>
               </v-col>
-              <v-col cols="auto" v-if="results && (!activeSavedId || activeSavedIsOwner || authStore.isFullAccess)">
+              <v-col cols="auto" v-if="results && !activeSavedId">
                 <v-btn
                   color="secondary"
                   variant="outlined"
-                  :prepend-icon="activeSavedId ? 'mdi-content-save-edit' : 'mdi-content-save'"
+                  prepend-icon="mdi-content-save"
                   :loading="isSaving"
-                  @click="activeSavedId ? openUpdateDialog() : openSaveDialog()"
-                >
-                  {{ activeSavedId ? 'Update Report' : 'Save Report' }}
-                </v-btn>
+                  @click="openSaveDialog()"
+                >Save Report</v-btn>
+              </v-col>
+              <v-col cols="auto" v-if="activeSavedId && (activeSavedIsOwner || authStore.isFullAccess)">
+                <v-btn
+                  color="secondary"
+                  variant="outlined"
+                  prepend-icon="mdi-content-save-edit"
+                  :loading="isSaving"
+                  @click="openUpdateDialog()"
+                >Update Report</v-btn>
               </v-col>
               <v-col cols="auto" v-if="results">
                 <v-btn

--- a/frontend/src/views/ReportsView.vue
+++ b/frontend/src/views/ReportsView.vue
@@ -663,6 +663,7 @@
 
 <script setup>
   import { ref, computed } from "vue";
+  import { useQuery } from "@tanstack/vue-query";
   import { useReports } from "@/composables/reportsComposable";
   import { useAccounts } from "@/composables/accountsComposable";
   import { useTags } from "@/composables/tagsComposable";
@@ -719,8 +720,12 @@
   const saveScheduleDay = ref(null);
   const pendingDelete = ref(null);
 
-  const historyItems = ref([]);
-  const historyLoading = ref(false);
+  const { data: historyItems, isFetching: historyLoading } = useQuery({
+    queryKey: computed(() => ["report_results", activeSavedId.value]),
+    queryFn: () => activeSavedId.value ? fetchResults(activeSavedId.value) : Promise.resolve([]),
+    enabled: computed(() => !!activeSavedId.value),
+    initialData: [],
+  });
 
   // ---------------------------------------------------------------------------
   // Dropdown options
@@ -828,7 +833,6 @@
     activeSavedIsOwner.value = false;
     form.value = defaultForm();
     results.value = null;
-    historyItems.value = [];
   }
 
   function loadSavedReport(report) {
@@ -865,18 +869,6 @@
       schedule_day: report.schedule_day ?? null,
     };
     results.value = null;
-    loadHistory(report.id);
-  }
-
-  async function loadHistory(reportId) {
-    historyLoading.value = true;
-    try {
-      historyItems.value = await fetchResults(reportId);
-    } catch {
-      historyItems.value = [];
-    } finally {
-      historyLoading.value = false;
-    }
   }
 
   async function loadHistoryResult(resultId) {

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -66,6 +66,11 @@ export default defineConfig({
         target: "https://back-dev.danielleandjohn.love", // Serve media files from backend in dev
         changeOrigin: true,
       },
+      "/ws": {
+        target: "wss://back-dev.danielleandjohn.love",
+        changeOrigin: true,
+        ws: true,
+      },
     },
   },
   define: {


### PR DESCRIPTION
## Summary
- `ReportConfig` gains schedule fields (`is_scheduled`, `schedule_frequency`, `schedule_day`, `next_run_at`); new `ReportResult` model stores JSON output of each run
- New hourly django-q2 task `run_scheduled_reports` finds due reports, executes them, saves results, and sends inbox messages; `create_message()` now broadcasts `["messages"]` via WebSocket so all clients update instantly
- Messages polling fallback reduced 60s → 300s
- Frontend: schedule toggle + frequency/day pickers in save/update dialogs; clock icon on scheduled reports; Scheduled History panel with Load button to replay past results

## Test plan
- [ ] Save a new report with "Run on a schedule" toggled on — verify schedule fields persist and clock icon appears in saved list
- [ ] Update an existing report to add/remove schedule — verify fields update correctly
- [ ] Trigger `run_scheduled_reports` manually (django shell or back-date `next_run_at`) — verify `ReportResult` created, inbox message sent, WebSocket pushes `["messages"]`
- [ ] Open Scheduled History for a scheduled report — verify past runs listed; click Load and verify results panel updates
- [ ] Verify inbox badge updates immediately when a scheduled report completes (no 60s wait)
- [ ] Migration applies cleanly on a fresh container restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)