### PR TITLE
feat: investment performance estimation

### DIFF
--- a/backend/accounts/api/schemas/investment_return.py
+++ b/backend/accounts/api/schemas/investment_return.py
@@ -1,0 +1,9 @@
+from ninja import Schema
+from typing import Optional
+
+
+class InvestmentReturnOut(Schema):
+    rate: Optional[float] = None
+    period_months: int
+    data_points: int
+    sufficient_data: bool

--- a/backend/accounts/api/views/account.py
+++ b/backend/accounts/api/views/account.py
@@ -4,6 +4,8 @@ from django.core.cache import cache
 from ninja.errors import HttpError
 from accounts.models import Account, AccountFavorite, Reward
 from transactions.models import Transaction
+from accounts.api.schemas.investment_return import InvestmentReturnOut
+from accounts.services import calculate_investment_return
 from accounts.api.schemas.account import (
     AccountIn,
     AccountOut,
@@ -334,6 +336,31 @@ def get_favorite_balances(request):
 
         api_logger.debug("Favorite balances retrieved")
         return result
+    except Exception as e:
+        error_logger.exception(str(e))
+        raise HttpError(500, f"Record retrieval error: {str(e)}")
+
+
+@account_router.get("/{account_id}/investment-return", response=InvestmentReturnOut)
+def get_investment_return(request, account_id: int):
+    """
+    Returns Modified Dietz annualised return for an investment account.
+    """
+    try:
+        result = calculate_investment_return(account_id)
+        if result is None:
+            return InvestmentReturnOut(
+                rate=None,
+                period_months=12,
+                data_points=0,
+                sufficient_data=False,
+            )
+        return InvestmentReturnOut(
+            rate=result["rate"],
+            period_months=result["period_months"],
+            data_points=result["data_points"],
+            sufficient_data=True,
+        )
     except Exception as e:
         error_logger.exception(str(e))
         raise HttpError(500, f"Record retrieval error: {str(e)}")

--- a/backend/accounts/services/__init__.py
+++ b/backend/accounts/services/__init__.py
@@ -4,3 +4,6 @@ from accounts.services.account_financials import (
     list_accounts_with_financials as list_accounts_with_financials,
 )
 from accounts.services.forecast import get_account_forecast as get_account_forecast
+from accounts.services.investment_performance import (
+    calculate_investment_return as calculate_investment_return,
+)

--- a/backend/accounts/services/investment_performance.py
+++ b/backend/accounts/services/investment_performance.py
@@ -1,0 +1,117 @@
+from decimal import Decimal, InvalidOperation
+from datetime import date
+
+from dateutil.relativedelta import relativedelta
+from django.db.models import Q
+
+from accounts.models import Account
+from transactions.models import Transaction, TransactionStatus
+
+
+def _signed_amount(tx, account_id: int) -> Decimal:
+    """Amount from this account's perspective: incoming = positive, outgoing = raw (negative)."""
+    if tx.destination_account_id == account_id:
+        return abs(tx.total_amount)
+    return tx.total_amount
+
+
+def calculate_investment_return(account_id: int, months: int = 12) -> dict | None:
+    """
+    Modified Dietz return for an investment account over the last `months` months.
+
+    Returns None when the account isn't an investment type, has no cleared history,
+    or the measurement window is too short to be meaningful.
+
+    Return dict: {rate (annualised % float), period_months, data_points}
+    """
+    try:
+        account = Account.objects.select_related("account_type").get(pk=account_id)
+    except Account.DoesNotExist:
+        return None
+
+    if account.account_type.slug != "investment":
+        return None
+
+    try:
+        cleared_status = TransactionStatus.objects.get(slug="cleared")
+    except TransactionStatus.DoesNotExist:
+        return None
+
+    today = date.today()
+    start_date = today - relativedelta(months=months)
+    total_days = (today - start_date).days
+
+    if total_days < 30:
+        return None
+
+    account_q = Q(source_account_id=account_id) | Q(destination_account_id=account_id)
+
+    # --- Beginning Market Value (all cleared txs strictly before period start) ---
+    pre_txs = Transaction.objects.filter(
+        account_q,
+        status=cleared_status,
+        transaction_date__lt=start_date,
+    ).select_related("transaction_type")
+
+    bmv = account.opening_balance + account.archive_balance
+    for tx in pre_txs:
+        bmv += _signed_amount(tx, account_id)
+
+    # --- Ending Market Value (all cleared txs up to today) ---
+    emv = account.opening_balance + account.archive_balance
+    all_cleared = Transaction.objects.filter(
+        account_q,
+        status=cleared_status,
+        transaction_date__lte=today,
+    ).select_related("transaction_type")
+    for tx in all_cleared:
+        emv += _signed_amount(tx, account_id)
+
+    # --- Period transactions (for data_points count and cash-flow weighting) ---
+    period_txs = Transaction.objects.filter(
+        account_q,
+        status=cleared_status,
+        transaction_date__gte=start_date,
+        transaction_date__lte=today,
+    ).select_related("transaction_type").order_by("transaction_date")
+
+    data_points = period_txs.count()
+    if data_points == 0:
+        return None
+
+    # --- Cash flows: only external transfers (money moving in/out from other accounts) ---
+    # Income/expense transactions are intrinsic returns (dividends, fees) — excluded from CF.
+    net_cf = Decimal("0")
+    weighted_cf = Decimal("0")
+    for tx in period_txs:
+        if tx.transaction_type and tx.transaction_type.slug == "transfer":
+            cf = _signed_amount(tx, account_id)
+            days_remaining = (today - tx.transaction_date).days
+            weight = Decimal(days_remaining) / Decimal(total_days)
+            net_cf += cf
+            weighted_cf += cf * weight
+
+    # --- Modified Dietz ---
+    denominator = bmv + weighted_cf
+    if denominator == 0:
+        return None
+
+    try:
+        period_return = (emv - bmv - net_cf) / denominator
+        # Annualise: (1 + R)^(365/days) - 1
+        annualized = (Decimal("1") + period_return) ** (
+            Decimal("365") / Decimal(total_days)
+        ) - Decimal("1")
+        rate = float(annualized * 100)
+    except (InvalidOperation, ZeroDivisionError, OverflowError):
+        return None
+
+    # Sanity-check: clamp extreme values that indicate bad data
+    if abs(rate) > 1000:
+        return None
+
+    return {
+        "rate": round(rate, 2),
+        "period_months": months,
+        "data_points": data_points,
+    }

--- a/frontend/src/components/AccountHeaderWidget.vue
+++ b/frontend/src/components/AccountHeaderWidget.vue
@@ -316,6 +316,22 @@
               <div class="text-white font-weight-bold text-body">
                 <span v-if="investmentReturn && investmentReturn.sufficient_data">
                   {{ investmentReturn.rate > 0 ? '+' : '' }}{{ investmentReturn.rate.toFixed(2) }}%
+                  <v-tooltip
+                    v-if="account.calculate_interest && authStore.isFullAccess && isOnline"
+                    location="bottom"
+                    text="Apply to forecast APY"
+                  >
+                    <template v-slot:activator="{ props: tipProps }">
+                      <v-icon
+                        size="x-small"
+                        icon="mdi-chart-line-variant"
+                        color="accent"
+                        class="cursor-pointer"
+                        v-bind="tipProps"
+                        @click="applyReturnToForecast()"
+                      />
+                    </template>
+                  </v-tooltip>
                 </span>
                 <span v-else class="text-primary-lighten-2">—</span>
               </div>
@@ -330,26 +346,6 @@
                   </template>
                 </v-tooltip>
               </div>
-            </v-col>
-            <v-col
-              v-if="account.account_type.slug === 'investment' && account.calculate_interest && authStore.isFullAccess && investmentReturn && investmentReturn.sufficient_data"
-              class="text-center align-content-end"
-            >
-              <v-tooltip location="bottom" text="Set this rate as the forecast APY">
-                <template v-slot:activator="{ props: tipProps }">
-                  <v-btn
-                    size="small"
-                    variant="tonal"
-                    color="accent"
-                    prepend-icon="mdi-chart-line-variant"
-                    v-bind="tipProps"
-                    :disabled="!isOnline"
-                    @click="applyReturnToForecast()"
-                  >
-                    Apply to Forecast
-                  </v-btn>
-                </template>
-              </v-tooltip>
             </v-col>
           </v-row>
           <!-- Small Display View -->
@@ -412,25 +408,26 @@
                 <div class="text-white font-weight-bold text-body">
                   <span v-if="investmentReturn && investmentReturn.sufficient_data">
                     {{ investmentReturn.rate > 0 ? '+' : '' }}{{ investmentReturn.rate.toFixed(2) }}%
+                    <v-tooltip
+                      v-if="account.calculate_interest && authStore.isFullAccess && isOnline"
+                      location="bottom"
+                      text="Apply to forecast APY"
+                    >
+                      <template v-slot:activator="{ props: tipProps }">
+                        <v-icon
+                          size="x-small"
+                          icon="mdi-chart-line-variant"
+                          color="accent"
+                          class="cursor-pointer"
+                          v-bind="tipProps"
+                          @click="applyReturnToForecast()"
+                        />
+                      </template>
+                    </v-tooltip>
                   </span>
                   <span v-else class="text-primary-lighten-2">—</span>
                 </div>
                 <div class="text-primary-lighten-2">est. annual return</div>
-              </v-col>
-              <v-col
-                v-if="account.calculate_interest && authStore.isFullAccess && investmentReturn && investmentReturn.sufficient_data"
-                class="text-center align-content-end"
-              >
-                <v-btn
-                  size="small"
-                  variant="tonal"
-                  color="accent"
-                  prepend-icon="mdi-chart-line-variant"
-                  :disabled="!isOnline"
-                  @click="applyReturnToForecast()"
-                >
-                  Apply to Forecast
-                </v-btn>
               </v-col>
             </v-row>
           </v-container>

--- a/frontend/src/components/AccountHeaderWidget.vue
+++ b/frontend/src/components/AccountHeaderWidget.vue
@@ -308,6 +308,49 @@
               </div>
               <div class="text-primary-lighten-2">available credit</div>
             </v-col>
+            <!-- Investment: estimated annual return -->
+            <v-col
+              v-if="account.account_type.slug === 'investment'"
+              class="text-center align-content-end"
+            >
+              <div class="text-white font-weight-bold text-body">
+                <span v-if="investmentReturn && investmentReturn.sufficient_data">
+                  {{ investmentReturn.rate > 0 ? '+' : '' }}{{ investmentReturn.rate.toFixed(2) }}%
+                </span>
+                <span v-else class="text-primary-lighten-2">—</span>
+              </div>
+              <div class="text-primary-lighten-2">
+                est. annual return
+                <v-tooltip
+                  location="bottom"
+                  :text="`Based on last ${investmentReturn?.period_months ?? 12} months (${investmentReturn?.data_points ?? 0} transactions)`"
+                >
+                  <template v-slot:activator="{ props: tipProps }">
+                    <v-icon size="x-small" icon="mdi-information-outline" v-bind="tipProps" />
+                  </template>
+                </v-tooltip>
+              </div>
+            </v-col>
+            <v-col
+              v-if="account.account_type.slug === 'investment' && authStore.isFullAccess && investmentReturn && investmentReturn.sufficient_data"
+              class="text-center align-content-end"
+            >
+              <v-tooltip location="bottom" text="Set this rate as the forecast APY">
+                <template v-slot:activator="{ props: tipProps }">
+                  <v-btn
+                    size="small"
+                    variant="tonal"
+                    color="accent"
+                    prepend-icon="mdi-chart-line-variant"
+                    v-bind="tipProps"
+                    :disabled="!isOnline"
+                    @click="applyReturnToForecast()"
+                  >
+                    Apply to Forecast
+                  </v-btn>
+                </template>
+              </v-tooltip>
+            </v-col>
           </v-row>
           <!-- Small Display View -->
           <v-row density="compact" v-if="smAndDown">
@@ -355,13 +398,43 @@
                 variant="text"
                 :append-icon="!showMore ? 'mdi-chevron-down' : 'mdi-chevron-up'"
                 @click="toggleMore"
-                v-if="account.account_type.id == 1"
+                v-if="account.account_type.id == 1 || account.account_type.slug === 'investment'"
               >
                 {{ !showMore ? "more" : "less" }}
               </v-btn>
             </v-col>
           </v-row>
         </v-container>
+        <v-expand-transition>
+          <v-container fluid v-if="account.account_type.slug === 'investment' && showMore">
+            <v-row density="compact">
+              <v-col class="text-center align-content-end">
+                <div class="text-white font-weight-bold text-body">
+                  <span v-if="investmentReturn && investmentReturn.sufficient_data">
+                    {{ investmentReturn.rate > 0 ? '+' : '' }}{{ investmentReturn.rate.toFixed(2) }}%
+                  </span>
+                  <span v-else class="text-primary-lighten-2">—</span>
+                </div>
+                <div class="text-primary-lighten-2">est. annual return</div>
+              </v-col>
+              <v-col
+                v-if="authStore.isFullAccess && investmentReturn && investmentReturn.sufficient_data"
+                class="text-center align-content-end"
+              >
+                <v-btn
+                  size="small"
+                  variant="tonal"
+                  color="accent"
+                  prepend-icon="mdi-chart-line-variant"
+                  :disabled="!isOnline"
+                  @click="applyReturnToForecast()"
+                >
+                  Apply to Forecast
+                </v-btn>
+              </v-col>
+            </v-row>
+          </v-container>
+        </v-expand-transition>
         <v-expand-transition>
           <v-container fluid v-if="account.account_type.id == 1 && showMore">
             <v-row density="compact" class="">
@@ -461,8 +534,8 @@
   </div>
 </template>
 <script setup>
-  import { defineProps, ref } from "vue";
-  import { useAccountByID, useAccounts } from "@/composables/accountsComposable";
+  import { defineProps, ref, computed } from "vue";
+  import { useAccountByID, useAccounts, useInvestmentReturn } from "@/composables/accountsComposable";
   import EditAccountForm from "./EditAccountForm.vue";
   import AdjustBalanceForm from "./AdjustBalanceForm.vue";
   import DeleteAccountForm from "./DeleteAccountForm.vue";
@@ -486,8 +559,26 @@
     account: Array,
   });
 
-  const { account } = useAccountByID(props.account);
+  const { account, editAccount } = useAccountByID(props.account);
   const { toggleFavorite } = useAccounts();
+
+  const accountId = computed(() =>
+    Array.isArray(props.account) ? props.account[0] : props.account,
+  );
+  const isInvestment = computed(
+    () => account.value?.account_type?.slug === "investment",
+  );
+  const { investmentReturn } = useInvestmentReturn(
+    computed(() => (isInvestment.value ? accountId.value : null)),
+  );
+
+  async function applyReturnToForecast() {
+    if (!investmentReturn.value?.sufficient_data) return;
+    await editAccount({
+      id: accountId.value,
+      annual_rate: investmentReturn.value.rate,
+    });
+  }
 
   const updateAdjBalDialog = value => {
     adjBalDialog.value = value;

--- a/frontend/src/components/AccountHeaderWidget.vue
+++ b/frontend/src/components/AccountHeaderWidget.vue
@@ -332,7 +332,7 @@
               </div>
             </v-col>
             <v-col
-              v-if="account.account_type.slug === 'investment' && authStore.isFullAccess && investmentReturn && investmentReturn.sufficient_data"
+              v-if="account.account_type.slug === 'investment' && account.calculate_interest && authStore.isFullAccess && investmentReturn && investmentReturn.sufficient_data"
               class="text-center align-content-end"
             >
               <v-tooltip location="bottom" text="Set this rate as the forecast APY">
@@ -418,7 +418,7 @@
                 <div class="text-primary-lighten-2">est. annual return</div>
               </v-col>
               <v-col
-                v-if="authStore.isFullAccess && investmentReturn && investmentReturn.sufficient_data"
+                v-if="account.calculate_interest && authStore.isFullAccess && investmentReturn && investmentReturn.sufficient_data"
                 class="text-center align-content-end"
               >
                 <v-btn

--- a/frontend/src/components/EditAccountForm.vue
+++ b/frontend/src/components/EditAccountForm.vue
@@ -343,6 +343,17 @@
                     density="comfortable"
                     :error-messages="annual_rate.errorMessage.value"
                   ></v-text-field>
+                  <v-chip
+                    v-if="props.account.account_type.slug === 'investment' && investmentReturn?.sufficient_data"
+                    size="small"
+                    color="accent"
+                    variant="tonal"
+                    prepend-icon="mdi-calculator"
+                    class="mt-1"
+                    @click="annual_rate.value.value = investmentReturn.rate"
+                  >
+                    Calculated from history: {{ investmentReturn.rate > 0 ? '+' : '' }}{{ investmentReturn.rate.toFixed(2) }}% — click to use
+                  </v-chip>
                 </v-col>
                 <v-col :cols="smAndDown ? 12 : undefined">
                   <v-select
@@ -378,7 +389,7 @@
   } from "vue";
   import { useDisplay } from "vuetify";
   import { useBanks } from "@/composables/banksComposable";
-  import { useAccountByID } from "@/composables/accountsComposable";
+  import { useAccountByID, useInvestmentReturn } from "@/composables/accountsComposable";
   import { useMainStore } from "@/stores/main";
   import { useAccounts } from "@/composables/accountsComposable";
   import { useOnlineStatus } from "@/composables/useOnlineStatus";
@@ -534,6 +545,10 @@
   });
   const { editAccount } = useAccountByID(props.account.id);
   const generalError = ref("");
+
+  const { investmentReturn } = useInvestmentReturn(
+    props.account.account_type.slug === "investment" ? props.account.id : null,
+  );
 
   const submit = handleSubmit(
     values => {

--- a/frontend/src/composables/accountsComposable.js
+++ b/frontend/src/composables/accountsComposable.js
@@ -265,6 +265,28 @@ export function useFavoriteBalances() {
   return { favoriteBalances, isLoading };
 }
 
+export function useInvestmentReturn(account_id) {
+  const queryClient = useQueryClient();
+  const { data: investmentReturn, isLoading } = useQuery({
+    queryKey: ["accounts", "investment_return", account_id],
+    queryFn: async () => {
+      try {
+        const response = await apiClient.get(
+          `/accounts/${account_id}/investment-return`,
+        );
+        return response.data;
+      } catch (error) {
+        handleApiError(error, "Investment return not fetched");
+      }
+    },
+    select: response => response,
+    enabled: !!account_id,
+    client: queryClient,
+  });
+
+  return { investmentReturn, isLoading };
+}
+
 function formatDateToYYYYMMDD(date) {
   if (date) {
     return new Intl.DateTimeFormat("en-CA", {

--- a/frontend/src/composables/accountsComposable.js
+++ b/frontend/src/composables/accountsComposable.js
@@ -1,4 +1,5 @@
 import { useQuery, useQueryClient, useMutation } from "@tanstack/vue-query";
+import { toValue, computed } from "vue";
 import apiClient from "./apiClient";
 import { useMainStore } from "@/stores/main";
 
@@ -271,8 +272,9 @@ export function useInvestmentReturn(account_id) {
     queryKey: ["accounts", "investment_return", account_id],
     queryFn: async () => {
       try {
+        const id = toValue(account_id);
         const response = await apiClient.get(
-          `/accounts/${account_id}/investment-return`,
+          `/accounts/${id}/investment-return`,
         );
         return response.data;
       } catch (error) {
@@ -280,7 +282,7 @@ export function useInvestmentReturn(account_id) {
       }
     },
     select: response => response,
-    enabled: !!account_id,
+    enabled: computed(() => !!toValue(account_id)),
     client: queryClient,
   });
 


### PR DESCRIPTION
## Summary

- Adds a `calculate_investment_return()` service using the Modified Dietz method — looks at 12 months of cleared transactions for an investment account, treats external transfers as cash flows, and derives an annualised return rate
- New endpoint `GET /accounts/{id}/investment-return` returns `{rate, period_months, data_points, sufficient_data}`
- `AccountHeaderWidget` shows **Est. Annual Return** for investment accounts with an info tooltip showing the measurement window and transaction count
- **Apply to Forecast** button (full-access only) patches `annual_rate` on the account, triggering the existing APY forecast machinery with the derived rate
- Feature gracefully degrades: returns `sufficient_data: false` when there are fewer than 30 days or no cleared transactions; UI shows "—" instead of a rate

## Test plan

- [ ] Open an investment account detail page — confirm "est. annual return" column appears in the header
- [ ] If account has <30 days of cleared transactions, confirm "—" is shown (no button)
- [ ] With sufficient history, confirm rate looks reasonable given the account's known balance history
- [ ] Click "Apply to Forecast" — confirm `annual_rate` is updated on the account and the forecast chart updates with the projected growth
- [ ] Non-investment accounts (checking, savings, CC) — confirm no new columns appear
- [ ] Readonly user — confirm Apply to Forecast button is not shown
- [ ] Mobile: confirm "more" toggle works for investment accounts and shows the rate + Apply button in the expand panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)