### PR TITLE
feat: recurring transaction detection with weekly scan and inbox alerts

### DIFF
--- a/backend/administration/api/schemas/message.py
+++ b/backend/administration/api/schemas/message.py
@@ -1,6 +1,6 @@
 from ninja import Schema
 from datetime import datetime
-from typing import List
+from typing import List, Optional
 from pydantic import ConfigDict
 
 
@@ -17,6 +17,7 @@ class MessageOut(Schema):
     message_date: datetime
     message: str
     unread: bool
+    link: Optional[str] = None
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/backend/administration/migrations/0025_message_link.py
+++ b/backend/administration/migrations/0025_message_link.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("administration", "0024_message_user"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="message",
+            name="link",
+            field=models.CharField(blank=True, max_length=254, null=True),
+        ),
+    ]

--- a/backend/administration/models.py
+++ b/backend/administration/models.py
@@ -190,6 +190,7 @@ class Message(models.Model):
     user = models.ForeignKey(
         "auth.User", on_delete=models.CASCADE, null=True, blank=True, related_name="messages"
     )
+    link = models.CharField(max_length=254, null=True, blank=True)
 
     def __str__(self):
         return self.message

--- a/backend/backend/api.py
+++ b/backend/backend/api.py
@@ -42,6 +42,7 @@ from planning.api.routers.calculator import calculator_router
 from planning.api.routers.planning_graph import planning_graph_router
 from planning.api.routers.budget import budget_router
 from planning.api.routers.retirement import retirement_router
+from planning.api.routers.detected_recurring import router as detected_recurring_router
 from administration.api.routers.health import health_router
 from administration.api.routers.backup import backup_router
 from administration.api.routers.logs import router as logs_router
@@ -96,6 +97,7 @@ api.add_router("/planning/calculator", calculator_router)
 api.add_router("/planning/graph", planning_graph_router)
 api.add_router("/planning/budget", budget_router)
 api.add_router("/planning/retirement", retirement_router)
+api.add_router("/planning/detected-recurring", detected_recurring_router)
 api.add_router("/administration/health", health_router)
 api.add_router("/administration/backups", backup_router)
 api.add_router("/administration/logs", logs_router)

--- a/backend/planning/admin.py
+++ b/backend/planning/admin.py
@@ -1,6 +1,7 @@
 from django.contrib import admin
+from unfold.admin import ModelAdmin
 from core.admin import UnfoldImportExportModelAdmin
-from .models import ChristmasGift, ContribRule, Contribution, Note, CalculationRule, Budget
+from .models import ChristmasGift, ContribRule, Contribution, Note, CalculationRule, Budget, DetectedRecurring
 
 
 class ChristmasGiftAdmin(UnfoldImportExportModelAdmin):
@@ -39,9 +40,16 @@ class BudgetAdmin(UnfoldImportExportModelAdmin):
     ordering = ["name"]
 
 
+class DetectedRecurringAdmin(ModelAdmin):
+    list_display = ["description", "estimated_amount", "repeat", "next_estimated_date", "is_ignored", "created_at"]
+    list_filter = ["is_ignored"]
+    search_fields = ["description"]
+
+
 admin.site.register(ChristmasGift, ChristmasGiftAdmin)
 admin.site.register(ContribRule, ContribRuleAdmin)
 admin.site.register(Contribution, ContributionAdmin)
 admin.site.register(Note, NoteAdmin)
 admin.site.register(CalculationRule, CalculationRuleAdmin)
 admin.site.register(Budget, BudgetAdmin)
+admin.site.register(DetectedRecurring, DetectedRecurringAdmin)

--- a/backend/planning/api/routers/detected_recurring.py
+++ b/backend/planning/api/routers/detected_recurring.py
@@ -1,0 +1,5 @@
+from ninja import Router
+from planning.api.views.detected_recurring import detected_recurring_router
+
+router = Router()
+router.add_router("/", detected_recurring_router)

--- a/backend/planning/api/schemas/detected_recurring.py
+++ b/backend/planning/api/schemas/detected_recurring.py
@@ -1,0 +1,15 @@
+from ninja import Schema
+from typing import List, Optional
+from datetime import date, datetime
+from decimal import Decimal
+
+
+class DetectedRecurringOut(Schema):
+    id: int
+    description: str
+    estimated_amount: Decimal
+    repeat_id: Optional[int] = None
+    repeat_name: Optional[str] = None
+    next_estimated_date: date
+    transaction_ids: List[int]
+    created_at: datetime

--- a/backend/planning/api/schemas/detected_recurring.py
+++ b/backend/planning/api/schemas/detected_recurring.py
@@ -13,3 +13,5 @@ class DetectedRecurringOut(Schema):
     next_estimated_date: date
     transaction_ids: List[int]
     created_at: datetime
+    suggested_tag_id: Optional[int] = None
+    suggested_account_id: Optional[int] = None

--- a/backend/planning/api/views/detected_recurring.py
+++ b/backend/planning/api/views/detected_recurring.py
@@ -1,0 +1,62 @@
+from ninja import Router
+from ninja.errors import HttpError
+from django.shortcuts import get_object_or_404
+from django.http import Http404
+from typing import List
+import logging
+
+from planning.models import DetectedRecurring
+from planning.api.schemas.detected_recurring import DetectedRecurringOut
+
+api_logger = logging.getLogger("api")
+error_logger = logging.getLogger("error")
+
+detected_recurring_router = Router(tags=["Detected Recurring"])
+
+
+def _serialize(d: DetectedRecurring) -> dict:
+    return {
+        "id": d.id,
+        "description": d.description,
+        "estimated_amount": d.estimated_amount,
+        "repeat_id": d.repeat_id,
+        "repeat_name": d.repeat.repeat_name if d.repeat else None,
+        "next_estimated_date": d.next_estimated_date,
+        "transaction_ids": d.transaction_ids,
+        "created_at": d.created_at,
+    }
+
+
+@detected_recurring_router.get("", response=List[DetectedRecurringOut])
+def list_detected(request):
+    detections = DetectedRecurring.objects.filter(is_ignored=False).select_related("repeat")
+    return [_serialize(d) for d in detections]
+
+
+@detected_recurring_router.post("/{detection_id}/ignore")
+def ignore_detected(request, detection_id: int):
+    try:
+        detection = get_object_or_404(DetectedRecurring, id=detection_id)
+        detection.is_ignored = True
+        detection.save(update_fields=["is_ignored"])
+        api_logger.info(f"Detection ignored: {detection.description}")
+        return {"success": True}
+    except Http404:
+        raise HttpError(404, "Detection not found")
+    except Exception as e:
+        error_logger.exception(str(e))
+        raise HttpError(500, "Failed to ignore detection")
+
+
+@detected_recurring_router.delete("/{detection_id}")
+def delete_detected(request, detection_id: int):
+    try:
+        detection = get_object_or_404(DetectedRecurring, id=detection_id)
+        detection.delete()
+        api_logger.info(f"Detection deleted: {detection_id}")
+        return {"success": True}
+    except Http404:
+        raise HttpError(404, "Detection not found")
+    except Exception as e:
+        error_logger.exception(str(e))
+        raise HttpError(500, "Failed to delete detection")

--- a/backend/planning/api/views/detected_recurring.py
+++ b/backend/planning/api/views/detected_recurring.py
@@ -24,6 +24,8 @@ def _serialize(d: DetectedRecurring) -> dict:
         "next_estimated_date": d.next_estimated_date,
         "transaction_ids": d.transaction_ids,
         "created_at": d.created_at,
+        "suggested_tag_id": d.suggested_tag_id,
+        "suggested_account_id": d.suggested_account_id,
     }
 
 

--- a/backend/planning/migrations/0009_detectedrecurring.py
+++ b/backend/planning/migrations/0009_detectedrecurring.py
@@ -1,0 +1,37 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("planning", "0008_note_text_to_textfield"),
+        ("reminders", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="DetectedRecurring",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("description", models.CharField(max_length=254)),
+                ("estimated_amount", models.DecimalField(decimal_places=2, max_digits=12)),
+                (
+                    "repeat",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        to="reminders.repeat",
+                    ),
+                ),
+                ("next_estimated_date", models.DateField()),
+                ("transaction_ids", models.JSONField(default=list)),
+                ("is_ignored", models.BooleanField(default=False)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+            ],
+            options={
+                "ordering": ["-created_at"],
+            },
+        ),
+    ]

--- a/backend/planning/migrations/0010_detectedrecurring_suggested_fields.py
+++ b/backend/planning/migrations/0010_detectedrecurring_suggested_fields.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("planning", "0009_detectedrecurring"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="detectedrecurring",
+            name="suggested_tag_id",
+            field=models.IntegerField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="detectedrecurring",
+            name="suggested_account_id",
+            field=models.IntegerField(blank=True, null=True),
+        ),
+    ]

--- a/backend/planning/models.py
+++ b/backend/planning/models.py
@@ -116,6 +116,24 @@ class CalculationRule(models.Model):
     destination_account_id = models.IntegerField()
 
 
+class DetectedRecurring(models.Model):
+    description = models.CharField(max_length=254)
+    estimated_amount = models.DecimalField(max_digits=12, decimal_places=2)
+    repeat = models.ForeignKey(
+        Repeat, null=True, blank=True, on_delete=models.SET_NULL
+    )
+    next_estimated_date = models.DateField()
+    transaction_ids = models.JSONField(default=list)
+    is_ignored = models.BooleanField(default=False)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        ordering = ["-created_at"]
+
+    def __str__(self):
+        return self.description
+
+
 class Budget(models.Model):
     """
     Model representing a budget.

--- a/backend/planning/models.py
+++ b/backend/planning/models.py
@@ -126,6 +126,8 @@ class DetectedRecurring(models.Model):
     transaction_ids = models.JSONField(default=list)
     is_ignored = models.BooleanField(default=False)
     created_at = models.DateTimeField(auto_now_add=True)
+    suggested_tag_id = models.IntegerField(null=True, blank=True)
+    suggested_account_id = models.IntegerField(null=True, blank=True)
 
     class Meta:
         ordering = ["-created_at"]

--- a/backend/transactions/management/commands/scheduletasks.py
+++ b/backend/transactions/management/commands/scheduletasks.py
@@ -125,6 +125,15 @@ class Command(BaseCommand):
                 "start_today": True,
                 "delete": False,
             },
+            {
+                "task_name": "Detect Recurring Transactions",
+                "function": "transactions.tasks.detect_recurring_transactions",
+                "time": "08:00",
+                "arguments": "",
+                "type": "WEEKLY",
+                "start_today": False,
+                "delete": False,
+            },
         ]
 
         # Schedule or modify tasks

--- a/backend/transactions/management/commands/scheduletasks.py
+++ b/backend/transactions/management/commands/scheduletasks.py
@@ -131,7 +131,7 @@ class Command(BaseCommand):
                 "time": "08:00",
                 "arguments": "",
                 "type": "WEEKLY",
-                "start_today": False,
+                "start_today": True,
                 "delete": False,
             },
         ]

--- a/backend/transactions/tasks.py
+++ b/backend/transactions/tasks.py
@@ -1650,6 +1650,9 @@ def detect_recurring_transactions():
         if any(abs(a - avg_amount) / avg_amount > 0.20 for a in amounts):
             continue
 
+        if (today - dates[-1]).days > target + tolerance:
+            continue
+
         next_date = dates[-1] + timedelta(days=target)
         repeat = repeat_by_days.get(target)
 

--- a/backend/transactions/tasks.py
+++ b/backend/transactions/tasks.py
@@ -1573,8 +1573,9 @@ def detect_recurring_transactions():
     """Scan transaction history for recurring patterns and create DetectedRecurring records."""
     from planning.models import DetectedRecurring
     from reminders.models import Repeat, Reminder
-    from transactions.models import Transaction, TransactionStatus
-    from collections import defaultdict
+    from transactions.models import Transaction, TransactionStatus, TransactionDetail
+    from django.db.models import Count as _Count
+    from collections import defaultdict, Counter
     from datetime import timedelta
     from decimal import Decimal as D
 
@@ -1593,7 +1594,7 @@ def detect_recurring_transactions():
         )
         .exclude(description__isnull=True)
         .exclude(description="")
-        .values("id", "description", "transaction_date", "total_amount")
+        .values("id", "description", "transaction_date", "total_amount", "source_account_id")
         .order_by("description", "transaction_date")
     )
 
@@ -1619,7 +1620,10 @@ def detect_recurring_transactions():
     new_detections = []
     for key, group in groups.items():
         description = group[0]["description"].strip()
-        if description.lower() in {d.lower() for d in existing_descriptions} or key in {d.strip().lower() for d in ignored_descriptions}:
+        desc_lower = description.lower()
+        if any(desc_lower in d.lower() or d.lower() in desc_lower for d in existing_descriptions):
+            continue
+        if key in {d.strip().lower() for d in ignored_descriptions}:
             continue
 
         group = sorted(group, key=lambda t: t["transaction_date"])
@@ -1649,6 +1653,7 @@ def detect_recurring_transactions():
             continue
         if any(abs(a - avg_amount) / avg_amount > 0.20 for a in amounts):
             continue
+        recent_amount = amounts[-1]
 
         if (today - dates[-1]).days > target + tolerance:
             continue
@@ -1656,13 +1661,29 @@ def detect_recurring_transactions():
         next_date = dates[-1] + timedelta(days=target)
         repeat = repeat_by_days.get(target)
 
+        tx_ids = [t["id"] for t in group]
+        tag_row = (
+            TransactionDetail.objects.filter(transaction_id__in=tx_ids)
+            .exclude(tag_id__isnull=True)
+            .values("tag_id")
+            .annotate(n=_Count("id"))
+            .order_by("-n")
+            .first()
+        )
+        suggested_tag_id = tag_row["tag_id"] if tag_row else None
+
+        account_counts = Counter(t["source_account_id"] for t in group if t["source_account_id"] is not None)
+        suggested_account_id = account_counts.most_common(1)[0][0] if account_counts else None
+
         new_detections.append(
             DetectedRecurring(
                 description=description,
-                estimated_amount=D(str(round(avg_amount, 2))),
+                estimated_amount=D(str(round(recent_amount, 2))),
                 repeat=repeat,
                 next_estimated_date=next_date,
                 transaction_ids=[t["id"] for t in group],
+                suggested_tag_id=suggested_tag_id,
+                suggested_account_id=suggested_account_id,
             )
         )
 

--- a/backend/transactions/tasks.py
+++ b/backend/transactions/tasks.py
@@ -109,7 +109,7 @@ def cleanup_old_backups():
             error_logger.exception(f"Failed to delete backup {f}: {e}")
 
 
-def create_message(message_text, user=None):
+def create_message(message_text, user=None, link=None):
     """
     The function `create_message` creates a Message object for
     displaying a message alert in the app inbox.
@@ -118,6 +118,8 @@ def create_message(message_text, user=None):
         message_text (str): The text of the message
         user: Optional User instance — if set, message is private to that user
               and the WebSocket notification targets only their channel group.
+        link (str): Optional frontend route (e.g. '/planning/detections') —
+                    clicking the message navigates there.
     """
 
     Message.objects.create(
@@ -125,6 +127,7 @@ def create_message(message_text, user=None):
         message=message_text,
         unread=True,
         user=user,
+        link=link,
     )
     group = f"user_{user.pk}" if user else "global"
     broadcast_invalidate(["messages"], group=group)
@@ -1693,7 +1696,8 @@ def detect_recurring_transactions():
         DetectedRecurring.objects.bulk_create(new_detections)
         create_message(
             f"{len(new_detections)} recurring transaction pattern(s) detected. "
-            "View suggestions under Planning → Detections."
+            "View suggestions under Planning → Detections.",
+            link="/planning/detections",
         )
         task_logger.info(f"detect_recurring_transactions: {len(new_detections)} patterns found.")
     else:

--- a/backend/transactions/tasks.py
+++ b/backend/transactions/tasks.py
@@ -1674,6 +1674,7 @@ def detect_recurring_transactions():
         task_logger.info(f"detect_recurring_transactions: {len(new_detections)} patterns found.")
     else:
         task_logger.info("detect_recurring_transactions: no new patterns found.")
+    broadcast_invalidate(["detected_recurring"])
 
 
 # TODO: Task to look for negative dips

--- a/backend/transactions/tasks.py
+++ b/backend/transactions/tasks.py
@@ -1579,7 +1579,7 @@ def detect_recurring_transactions():
     from decimal import Decimal as D
 
     today = date.today()
-    window_start = today - timedelta(days=120)
+    window_start = today - timedelta(days=400)
 
     status_ids = list(
         TransactionStatus.objects.filter(slug__in=["cleared", "reconciled", "archived"])
@@ -1608,7 +1608,8 @@ def detect_recurring_transactions():
         if total_days > 0:
             repeat_by_days[total_days] = r
 
-    TARGET_PERIODS = [7, 14, 30]
+    # (period_days, tolerance_days, min_occurrences)
+    TARGET_PERIODS = [(7, 5, 3), (14, 5, 3), (30, 5, 3), (365, 14, 2)]
 
     groups = defaultdict(list)
     for tx in txs:
@@ -1618,20 +1619,27 @@ def detect_recurring_transactions():
     for description, group in groups.items():
         if description in existing_descriptions or description in ignored_descriptions:
             continue
-        if len(group) < 3:
-            continue
 
         group = sorted(group, key=lambda t: t["transaction_date"])
         dates = [t["transaction_date"] for t in group]
         amounts = [abs(float(t["total_amount"])) for t in group]
 
+        if len(group) < 2:
+            continue
+
         intervals = [(dates[i + 1] - dates[i]).days for i in range(len(dates) - 1)]
         avg_interval = sum(intervals) / len(intervals)
 
-        target = next((p for p in TARGET_PERIODS if abs(avg_interval - p) <= 5), None)
-        if target is None:
+        match = next(
+            ((p, tol, min_occ) for p, tol, min_occ in TARGET_PERIODS if abs(avg_interval - p) <= tol),
+            None,
+        )
+        if match is None:
             continue
-        if any(abs(iv - avg_interval) > 5 for iv in intervals):
+        target, tolerance, min_occurrences = match
+        if len(group) < min_occurrences:
+            continue
+        if any(abs(iv - avg_interval) > tolerance for iv in intervals):
             continue
 
         avg_amount = sum(amounts) / len(amounts)

--- a/backend/transactions/tasks.py
+++ b/backend/transactions/tasks.py
@@ -1613,11 +1613,13 @@ def detect_recurring_transactions():
 
     groups = defaultdict(list)
     for tx in txs:
-        groups[tx["description"]].append(tx)
+        key = tx["description"].strip().lower()
+        groups[key].append(tx)
 
     new_detections = []
-    for description, group in groups.items():
-        if description in existing_descriptions or description in ignored_descriptions:
+    for key, group in groups.items():
+        description = group[0]["description"].strip()
+        if description.lower() in {d.lower() for d in existing_descriptions} or key in {d.strip().lower() for d in ignored_descriptions}:
             continue
 
         group = sorted(group, key=lambda t: t["transaction_date"])

--- a/backend/transactions/tasks.py
+++ b/backend/transactions/tasks.py
@@ -1569,6 +1569,103 @@ def run_scheduled_reports():
         broadcast_invalidate(["report_results"])
 
 
+def detect_recurring_transactions():
+    """Scan transaction history for recurring patterns and create DetectedRecurring records."""
+    from planning.models import DetectedRecurring
+    from reminders.models import Repeat, Reminder
+    from transactions.models import Transaction, TransactionStatus
+    from collections import defaultdict
+    from datetime import timedelta
+    from decimal import Decimal as D
+
+    today = date.today()
+    window_start = today - timedelta(days=120)
+
+    status_ids = list(
+        TransactionStatus.objects.filter(slug__in=["cleared", "reconciled", "archived"])
+        .values_list("id", flat=True)
+    )
+
+    txs = list(
+        Transaction.objects.filter(
+            transaction_date__gte=window_start,
+            status_id__in=status_ids,
+        )
+        .exclude(description__isnull=True)
+        .exclude(description="")
+        .values("id", "description", "transaction_date", "total_amount")
+        .order_by("description", "transaction_date")
+    )
+
+    existing_descriptions = set(Reminder.objects.values_list("description", flat=True))
+    ignored_descriptions = set(
+        DetectedRecurring.objects.filter(is_ignored=True).values_list("description", flat=True)
+    )
+
+    repeat_by_days = {}
+    for r in Repeat.objects.all():
+        total_days = r.days + r.weeks * 7 + r.months * 30 + r.years * 365
+        if total_days > 0:
+            repeat_by_days[total_days] = r
+
+    TARGET_PERIODS = [7, 14, 30]
+
+    groups = defaultdict(list)
+    for tx in txs:
+        groups[tx["description"]].append(tx)
+
+    new_detections = []
+    for description, group in groups.items():
+        if description in existing_descriptions or description in ignored_descriptions:
+            continue
+        if len(group) < 3:
+            continue
+
+        group = sorted(group, key=lambda t: t["transaction_date"])
+        dates = [t["transaction_date"] for t in group]
+        amounts = [abs(float(t["total_amount"])) for t in group]
+
+        intervals = [(dates[i + 1] - dates[i]).days for i in range(len(dates) - 1)]
+        avg_interval = sum(intervals) / len(intervals)
+
+        target = next((p for p in TARGET_PERIODS if abs(avg_interval - p) <= 5), None)
+        if target is None:
+            continue
+        if any(abs(iv - avg_interval) > 5 for iv in intervals):
+            continue
+
+        avg_amount = sum(amounts) / len(amounts)
+        if avg_amount == 0:
+            continue
+        if any(abs(a - avg_amount) / avg_amount > 0.20 for a in amounts):
+            continue
+
+        next_date = dates[-1] + timedelta(days=target)
+        repeat = repeat_by_days.get(target)
+
+        new_detections.append(
+            DetectedRecurring(
+                description=description,
+                estimated_amount=D(str(round(avg_amount, 2))),
+                repeat=repeat,
+                next_estimated_date=next_date,
+                transaction_ids=[t["id"] for t in group],
+            )
+        )
+
+    DetectedRecurring.objects.filter(is_ignored=False).delete()
+
+    if new_detections:
+        DetectedRecurring.objects.bulk_create(new_detections)
+        create_message(
+            f"{len(new_detections)} recurring transaction pattern(s) detected. "
+            "View suggestions under Planning → Detections."
+        )
+        task_logger.info(f"detect_recurring_transactions: {len(new_detections)} patterns found.")
+    else:
+        task_logger.info("detect_recurring_transactions: no new patterns found.")
+
+
 # TODO: Task to look for negative dips
 # TODO: Task to look for under threshold
 # TODO: Task to update Credit Card specific information

--- a/frontend/src/components/PlanningMenu.vue
+++ b/frontend/src/components/PlanningMenu.vue
@@ -99,6 +99,12 @@
       optional: true,
     },
     {
+      title: "Detections",
+      link: "/planning/detections",
+      icon: "mdi-radar",
+      optional: false,
+    },
+    {
       title: "Reports",
       link: "/reports",
       icon: "mdi-chart-pie",

--- a/frontend/src/components/ReminderForm.vue
+++ b/frontend/src/components/ReminderForm.vue
@@ -209,7 +209,7 @@
         </v-card-text>
         <v-card-actions>
           <v-spacer></v-spacer>
-          <v-btn color="primary" variant="text" @click="closeDialog">Close</v-btn>
+          <v-btn color="primary" variant="text" @click="closeDialog()">Close</v-btn>
           <v-btn color="primary" variant="text" type="submit" :disabled="!isOnline">Save</v-btn>
         </v-card-actions>
       </v-card>
@@ -350,11 +350,11 @@
     } else {
       addReminder(payload);
     }
-    closeDialog();
+    closeDialog(true);
   });
 
-  const closeDialog = () => {
-    emit("updateDialog", false);
+  const closeDialog = (saved = false) => {
+    emit("updateDialog", saved);
   };
 
   const initializeFormData = () => {

--- a/frontend/src/composables/detectionsComposable.js
+++ b/frontend/src/composables/detectionsComposable.js
@@ -42,7 +42,6 @@ export function useDetections() {
   const { data: detections, isLoading, isFetching } = useQuery({
     queryKey: ["detected_recurring"],
     queryFn: listDetectionsFunction,
-    initialData: [],
   });
 
   const ignoreMutation = useMutation({

--- a/frontend/src/composables/detectionsComposable.js
+++ b/frontend/src/composables/detectionsComposable.js
@@ -1,0 +1,77 @@
+import { useQuery, useQueryClient, useMutation } from "@tanstack/vue-query";
+import apiClient from "./apiClient";
+import { useMainStore } from "@/stores/main";
+
+async function handleApiError(error, message) {
+  if (error.response?.status === 401) throw error;
+  const mainstore = useMainStore();
+  mainstore.showSnackbar(message + " : " + (error.response?.data?.detail ?? error.message), "error");
+  throw error;
+}
+
+async function listDetectionsFunction() {
+  try {
+    const response = await apiClient.get("/planning/detected-recurring");
+    return response.data;
+  } catch (error) {
+    return await handleApiError(error, "Failed to load detections");
+  }
+}
+
+async function ignoreDetectionFunction(id) {
+  try {
+    const response = await apiClient.post(`/planning/detected-recurring/${id}/ignore`);
+    return response.data;
+  } catch (error) {
+    return await handleApiError(error, "Failed to ignore detection");
+  }
+}
+
+async function deleteDetectionFunction(id) {
+  try {
+    const response = await apiClient.delete(`/planning/detected-recurring/${id}`);
+    return response.data;
+  } catch (error) {
+    return await handleApiError(error, "Failed to delete detection");
+  }
+}
+
+export function useDetections() {
+  const queryClient = useQueryClient();
+
+  const { data: detections, isLoading, isFetching } = useQuery({
+    queryKey: ["detected_recurring"],
+    queryFn: listDetectionsFunction,
+    initialData: [],
+  });
+
+  const ignoreMutation = useMutation({
+    mutationFn: ignoreDetectionFunction,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["detected_recurring"] });
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: deleteDetectionFunction,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["detected_recurring"] });
+    },
+  });
+
+  function ignoreDetection(id) {
+    ignoreMutation.mutate(id);
+  }
+
+  function deleteDetection(id) {
+    deleteMutation.mutate(id);
+  }
+
+  return {
+    detections,
+    isLoading,
+    isFetching,
+    ignoreDetection,
+    deleteDetection,
+  };
+}

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -16,6 +16,7 @@ import ContributionsView from "@/views/ContributionsView.vue";
 import ExpensesView from "@/views/ExpensesView.vue";
 import NotesView from "@/views/NotesView.vue";
 import RetirementView from "@/views/RetirementView.vue";
+import DetectionsView from "@/views/DetectionsView.vue";
 import BudgetsView from "@/views/BudgetsView.vue";
 import BackupView from "@/views/BackupView.vue";
 import LogsView from "@/views/LogsView.vue";
@@ -113,6 +114,11 @@ const routes = [
     path: "/planning/retirement",
     name: "retirement",
     component: RetirementView,
+  },
+  {
+    path: "/planning/detections",
+    name: "detections",
+    component: DetectionsView,
   },
   {
     path: "/backup",

--- a/frontend/src/views/AppNavigationVue.vue
+++ b/frontend/src/views/AppNavigationVue.vue
@@ -128,17 +128,15 @@
                 "
                 v-for="message in messages.messages"
                 :key="message.id"
+                :to="message.link || undefined"
+                :style="message.link ? 'cursor: pointer' : ''"
               >
-                <v-list-item-title>
-                  <span :class="message.unread ? 'font-weight-bold' : ''">
-                    {{ message.message }}
-                  </span>
-                </v-list-item-title>
-                <v-list-item-subtitle>
-                  <span :class="message.unread ? 'font-weight-bold' : ''">
-                    {{ getPrettyDate(message.message_date) }}
-                  </span>
-                </v-list-item-subtitle>
+                <div :class="['text-body-2 text-wrap', message.unread ? 'font-weight-bold' : '']">
+                  {{ message.message }}
+                </div>
+                <div :class="['text-caption text-medium-emphasis', message.unread ? 'font-weight-bold' : '']">
+                  {{ getPrettyDate(message.message_date) }}
+                </div>
               </v-list-item>
               <v-list-item v-if="messages.total_count == 0">
                 No messages : You're all caught up!

--- a/frontend/src/views/DetectionsView.vue
+++ b/frontend/src/views/DetectionsView.vue
@@ -1,0 +1,169 @@
+<template>
+  <v-container fluid>
+    <v-row>
+      <v-col>
+        <h4 class="text-h5 font-weight-bold mb-2">Recurring Detections</h4>
+        <p class="text-body-2 text-medium-emphasis mb-4">
+          Patterns detected from your transaction history. Create a reminder or ignore to stop seeing a suggestion.
+        </p>
+      </v-col>
+    </v-row>
+
+    <v-progress-linear indeterminate v-if="isFetching" color="primary" class="mb-4"></v-progress-linear>
+
+    <v-row v-if="!isLoading && detections.length === 0">
+      <v-col>
+        <v-sheet border rounded class="pa-6 text-center text-medium-emphasis">
+          <v-icon icon="mdi-check-circle-outline" size="48" class="mb-2"></v-icon>
+          <div class="text-body-1">No recurring patterns detected yet.</div>
+          <div class="text-body-2 mt-1">Detection runs weekly — check back after more transactions are recorded.</div>
+        </v-sheet>
+      </v-col>
+    </v-row>
+
+    <v-row>
+      <v-col
+        cols="12"
+        md="6"
+        lg="4"
+        v-for="detection in detections"
+        :key="detection.id"
+      >
+        <v-card variant="outlined" :elevation="2" class="bg-surface h-100">
+          <v-card-title class="text-subtitle-1 font-weight-bold text-truncate pb-0">
+            {{ detection.description }}
+          </v-card-title>
+          <v-card-text class="pt-2">
+            <v-row dense>
+              <v-col cols="6">
+                <div class="text-caption text-medium-emphasis">Avg Amount</div>
+                <div class="text-body-1 font-weight-bold text-success">
+                  {{ formatCurrency(detection.estimated_amount) }}
+                </div>
+              </v-col>
+              <v-col cols="6">
+                <div class="text-caption text-medium-emphasis">Frequency</div>
+                <div class="text-body-2">{{ detection.repeat_name ?? "Unknown" }}</div>
+              </v-col>
+              <v-col cols="6" class="mt-1">
+                <div class="text-caption text-medium-emphasis">Next Expected</div>
+                <div class="text-body-2">{{ detection.next_estimated_date }}</div>
+              </v-col>
+              <v-col cols="6" class="mt-1">
+                <div class="text-caption text-medium-emphasis">Occurrences</div>
+                <div class="text-body-2">{{ detection.transaction_ids.length }} in last 120 days</div>
+              </v-col>
+            </v-row>
+          </v-card-text>
+          <v-card-actions>
+            <v-btn
+              color="primary"
+              variant="tonal"
+              size="small"
+              prepend-icon="mdi-bell-plus"
+              @click="openReminderForm(detection)"
+              :disabled="!isOnline"
+            >Create Reminder</v-btn>
+            <v-spacer></v-spacer>
+            <v-btn
+              color="error"
+              variant="text"
+              size="small"
+              prepend-icon="mdi-eye-off"
+              @click="confirmIgnore(detection)"
+              :disabled="!isOnline"
+            >Ignore</v-btn>
+          </v-card-actions>
+        </v-card>
+      </v-col>
+    </v-row>
+
+    <!-- Reminder form dialog -->
+    <ReminderForm
+      v-model="reminderDialog"
+      :isEdit="false"
+      @update-dialog="onReminderSaved"
+      :passedFormData="reminderFormData"
+    />
+
+    <!-- Ignore confirm dialog -->
+    <v-dialog v-model="ignoreDialog" max-width="380">
+      <v-card>
+        <v-card-title class="text-h6">Ignore Detection</v-card-title>
+        <v-card-text>
+          Stop suggesting <strong>{{ pendingIgnore?.description }}</strong> as a recurring reminder?
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer></v-spacer>
+          <v-btn @click="ignoreDialog = false">Cancel</v-btn>
+          <v-btn color="error" @click="doIgnore">Ignore</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+  </v-container>
+</template>
+
+<script setup>
+  import { ref } from "vue";
+  import { useDetections } from "@/composables/detectionsComposable";
+  import { useOnlineStatus } from "@/composables/useOnlineStatus";
+  import ReminderForm from "@/components/ReminderForm.vue";
+
+  const { isOnline } = useOnlineStatus();
+  const { detections, isLoading, isFetching, ignoreDetection, deleteDetection } = useDetections();
+
+  const reminderDialog = ref(false);
+  const reminderFormData = ref(null);
+  const activeDetectionId = ref(null);
+
+  const ignoreDialog = ref(false);
+  const pendingIgnore = ref(null);
+
+  const today = new Date();
+  const tomorrow = new Date(today);
+  tomorrow.setDate(today.getDate() + 1);
+  const tomorrowStr = `${tomorrow.getFullYear()}-${String(tomorrow.getMonth() + 1).padStart(2, "0")}-${String(tomorrow.getDate()).padStart(2, "0")}`;
+
+  function openReminderForm(detection) {
+    activeDetectionId.value = detection.id;
+    reminderFormData.value = {
+      id: 0,
+      tag: { id: null },
+      amount: detection.estimated_amount,
+      reminder_source_account: { id: null },
+      reminder_destination_account: { id: null },
+      description: detection.description,
+      transaction_type: { id: 1 },
+      start_date: detection.next_estimated_date ?? tomorrowStr,
+      next_date: detection.next_estimated_date ?? tomorrowStr,
+      end_date: null,
+      repeat: { id: detection.repeat_id ?? null },
+      auto_add: true,
+    };
+    reminderDialog.value = true;
+  }
+
+  function onReminderSaved() {
+    reminderDialog.value = false;
+    if (activeDetectionId.value) {
+      deleteDetection(activeDetectionId.value);
+      activeDetectionId.value = null;
+    }
+  }
+
+  function confirmIgnore(detection) {
+    pendingIgnore.value = detection;
+    ignoreDialog.value = true;
+  }
+
+  function doIgnore() {
+    ignoreDetection(pendingIgnore.value.id);
+    ignoreDialog.value = false;
+    pendingIgnore.value = null;
+  }
+
+  function formatCurrency(value) {
+    if (value === null || value === undefined) return "—";
+    return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(parseFloat(value));
+  }
+</script>

--- a/frontend/src/views/DetectionsView.vue
+++ b/frontend/src/views/DetectionsView.vue
@@ -128,9 +128,9 @@
     activeDetectionId.value = detection.id;
     reminderFormData.value = {
       id: 0,
-      tag: { id: null },
+      tag: { id: detection.suggested_tag_id ?? null },
       amount: detection.estimated_amount,
-      reminder_source_account: { id: null },
+      reminder_source_account: { id: detection.suggested_account_id ?? null },
       reminder_destination_account: { id: null },
       description: detection.description,
       transaction_type: { id: 1 },
@@ -143,9 +143,9 @@
     reminderDialog.value = true;
   }
 
-  function onReminderSaved() {
+  function onReminderSaved(saved) {
     reminderDialog.value = false;
-    if (activeDetectionId.value) {
+    if (saved && activeDetectionId.value) {
       deleteDetection(activeDetectionId.value);
       activeDetectionId.value = null;
     }

--- a/frontend/src/views/DetectionsView.vue
+++ b/frontend/src/views/DetectionsView.vue
@@ -11,7 +11,7 @@
 
     <v-progress-linear indeterminate v-if="isFetching" color="primary" class="mb-4"></v-progress-linear>
 
-    <v-row v-if="!isLoading && detections.length === 0">
+    <v-row v-if="!isLoading && (!detections || detections.length === 0)">
       <v-col>
         <v-sheet border rounded class="pa-6 text-center text-medium-emphasis">
           <v-icon icon="mdi-check-circle-outline" size="48" class="mb-2"></v-icon>
@@ -26,7 +26,7 @@
         cols="12"
         md="6"
         lg="4"
-        v-for="detection in detections"
+        v-for="detection in (detections ?? [])"
         :key="detection.id"
       >
         <v-card variant="outlined" :elevation="2" class="bg-surface h-100">


### PR DESCRIPTION
## Summary
- New `DetectedRecurring` model in `planning` app stores detected patterns (description, estimated amount, inferred repeat type, next expected date, source transaction IDs, ignored flag, suggested tag/account)
- Weekly django-q2 task (`detect_recurring_transactions`) scans 400 days of cleared/reconciled/archived transactions; groups by normalized description; checks for 7/14/30/365-day intervals with tolerance; dormancy check skips patterns not seen within one full period
- Existing reminder filter uses substring matching so partial descriptions (e.g. `'Cloudflare'` vs `'Cloudflare Domain'`) are correctly suppressed
- Suggested amount uses most recent transaction, not average, to reflect current pricing
- Suggested tag (from most common `TransactionDetail` tag) and source account pre-fill the reminder form
- Global inbox message fires when new patterns are found; task also runs on first startup to populate data immediately
- REST API: `GET /planning/detected-recurring`, `POST /{id}/ignore`, `DELETE /{id}`
- **Detections** page added under Planning menu (`mdi-radar` icon) — cards per pattern showing amount, frequency, next date, occurrence count
- \"Create Reminder\" pre-fills `ReminderForm` with description, most recent amount, repeat type, next date, suggested tag, and source account; detection auto-deletes only on confirmed save (not cancel)
- \"Ignore\" shows confirmation dialog and marks pattern as ignored so it never resurfaces

## Test plan
- [ ] Rebuild and confirm Planning → Detections shows patterns after startup
- [ ] Verify descriptions with existing reminders (including partial matches) are not suggested
- [ ] Click Create Reminder — verify form pre-filled with correct tag and source account; save; verify detection removed
- [ ] Click Close on Create Reminder dialog — verify detection is NOT removed
- [ ] Click Ignore — verify confirmation dialog; confirm; verify detection removed and doesn't reappear on next scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)