### PR TITLE
fix: allow creating messages from Django admin

### DIFF
--- a/backend/administration/admin.py
+++ b/backend/administration/admin.py
@@ -36,9 +36,6 @@ class MessageAdmin(ModelAdmin):
     ordering = ["-message_date"]
     list_filter = ["unread", "user"]
 
-    def has_add_permission(self, request):
-        return False
-
     def has_delete_permission(self, request, obj=None):
         return False
 


### PR DESCRIPTION
## Summary
- Removes `has_add_permission` override from `MessageAdmin` so the "Add" button appears in Django admin
- Delete and change are still disabled (messages should only be managed via the app inbox API)
- Combined with PR #182 (WebSocket signal), messages created in admin will now immediately appear in the frontend inbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)