### PR TITLE
fix: broadcast WebSocket invalidation on all Message creation paths

### DIFF
--- a/backend/administration/apps.py
+++ b/backend/administration/apps.py
@@ -4,3 +4,6 @@ from django.apps import AppConfig
 class AdministrationConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'administration'
+
+    def ready(self):
+        import administration.signals  # noqa: F401

--- a/backend/administration/signals.py
+++ b/backend/administration/signals.py
@@ -1,0 +1,11 @@
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+from administration.models import Message
+from core.broadcast import broadcast_invalidate
+
+
+@receiver(post_save, sender=Message)
+def message_saved(sender, instance, created, **kwargs):
+    if created:
+        group = f"user_{instance.user.pk}" if instance.user_id else "global"
+        broadcast_invalidate(["messages"], group=group)


### PR DESCRIPTION
## Summary
- Adds a `post_save` signal on the `Message` model in `administration/signals.py`
- Signal calls `broadcast_invalidate(["messages"])` with the correct group (`user_<pk>` for user-scoped messages, `global` for broadcast messages)
- Wires the signal in `AdministrationConfig.ready()` so it loads on app startup
- Previously, WebSocket invalidation was only triggered via `transactions/tasks.py`'s `create_message()` helper — messages created via Django shell, admin, or any other path did not push updates to the frontend

## Test plan
- [ ] Create a `Message` via Django admin or shell — it should appear in the inbox immediately without a page refresh
- [ ] Create a user-scoped `Message` — only that user's inbox should update
- [ ] Create a global `Message` (`user=None`) — all connected clients should receive the invalidation

🤖 Generated with [Claude Code](https://claude.com/claude-code)