### PR TITLE
fix: save edited note values instead of the original row

### DIFF
--- a/frontend/src/views/NotesView.vue
+++ b/frontend/src/views/NotesView.vue
@@ -201,8 +201,10 @@
     addNote(note);
   };
 
-  const clickEditNote = () => {
-    editNote(editedNote.value);
+  // Takes the edited values emitted by NoteForm. The id comes from the selected
+  // row rather than the form, since it is not part of the validation schema.
+  const clickEditNote = note => {
+    editNote({ ...note, id: editedNote.value.id });
     selectedNote.value = [];
   };
 


### PR DESCRIPTION
## Problem

Editing a note appeared to succeed — green "Note updated successfully!" snackbar — but the change never stuck.

## Cause

`clickEditNote` in `frontend/src/views/NotesView.vue` took **no argument**, so it ignored the payload `NoteForm` emits on submit and passed `editedNote.value` instead — the row originally selected in the data table. The PUT therefore sent back the unmodified note. Since the API returned 200, the UI reported success.

`clickAddNote` two lines above correctly uses its emitted payload, which is why adding worked and only editing failed. The backend was never at fault.

## Fix

Use the emitted form values, merging in the `id` from the selected row. `id` is registered via `useField("id")` but is **not** part of `NoteForm`'s `validationSchema`, so it can't be relied on to reach `handleSubmit` values — taking it from the row keeps the request URL well-formed either way.

## Testing

- `npm run lint` clean
- Backend `pytest` unaffected (no backend change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)