### PR TITLE
ci: make Patreon post step non-blocking with continue-on-error

### DIFF
--- a/.github/workflows/announce_patreon.yml
+++ b/.github/workflows/announce_patreon.yml
@@ -53,6 +53,7 @@ jobs:
 
       - name: Post to Patreon
         if: steps.check_prerelease.outputs.skip == 'false'
+        continue-on-error: true
         env:
           COMMIT_TAG: ${{ github.event.release.tag_name || inputs.tag }}
           RELEASE_NOTES: ${{ steps.release_notes.outputs.result }}


### PR DESCRIPTION
## Summary

- Adds `continue-on-error: true` to the Post to Patreon step so a Patreon API failure doesn't mark the entire workflow as failed
- Patreon's API write scope (`w:campaigns.posts`) requires elevated access that isn't easily obtainable through the developer portal; the post will succeed once that's resolved but the release pipeline shouldn't be blocked in the meantime

## Test plan

- [x] Workflow still runs and logs the result
- [x] A Patreon API error will show as a warning in the step, not a workflow failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)