### PR TITLE
feat: web push notifications for inbox messages

### DIFF
--- a/backend/administration/api/schemas/push_subscription.py
+++ b/backend/administration/api/schemas/push_subscription.py
@@ -1,0 +1,11 @@
+from ninja import Schema
+
+
+class PushSubscribeIn(Schema):
+    endpoint: str
+    p256dh: str
+    auth: str
+
+
+class VapidPublicKeyOut(Schema):
+    public_key: str

--- a/backend/administration/api/views/push_subscription.py
+++ b/backend/administration/api/views/push_subscription.py
@@ -1,0 +1,53 @@
+import os
+import logging
+from ninja import Router
+from ninja.errors import HttpError
+
+from administration.models import PushSubscription
+from administration.api.schemas.push_subscription import PushSubscribeIn, VapidPublicKeyOut
+
+api_logger = logging.getLogger("api")
+error_logger = logging.getLogger("error")
+
+push_router = Router(tags=["Push Notifications"])
+
+
+@push_router.get("/vapid-public-key", response=VapidPublicKeyOut, auth=None)
+def get_vapid_public_key(request):
+    key = os.environ.get("VAPID_PUBLIC_KEY", "")
+    return {"public_key": key}
+
+
+@push_router.post("/subscribe", response={200: dict})
+def subscribe(request, payload: PushSubscribeIn):
+    try:
+        PushSubscription.objects.update_or_create(
+            endpoint=payload.endpoint,
+            defaults={
+                "user": request.user,
+                "p256dh": payload.p256dh,
+                "auth": payload.auth,
+            },
+        )
+        api_logger.info(f"Push subscription saved for user {request.user}")
+        return {"success": True}
+    except Exception as e:
+        error_logger.exception(str(e))
+        raise HttpError(500, "Failed to save push subscription")
+
+
+@push_router.delete("/unsubscribe", response={200: dict})
+def unsubscribe(request):
+    try:
+        deleted, _ = PushSubscription.objects.filter(user=request.user).delete()
+        api_logger.info(f"Push subscriptions removed for user {request.user} ({deleted})")
+        return {"success": True}
+    except Exception as e:
+        error_logger.exception(str(e))
+        raise HttpError(500, "Failed to remove push subscription")
+
+
+@push_router.get("/status", response={200: dict})
+def subscription_status(request):
+    has_sub = PushSubscription.objects.filter(user=request.user).exists()
+    return {"subscribed": has_sub}

--- a/backend/administration/migrations/0026_pushsubscription.py
+++ b/backend/administration/migrations/0026_pushsubscription.py
@@ -1,0 +1,32 @@
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("administration", "0025_message_link"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="PushSubscription",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("endpoint", models.TextField(unique=True)),
+                ("p256dh", models.TextField()),
+                ("auth", models.TextField()),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                (
+                    "user",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="push_subscriptions",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+        ),
+    ]

--- a/backend/administration/models.py
+++ b/backend/administration/models.py
@@ -196,6 +196,21 @@ class Message(models.Model):
         return self.message
 
 
+class PushSubscription(models.Model):
+    """Stores a browser Web Push subscription for a user."""
+
+    user = models.ForeignKey(
+        "auth.User", on_delete=models.CASCADE, related_name="push_subscriptions"
+    )
+    endpoint = models.TextField(unique=True)
+    p256dh = models.TextField()
+    auth = models.TextField()
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    def __str__(self):
+        return f"{self.user} — {self.endpoint[:60]}"
+
+
 class Version(SingletonModel):
     """
     Model representing app version.

--- a/backend/administration/push.py
+++ b/backend/administration/push.py
@@ -1,0 +1,50 @@
+import json
+import logging
+import os
+
+error_logger = logging.getLogger("error")
+task_logger = logging.getLogger("task")
+
+
+def send_push_notifications(message_text, link=None, user=None):
+    """
+    Send a Web Push notification for a new inbox message.
+
+    If user is given, only that user's subscriptions are targeted.
+    If user is None (global message), all subscriptions are notified.
+    Expired subscriptions (HTTP 410) are silently removed.
+    A missing VAPID_PRIVATE_KEY skips push silently (opt-in feature).
+    """
+    private_key = os.environ.get("VAPID_PRIVATE_KEY")
+    if not private_key:
+        return
+
+    from administration.models import PushSubscription
+    from pywebpush import webpush, WebPushException
+
+    email = os.environ.get("VAPID_EMAIL", "admin@example.com")
+    claims = {"sub": f"mailto:{email}"}
+    payload = json.dumps({"title": "LenoreFin", "body": message_text, "link": link or "/"})
+
+    subs = PushSubscription.objects.all()
+    if user is not None:
+        subs = subs.filter(user=user)
+
+    for sub in subs:
+        try:
+            webpush(
+                subscription_info={
+                    "endpoint": sub.endpoint,
+                    "keys": {"p256dh": sub.p256dh, "auth": sub.auth},
+                },
+                data=payload,
+                vapid_private_key=private_key,
+                vapid_claims=claims,
+            )
+        except WebPushException as e:
+            if e.response is not None and e.response.status_code == 410:
+                sub.delete()
+            else:
+                error_logger.exception(f"Push notification failed for subscription {sub.id}: {e}")
+        except Exception as e:
+            error_logger.exception(f"Unexpected push error for subscription {sub.id}: {e}")

--- a/backend/backend/api.py
+++ b/backend/backend/api.py
@@ -43,6 +43,7 @@ from planning.api.routers.planning_graph import planning_graph_router
 from planning.api.routers.budget import budget_router
 from planning.api.routers.retirement import retirement_router
 from planning.api.routers.detected_recurring import router as detected_recurring_router
+from administration.api.views.push_subscription import push_router
 from administration.api.routers.health import health_router
 from administration.api.routers.backup import backup_router
 from administration.api.routers.logs import router as logs_router
@@ -98,6 +99,7 @@ api.add_router("/planning/graph", planning_graph_router)
 api.add_router("/planning/budget", budget_router)
 api.add_router("/planning/retirement", retirement_router)
 api.add_router("/planning/detected-recurring", detected_recurring_router)
+api.add_router("/administration/push", push_router)
 api.add_router("/administration/health", health_router)
 api.add_router("/administration/backups", backup_router)
 api.add_router("/administration/logs", logs_router)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -24,3 +24,4 @@ pytest==9.0.3
 pytest-django==4.12.0
 django-model-utils==5.0.0
 pytest-mock==3.15.1
+pywebpush==2.3.0

--- a/backend/transactions/tasks.py
+++ b/backend/transactions/tasks.py
@@ -131,6 +131,8 @@ def create_message(message_text, user=None, link=None):
     )
     group = f"user_{user.pk}" if user else "global"
     broadcast_invalidate(["messages"], group=group)
+    from administration.push import send_push_notifications
+    send_push_notifications(message_text, link=link, user=user)
 
 
 def convert_reminder():

--- a/example.env
+++ b/example.env
@@ -14,3 +14,8 @@ DJANGO_SUPERUSER_EMAIL=someone@somewhere.com
 DJANGO_SUPERUSER_USERNAME=superuser
 VITE_API_KEY=secretkey
 TIMEZONE=America/New_York
+# Optional — omit to disable browser push notifications
+# Generate with: python -c "from py_vapid import Vapid; from cryptography.hazmat.primitives import serialization; import base64; v=Vapid(); v.generate_keys(); print('VAPID_PRIVATE_KEY='+base64.urlsafe_b64encode(v.private_key.private_bytes(serialization.Encoding.DER,serialization.PrivateFormat.PKCS8,serialization.NoEncryption())).rstrip(b'=').decode()); print('VAPID_PUBLIC_KEY='+base64.urlsafe_b64encode(v.private_key.public_key().public_bytes(serialization.Encoding.X962,serialization.PublicFormat.UncompressedPoint)).rstrip(b'=').decode())"
+VAPID_PRIVATE_KEY=
+VAPID_PUBLIC_KEY=
+VAPID_EMAIL=someone@somewhere.com

--- a/frontend/src/composables/usePushNotifications.js
+++ b/frontend/src/composables/usePushNotifications.js
@@ -1,7 +1,8 @@
 import { ref } from "vue";
 import apiClient from "./apiClient";
 
-const isSupported = "serviceWorker" in navigator && "PushManager" in window && "Notification" in window;
+const browserSupported =
+  "serviceWorker" in navigator && "PushManager" in window && "Notification" in window;
 
 function urlBase64ToUint8Array(base64String) {
   const padding = "=".repeat((4 - (base64String.length % 4)) % 4);
@@ -11,21 +12,26 @@ function urlBase64ToUint8Array(base64String) {
 }
 
 export function usePushNotifications() {
+  const isSupported = ref(false);
   const isSubscribed = ref(false);
   const permissionDenied = ref(false);
 
   async function checkStatus() {
-    if (!isSupported) return;
+    if (!browserSupported) return;
     try {
-      const { data } = await apiClient.get("/administration/push/status");
-      isSubscribed.value = data.subscribed ?? false;
+      const [keyRes, statusRes] = await Promise.all([
+        apiClient.get("/administration/push/vapid-public-key"),
+        apiClient.get("/administration/push/status"),
+      ]);
+      isSupported.value = !!keyRes.data.public_key;
+      isSubscribed.value = statusRes.data.subscribed ?? false;
     } catch {
-      // non-fatal
+      // non-fatal — feature stays hidden
     }
   }
 
   async function subscribe() {
-    if (!isSupported) return;
+    if (!isSupported.value) return;
 
     const permission = await Notification.requestPermission();
     if (permission !== "granted") {
@@ -59,7 +65,7 @@ export function usePushNotifications() {
   }
 
   async function unsubscribe() {
-    if (!isSupported) return;
+    if (!isSupported.value) return;
     try {
       const reg = await navigator.serviceWorker.ready;
       const pushSub = await reg.pushManager.getSubscription();

--- a/frontend/src/composables/usePushNotifications.js
+++ b/frontend/src/composables/usePushNotifications.js
@@ -1,0 +1,75 @@
+import { ref } from "vue";
+import apiClient from "./apiClient";
+
+const isSupported = "serviceWorker" in navigator && "PushManager" in window && "Notification" in window;
+
+function urlBase64ToUint8Array(base64String) {
+  const padding = "=".repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, "+").replace(/_/g, "/");
+  const rawData = atob(base64);
+  return Uint8Array.from([...rawData].map((c) => c.charCodeAt(0)));
+}
+
+export function usePushNotifications() {
+  const isSubscribed = ref(false);
+  const permissionDenied = ref(false);
+
+  async function checkStatus() {
+    if (!isSupported) return;
+    try {
+      const { data } = await apiClient.get("/administration/push/status");
+      isSubscribed.value = data.subscribed ?? false;
+    } catch {
+      // non-fatal
+    }
+  }
+
+  async function subscribe() {
+    if (!isSupported) return;
+
+    const permission = await Notification.requestPermission();
+    if (permission !== "granted") {
+      permissionDenied.value = permission === "denied";
+      return;
+    }
+
+    try {
+      const { data } = await apiClient.get("/administration/push/vapid-public-key");
+      const applicationServerKey = urlBase64ToUint8Array(data.public_key);
+
+      const reg = await navigator.serviceWorker.ready;
+      const pushSub = await reg.pushManager.subscribe({
+        userVisibleOnly: true,
+        applicationServerKey,
+      });
+
+      const key = pushSub.getKey("p256dh");
+      const auth = pushSub.getKey("auth");
+
+      await apiClient.post("/administration/push/subscribe", {
+        endpoint: pushSub.endpoint,
+        p256dh: btoa(String.fromCharCode(...new Uint8Array(key))),
+        auth: btoa(String.fromCharCode(...new Uint8Array(auth))),
+      });
+
+      isSubscribed.value = true;
+    } catch (e) {
+      console.error("Push subscription failed:", e);
+    }
+  }
+
+  async function unsubscribe() {
+    if (!isSupported) return;
+    try {
+      const reg = await navigator.serviceWorker.ready;
+      const pushSub = await reg.pushManager.getSubscription();
+      if (pushSub) await pushSub.unsubscribe();
+      await apiClient.delete("/administration/push/unsubscribe");
+      isSubscribed.value = false;
+    } catch (e) {
+      console.error("Push unsubscribe failed:", e);
+    }
+  }
+
+  return { isSupported, isSubscribed, permissionDenied, checkStatus, subscribe, unsubscribe };
+}

--- a/frontend/src/sw.js
+++ b/frontend/src/sw.js
@@ -34,17 +34,23 @@ self.addEventListener("message", (event) => {
   }
 });
 
-// Web Push — show a native notification
+// Web Push — show a native notification only when the app isn't already focused
 self.addEventListener("push", (event) => {
   if (!event.data) return;
   const data = event.data.json();
   event.waitUntil(
-    self.registration.showNotification(data.title ?? "LenoreFin", {
-      body: data.body ?? "",
-      icon: "/android-chrome-192x192.png",
-      badge: "/android-chrome-192x192.png",
-      data: { link: data.link ?? "/" },
-    })
+    self.clients
+      .matchAll({ type: "window", includeUncontrolled: true })
+      .then((clientList) => {
+        const appFocused = clientList.some((c) => c.focused);
+        if (appFocused) return;
+        return self.registration.showNotification(data.title ?? "LenoreFin", {
+          body: data.body ?? "",
+          icon: "/android-chrome-192x192.png",
+          badge: "/android-chrome-192x192.png",
+          data: { link: data.link ?? "/" },
+        });
+      })
   );
 });
 

--- a/frontend/src/sw.js
+++ b/frontend/src/sw.js
@@ -1,0 +1,65 @@
+import { precacheAndRoute, cleanupOutdatedCaches, createHandlerBoundToURL } from "workbox-precaching";
+import { registerRoute, NavigationRoute } from "workbox-routing";
+import { NetworkFirst } from "workbox-strategies";
+import { ExpirationPlugin } from "workbox-expiration";
+import { CacheableResponsePlugin } from "workbox-cacheable-response";
+
+precacheAndRoute(self.__WB_MANIFEST);
+cleanupOutdatedCaches();
+
+// SPA navigation fallback — same denylist as before
+registerRoute(
+  new NavigationRoute(createHandlerBoundToURL("/index.html"), {
+    denylist: [/^\/api\//, /^\/admin/, /^\/static\//],
+  })
+);
+
+// API runtime caching — NetworkFirst with 10s timeout
+registerRoute(
+  ({ url }) => url.pathname.startsWith("/api/"),
+  new NetworkFirst({
+    cacheName: "api-cache",
+    networkTimeoutSeconds: 10,
+    plugins: [
+      new ExpirationPlugin({ maxEntries: 100, maxAgeSeconds: 3600 }),
+      new CacheableResponsePlugin({ statuses: [0, 200] }),
+    ],
+  })
+);
+
+// Allow App.vue update banner to activate a waiting SW
+self.addEventListener("message", (event) => {
+  if (event.data?.type === "SKIP_WAITING") {
+    self.skipWaiting();
+  }
+});
+
+// Web Push — show a native notification
+self.addEventListener("push", (event) => {
+  if (!event.data) return;
+  const data = event.data.json();
+  event.waitUntil(
+    self.registration.showNotification(data.title ?? "LenoreFin", {
+      body: data.body ?? "",
+      icon: "/android-chrome-192x192.png",
+      badge: "/android-chrome-192x192.png",
+      data: { link: data.link ?? "/" },
+    })
+  );
+});
+
+// Clicking the notification opens / focuses the app at the linked route
+self.addEventListener("notificationclick", (event) => {
+  event.notification.close();
+  const link = event.notification.data?.link ?? "/";
+  event.waitUntil(
+    self.clients
+      .matchAll({ type: "window", includeUncontrolled: true })
+      .then((clientList) => {
+        for (const client of clientList) {
+          if ("focus" in client) return client.focus();
+        }
+        return self.clients.openWindow(link);
+      })
+  );
+});

--- a/frontend/src/views/AppNavigationVue.vue
+++ b/frontend/src/views/AppNavigationVue.vue
@@ -118,7 +118,27 @@
           </v-btn>
         </template>
         <v-card width="500" density="compact">
+          <v-card-title class="d-flex align-center pa-3 pb-0">
+            <span class="text-subtitle-1">Inbox</span>
+            <v-spacer></v-spacer>
+            <v-tooltip v-if="pushSupported" :text="pushSubscribed ? 'Disable push notifications' : 'Enable push notifications'">
+              <template v-slot:activator="{ props: tipProps }">
+                <v-btn
+                  v-bind="tipProps"
+                  :icon="pushSubscribed ? 'mdi-bell' : 'mdi-bell-outline'"
+                  :color="pushSubscribed ? 'primary' : 'default'"
+                  size="small"
+                  variant="text"
+                  @click.stop="togglePush"
+                  :disabled="!isOnline"
+                ></v-btn>
+              </template>
+            </v-tooltip>
+          </v-card-title>
           <v-card-text>
+            <v-alert v-if="pushDenied" type="warning" density="compact" class="mb-2 text-body-2">
+              Notifications blocked — enable them in your browser settings.
+            </v-alert>
             <v-list density="compact" nav>
               <v-list-item
                 :prepend-icon="
@@ -275,6 +295,7 @@
   import PlanningMenu from "@/components/PlanningMenu.vue";
   import DashboardEditor from "@/components/DashboardEditor.vue";
   import { useMessages } from "@/composables/messagesComposable";
+  import { usePushNotifications } from "@/composables/usePushNotifications";
   import { useRouter, useRoute } from "vue-router";
   import { useTransactionsStore } from "@/stores/transactions";
   import { useThemeStore } from "@/stores/themeStore";
@@ -307,6 +328,25 @@
   const authStore = useAuthStore();
   const nav_toggle = ref(true);
   const { isOnline } = useOnlineStatus();
+
+  const {
+    isSupported: pushSupported,
+    isSubscribed: pushSubscribed,
+    permissionDenied: pushDenied,
+    checkStatus: checkPushStatus,
+    subscribe: subscribePush,
+    unsubscribe: unsubscribePush,
+  } = usePushNotifications();
+
+  checkPushStatus();
+
+  async function togglePush() {
+    if (pushSubscribed.value) {
+      await unsubscribePush();
+    } else {
+      await subscribePush();
+    }
+  }
 
   const setAccount = (account, forecast) => {
     transactions_store.resetFilters();

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -12,6 +12,9 @@ export default defineConfig({
     vue(),
     vueDevTools(),
     VitePWA({
+      strategies: "injectManifest",
+      srcDir: "src",
+      filename: "sw.js",
       registerType: "autoUpdate",
       includeAssets: ["favicon.ico", "logov2.png", "apple-touch-icon.png"],
       manifest: {
@@ -28,22 +31,8 @@ export default defineConfig({
           { src: "android-chrome-512x512.png", sizes: "512x512", type: "image/png", purpose: "maskable" },
         ],
       },
-      workbox: {
+      injectManifest: {
         maximumFileSizeToCacheInBytes: 3 * 1024 * 1024,
-        navigateFallback: "/index.html",
-        navigateFallbackDenylist: [/^\/api\//, /^\/admin/, /^\/static\//],
-        runtimeCaching: [
-          {
-            urlPattern: /^\/api\//,
-            handler: "NetworkFirst",
-            options: {
-              cacheName: "api-cache",
-              networkTimeoutSeconds: 10,
-              expiration: { maxEntries: 100, maxAgeSeconds: 3600 },
-              cacheableResponse: { statuses: [0, 200] },
-            },
-          },
-        ],
       },
     }),
     createHtmlPlugin({


### PR DESCRIPTION
## Summary
- New \`PushSubscription\` model stores each browser's push subscription (endpoint + crypto keys) per user
- VAPID key pair generated and added to env (\`VAPID_PRIVATE_KEY\`, \`VAPID_PUBLIC_KEY\`, \`VAPID_EMAIL\`)
- \`pywebpush 2.3.0\` added to requirements
- \`send_push_notifications()\` called from \`create_message()\` — fires a native OS notification when any inbox message is created; scoped to the message owner if user-specific, otherwise all subscriptions; expired subscriptions (HTTP 410) auto-deleted
- API endpoints under \`/api/v1/administration/push/\`: \`GET /vapid-public-key\` (public, no auth), \`POST /subscribe\`, \`DELETE /unsubscribe\`, \`GET /status\`
- vite-plugin-pwa switched from \`generateSW\` to \`injectManifest\` strategy; \`src/sw.js\` replicates previous Workbox caching (precache + NetworkFirst for /api/) and adds \`push\` and \`notificationclick\` SW event handlers
- \`usePushNotifications\` composable handles permission request, PushManager.subscribe, key encoding, backend sync, and unsubscribe
- Inbox card in app bar gains a bell icon toggle — filled when subscribed, outline when not; warning alert shown if browser blocks the permission

## Test plan
- [ ] Rebuild dev — confirm no SW/PWA regressions (app still loads, API calls work offline)
- [ ] Open inbox → click bell icon → browser prompts for notification permission → grant it
- [ ] Confirm bell turns filled (subscribed state)
- [ ] Trigger a detection task manually → verify Chrome native notification appears
- [ ] Click notification → verify app opens/focuses at /planning/detections
- [ ] Click bell again → unsubscribes; confirm bell returns to outline
- [ ] Deny permission in browser → confirm warning alert appears in inbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)