### PR TITLE
feat: convert computed forecast transactions to real transactions

### DIFF
--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -43,6 +43,7 @@ def patch_delete_pattern():
          patch("reminders.signals.delete_pattern", return_value=None), \
          patch("transactions.signals.delete_pattern", return_value=None), \
          patch("transactions.api.views.transaction.delete_pattern", return_value=None), \
+         patch("transactions.services.forecast_conversion.delete_pattern", return_value=None), \
          patch("transactions.tasks.delete_pattern", return_value=None):
         yield
 

--- a/backend/transactions/api/schemas/transaction.py
+++ b/backend/transactions/api/schemas/transaction.py
@@ -41,6 +41,13 @@ class TransactionList(Schema):
     transactions: List[int]
 
 
+# The class ForecastTransactionList is a schema for converting forecast
+# transactions. Ids are ForecastCacheTransaction pks, not the negated display
+# ids the transaction list emits for simulated rows.
+class ForecastTransactionList(Schema):
+    forecast_transactions: List[int]
+
+
 # The class MultiTransactionDate is a schema for editing dates of transactions.
 class MultiTranscationDate(Schema):
     transaction_ids: List[int]

--- a/backend/transactions/api/views/transaction.py
+++ b/backend/transactions/api/views/transaction.py
@@ -10,6 +10,7 @@ from transactions.api.schemas.transaction import (
     PaginatedTransactions,
     MultiTranscationDate,
     TransactionQuery,
+    ForecastTransactionList,
 )
 from django.shortcuts import get_object_or_404
 from django.http import Http404
@@ -28,6 +29,10 @@ from django.db.models.functions import Concat, Coalesce, Abs
 from transactions.services.transaction import (
     create_transaction_service,
     update_transaction_service,
+)
+from transactions.services.forecast_conversion import (
+    convert_forecast_transaction,
+    ForecastTransactionNotFound,
 )
 from utils.dates import (
     get_todays_date_timezone_adjusted,
@@ -263,6 +268,44 @@ def delete_transaction(request, payload: TransactionList):
         api_logger.error("Transaction not deleted")
         error_logger.exception(f"{str(e)}")
         raise HttpError(500, f"Record retrieval error: {str(e)}")
+
+
+@transaction_router.patch("/convert-forecast", auth=FullAccessAuth())
+def convert_forecast_transactions(request, payload: ForecastTransactionList):
+    """
+    The function `convert_forecast_transactions` turns computed forecast rows
+    (credit-card interest/payments, savings interest) into real pending
+    transactions, carrying them across as-is.
+
+    Reminder-derived rows are not handled here — those already convert through
+    /reminders/addtrans/{reminder_id}, which also advances the reminder.
+
+    Args:
+        request (HttpRequest): The HTTP request object.
+        payload (ForecastTransactionList): ForecastCacheTransaction ids to convert.
+
+    Returns:
+        dict: 'success' True, and 'converted' with the ids that were converted.
+
+    Raises:
+        HttpError: 404 if any id does not exist, 500 on failure.
+    """
+
+    try:
+        converted = []
+        for forecast_id in payload.forecast_transactions:
+            convert_forecast_transaction(forecast_id)
+            converted.append(forecast_id)
+            api_logger.info(f"Forecast transaction converted : #{forecast_id}")
+        return {"success": True, "converted": converted}
+    except ForecastTransactionNotFound as e:
+        api_logger.error("Forecast transaction not converted")
+        raise HttpError(404, str(e))
+    except Exception as e:
+        # Log other types of exceptions
+        api_logger.error("Forecast transaction not converted")
+        error_logger.exception(f"{str(e)}")
+        raise HttpError(500, f"Forecast conversion error: {str(e)}")
 
 
 @transaction_router.put("/update/{transaction_id}", auth=FullAccessAuth())

--- a/backend/transactions/services/__init__.py
+++ b/backend/transactions/services/__init__.py
@@ -9,3 +9,7 @@ from transactions.services.transaction import (
     create_transaction_service as create_transaction_service,
     update_transaction_service as update_transaction_service,
 )
+from transactions.services.forecast_conversion import (
+    convert_forecast_transaction as convert_forecast_transaction,
+    ForecastTransactionNotFound as ForecastTransactionNotFound,
+)

--- a/backend/transactions/services/forecast_conversion.py
+++ b/backend/transactions/services/forecast_conversion.py
@@ -1,0 +1,103 @@
+from django.db import transaction as db_transaction
+from django.db.models import Q
+
+from core.broadcast import broadcast_invalidate
+from core.cache.helpers import delete_pattern
+from core.cache.keys import account_all
+from tags.api.dependencies.custom_tag import CustomTag
+from transactions.api.dependencies.create_transactions import create_transactions
+from transactions.api.dependencies.full_transaction import FullTransaction
+from transactions.models import (
+    ForecastCacheTransaction,
+    ForecastCacheTransactionDetail,
+    TransactionStatus,
+)
+from utils.dates import get_todays_date_timezone_adjusted
+
+
+class ForecastTransactionNotFound(Exception):
+    pass
+
+
+def convert_forecast_transaction(forecast_id: int) -> None:
+    """
+    Materialises a computed forecast row into a real pending Transaction.
+
+    ForecastCacheTransactions are projections derived from account settings
+    (credit-card statement interest/payments, savings interest) rather than
+    instances of a Reminder, so unlike ReminderCacheTransaction they carry no
+    reminder FK and cannot go through add_reminder_transaction. This copies the
+    row across as-is — amount, dates, accounts and tags — and drops the cache
+    entry so the table reflects the change immediately.
+
+    The cache row is safe to delete because the generators rebuild it: the
+    credit-card payment forecast subtracts existing real and reminder
+    transactions in the payment window from the cycle payment, so once this
+    transaction exists the row is regenerated smaller or not at all.
+
+    Args:
+        forecast_id (int): id of the ForecastCacheTransaction to convert.
+
+    Raises:
+        ForecastTransactionNotFound: if no such forecast transaction exists.
+    """
+
+    try:
+        forecast = ForecastCacheTransaction.objects.get(id=forecast_id)
+    except ForecastCacheTransaction.DoesNotExist:
+        raise ForecastTransactionNotFound(
+            f"Forecast transaction {forecast_id} not found"
+        )
+
+    today = get_todays_date_timezone_adjusted()
+    pending_status_id = TransactionStatus.objects.values_list(
+        "id", flat=True
+    ).get(slug="pending")
+
+    # create_transactions re-derives the sign and the full-toggle amounts from
+    # transaction_type, so the stored (already signed) values are passed as
+    # magnitudes and come back out identical.
+    tags = [
+        CustomTag(
+            tag_name=None,
+            tag_amount=abs(detail.detail_amt),
+            tag_id=detail.tag_id,
+            tag_full_toggle=detail.full_toggle,
+        )
+        for detail in ForecastCacheTransactionDetail.objects.filter(
+            transaction_id=forecast.id
+        )
+        if detail.tag_id is not None
+    ]
+
+    new_transaction = FullTransaction(
+        transaction_date=forecast.transaction_date,
+        total_amount=forecast.total_amount,
+        status_id=pending_status_id,
+        memo=forecast.memo,
+        description=forecast.description,
+        edit_date=today,
+        add_date=today,
+        transaction_type_id=forecast.transaction_type_id,
+        paycheck_id=forecast.paycheck_id,
+        source_account_id=forecast.source_account_id,
+        destination_account_id=forecast.destination_account_id,
+        tags=tags,
+        checkNumber=forecast.checkNumber,
+    )
+
+    # Hold the account ids before the delete, then create and delete together so
+    # a failure can never leave the forecast row gone without its transaction.
+    account_ids = {forecast.source_account_id, forecast.destination_account_id}
+    with db_transaction.atomic():
+        create_transactions([new_transaction])
+        ForecastCacheTransaction.objects.filter(
+            Q(id=forecast_id)
+        ).delete()
+
+    for account_id in account_ids:
+        if account_id:
+            delete_pattern(account_all(account_id))
+    broadcast_invalidate(
+        ["accounts", "account_forecast", "tag_graph", "transactions"]
+    )

--- a/backend/transactions/tests/service/test_forecast_conversion.py
+++ b/backend/transactions/tests/service/test_forecast_conversion.py
@@ -1,0 +1,196 @@
+from decimal import Decimal
+
+import pytest
+
+from transactions.models import (
+    ForecastCacheTransaction,
+    ForecastCacheTransactionDetail,
+    Transaction,
+    TransactionDetail,
+)
+from transactions.services import (
+    ForecastTransactionNotFound,
+    convert_forecast_transaction,
+)
+
+
+@pytest.fixture
+def forecast_with_tag(
+    test_pending_transaction_status,
+    test_expense_transaction_type,
+    test_income_transaction_type,
+    test_checking_account,
+    test_tag,
+):
+    """A computed forecast row with one full-toggle detail, as the cc/interest
+    generators produce.
+
+    test_income_transaction_type is pulled in because create_transactions looks
+    up the income type to decide the sign, and errors if it does not exist.
+    """
+    forecast = ForecastCacheTransaction.objects.create(
+        status=test_pending_transaction_status,
+        description="(Test Card Estimated Payment)",
+        memo="projected",
+        transaction_type=test_expense_transaction_type,
+        source_account=test_checking_account,
+        total_amount=Decimal("-125.00"),
+    )
+    ForecastCacheTransactionDetail.objects.create(
+        transaction=forecast,
+        detail_amt=Decimal("-125.00"),
+        tag=test_tag,
+        full_toggle=True,
+    )
+    return forecast
+
+
+@pytest.mark.django_db
+@pytest.mark.service
+def test_convert_creates_real_transaction(forecast_with_tag, test_checking_account):
+    """The forecast row is carried across as-is into a real transaction."""
+    convert_forecast_transaction(forecast_with_tag.id)
+
+    created = Transaction.objects.get(description="(Test Card Estimated Payment)")
+    assert created.total_amount == Decimal("-125.00")
+    assert created.transaction_date == forecast_with_tag.transaction_date
+    assert created.source_account_id == test_checking_account.id
+    assert created.memo == "projected"
+    assert created.status.slug == "pending"
+
+
+@pytest.mark.django_db
+@pytest.mark.service
+def test_convert_removes_the_cache_row(forecast_with_tag):
+    """The cache entry is dropped so the table reflects the change immediately."""
+    convert_forecast_transaction(forecast_with_tag.id)
+
+    assert not ForecastCacheTransaction.objects.filter(
+        id=forecast_with_tag.id
+    ).exists()
+    # Details go with it, so no orphans are left behind.
+    assert not ForecastCacheTransactionDetail.objects.filter(
+        transaction_id=forecast_with_tag.id
+    ).exists()
+
+
+@pytest.mark.django_db
+@pytest.mark.service
+def test_convert_carries_tags_across(forecast_with_tag, test_tag):
+    """Detail rows are recreated against the real transaction, sign preserved."""
+    convert_forecast_transaction(forecast_with_tag.id)
+
+    created = Transaction.objects.get(description="(Test Card Estimated Payment)")
+    details = TransactionDetail.objects.filter(transaction_id=created.id)
+    assert details.count() == 1
+    detail = details.first()
+    assert detail.tag_id == test_tag.id
+    assert detail.full_toggle is True
+    # create_transactions re-derives the sign from transaction_type, so an
+    # expense must not come back positive after the round trip.
+    assert detail.detail_amt == Decimal("-125.00")
+
+
+@pytest.mark.django_db
+@pytest.mark.service
+def test_convert_untagged_forecast(
+    test_pending_transaction_status,
+    test_expense_transaction_type,
+    test_income_transaction_type,
+    test_checking_account,
+):
+    """A forecast row with no details still converts."""
+    forecast = ForecastCacheTransaction.objects.create(
+        status=test_pending_transaction_status,
+        description="(Test Savings Interest)",
+        transaction_type=test_expense_transaction_type,
+        source_account=test_checking_account,
+        total_amount=Decimal("-3.21"),
+    )
+
+    convert_forecast_transaction(forecast.id)
+
+    created = Transaction.objects.get(description="(Test Savings Interest)")
+    assert created.total_amount == Decimal("-3.21")
+    assert not TransactionDetail.objects.filter(transaction_id=created.id).exists()
+
+
+@pytest.mark.django_db
+@pytest.mark.service
+def test_convert_missing_forecast_raises(db):
+    """A stale id from an already-converted row is reported, not swallowed."""
+    with pytest.raises(ForecastTransactionNotFound):
+        convert_forecast_transaction(999999)
+
+
+@pytest.mark.django_db
+@pytest.mark.service
+def test_convert_leaves_other_forecasts_alone(
+    forecast_with_tag,
+    test_pending_transaction_status,
+    test_expense_transaction_type,
+    test_checking_account,
+):
+    """Converting one row does not disturb the rest of the cache."""
+    other = ForecastCacheTransaction.objects.create(
+        status=test_pending_transaction_status,
+        description="(Other Estimated Payment)",
+        transaction_type=test_expense_transaction_type,
+        source_account=test_checking_account,
+        total_amount=Decimal("-50.00"),
+    )
+
+    convert_forecast_transaction(forecast_with_tag.id)
+
+    assert ForecastCacheTransaction.objects.filter(id=other.id).exists()
+    assert not Transaction.objects.filter(
+        description="(Other Estimated Payment)"
+    ).exists()
+
+
+@pytest.mark.django_db
+@pytest.mark.api
+def test_convert_endpoint_converts_batch(
+    api_client,
+    patch_auth_as_full_access,
+    forecast_with_tag,
+    test_pending_transaction_status,
+    test_expense_transaction_type,
+    test_checking_account,
+):
+    """The endpoint takes a list and converts every id in it."""
+    second = ForecastCacheTransaction.objects.create(
+        status=test_pending_transaction_status,
+        description="(Second Estimated Payment)",
+        transaction_type=test_expense_transaction_type,
+        source_account=test_checking_account,
+        total_amount=Decimal("-10.00"),
+    )
+
+    response = api_client.patch(
+        "/transactions/convert-forecast",
+        json={"forecast_transactions": [forecast_with_tag.id, second.id]},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["success"] is True
+    assert Transaction.objects.filter(
+        description="(Test Card Estimated Payment)"
+    ).exists()
+    assert Transaction.objects.filter(
+        description="(Second Estimated Payment)"
+    ).exists()
+    assert ForecastCacheTransaction.objects.count() == 0
+
+
+@pytest.mark.django_db
+@pytest.mark.api
+def test_convert_endpoint_missing_id_returns_404(
+    api_client, patch_auth_as_full_access
+):
+    response = api_client.patch(
+        "/transactions/convert-forecast",
+        json={"forecast_transactions": [999999]},
+    )
+
+    assert response.status_code == 404

--- a/frontend/src/components/TransactionTableWidget.vue
+++ b/frontend/src/components/TransactionTableWidget.vue
@@ -190,33 +190,6 @@
           }"
         >
           <div class="text-center">
-            <v-btn
-              @click="toggleSelect(internalItem)"
-              variant="plain"
-              icon
-              block
-              :disabled="!isSelectable(internalItem.raw)"
-              v-if="!isSelectable(internalItem.raw)"
-            >
-              <v-icon
-                icon="mdi-alpha-p-circle"
-                color="textPending"
-                size="x-large"
-                v-if="internalItem.raw.status.id === 1"
-              ></v-icon>
-              <v-icon
-                icon="mdi-alpha-c-circle"
-                color="success"
-                v-if="internalItem.raw.status.id === 2"
-                size="large"
-              ></v-icon>
-              <v-icon
-                icon="mdi-alpha-r-circle"
-                color="error"
-                v-if="internalItem.raw.status.id === 3"
-                size="large"
-              ></v-icon>
-            </v-btn>
             <v-badge
               color="textPending-lighten-3"
               :icon="
@@ -227,14 +200,12 @@
               location="right top"
               :offset-x="6"
               :offset-y="10"
-              v-if="isSelectable(internalItem.raw)"
             >
               <v-btn
                 @click="toggleSelect(internalItem)"
                 variant="plain"
                 icon
                 block
-                :disabled="!isSelectable(internalItem.raw)"
               >
                 <v-icon
                   icon="mdi-alpha-p-circle"
@@ -945,7 +916,6 @@
   // from selected_reminders because they convert through a different endpoint.
   const selected_forecasts = ref([]);
   const selected_all = ref([]);
-  const isSelectable = item => item.id > -10000;
 
   const headers = ref([
     { title: "", key: "status", width: "72px" },

--- a/frontend/src/components/TransactionTableWidget.vue
+++ b/frontend/src/components/TransactionTableWidget.vue
@@ -707,6 +707,7 @@
                         clickClearTransaction(
                           selected_transactions,
                           selected_reminders,
+                          selected_forecasts,
                         )
                       "
                       v-bind="props"
@@ -750,7 +751,8 @@
   import { useTags } from "@/composables/tagsComposable";
   const { isOnline } = useOnlineStatus();
 
-  const { removeTransaction, clearTransaction } = useTransactions();
+  const { removeTransaction, clearTransaction, convertForecastTransactions } =
+    useTransactions();
   const { addReminderTransaction } = useReminders();
   const authStore = useAuthStore();
   const { smAndDown, mdAndUp } = useDisplay();
@@ -939,6 +941,9 @@
 
   const selected_transactions = ref([]);
   const selected_reminders = ref([]);
+  // Computed forecast rows (cc interest/payments, savings interest). Held apart
+  // from selected_reminders because they convert through a different endpoint.
+  const selected_forecasts = ref([]);
   const selected_all = ref([]);
   const isSelectable = item => item.id > -10000;
 
@@ -988,12 +993,19 @@
   const uncheck_all = () => {
     selected_transactions.value = [];
     selected_reminders.value = [];
+    selected_forecasts.value = [];
     selected_all.value = [];
     open.value = false;
   };
+  // Simulated rows are emitted with negated ids: reminder rows as -id, computed
+  // forecast rows as -id - 10000. This undoes the forecast offset to recover the
+  // ForecastCacheTransaction pk the convert endpoint expects.
+  const toForecastId = displayId => -displayId - 10000;
+
   const rowChanged = newSelection => {
     selected_transactions.value = [];
     selected_reminders.value = [];
+    selected_forecasts.value = [];
     for (const selectedrow of newSelection) {
       if (selectedrow.id > 0) {
         selected_transactions.value.push(selectedrow.id);
@@ -1004,9 +1016,14 @@
           transaction_date: selectedrow.transaction_date,
         };
         selected_reminders.value.push(reminder_trans_obj);
+      } else if (selectedrow.id <= -10000) {
+        selected_forecasts.value.push(toForecastId(selectedrow.id));
       }
     }
-    if (selected_reminders.value.length == 0) {
+    if (
+      selected_reminders.value.length == 0 &&
+      selected_forecasts.value.length == 0
+    ) {
       deleteDisable.value = false;
       editDisable.value = false;
     } else {
@@ -1015,7 +1032,8 @@
     }
     if (
       selected_transactions.value.length > 0 ||
-      selected_reminders.value.length > 0
+      selected_reminders.value.length > 0 ||
+      selected_forecasts.value.length > 0
     ) {
       clearDisable.value = false;
       open.value = true;
@@ -1031,7 +1049,11 @@
     clearFilters();
   };
 
-  const clickClearTransaction = async (transactions, reminderTransactions) => {
+  const clickClearTransaction = async (
+    transactions,
+    reminderTransactions,
+    forecastTransactions,
+  ) => {
     if (transactions.length > 0) {
       clearTransaction(transactions);
     }
@@ -1040,8 +1062,14 @@
     reminderTransactions.forEach(transaction => {
       addReminderTransaction(transaction);
     });
+    // Sent as one batch -- the endpoint takes a list, unlike the per-row
+    // reminder conversion above.
+    if (forecastTransactions.length > 0) {
+      convertForecastTransactions(forecastTransactions);
+    }
     selected_transactions.value = [];
     selected_reminders.value = [];
+    selected_forecasts.value = [];
     clearDisable.value = true;
     clearFilters();
   };

--- a/frontend/src/composables/transactionsComposable.js
+++ b/frontend/src/composables/transactionsComposable.js
@@ -133,6 +133,30 @@ async function clearTransactionFunction(clearedTransaction) {
   }
 }
 
+// Takes ForecastCacheTransaction ids, not the negated display ids the table
+// shows for simulated rows -- see toForecastId in TransactionTableWidget.
+async function convertForecastTransactionsFunction(forecastIds) {
+  const mainstore = useMainStore();
+  let payload = {
+    forecast_transactions: forecastIds,
+  };
+  try {
+    const response = await apiClient.patch(
+      "/transactions/convert-forecast",
+      payload,
+    );
+    mainstore.showSnackbar(
+      forecastIds.length > 1
+        ? "Forecast transactions converted successfully!"
+        : "Forecast transaction converted successfully!",
+      "success",
+    );
+    return response.data;
+  } catch (error) {
+    handleApiError(error, "Forecast transaction not converted: ");
+  }
+}
+
 async function updateTransactionFunction(updatedTransaction) {
   const mainstore = useMainStore();
   try {
@@ -221,6 +245,14 @@ export function useTransactions() {
     },
   });
 
+  const convertForecastTransactionsMutation = useMutation({
+    mutationFn: convertForecastTransactionsFunction,
+    onSuccess: () => {
+      invalidateTransactionDependencies(queryClient);
+      scheduleForecastRefetch(queryClient);
+    },
+  });
+
   const multiEditTransactionsMutation = useMutation({
     mutationFn: multiEditTransactionsFunction,
     onSuccess: () => {
@@ -257,6 +289,10 @@ export function useTransactions() {
     multiEditTransactionsMutation.mutate(data);
   }
 
+  async function convertForecastTransactions(forecastIds) {
+    convertForecastTransactionsMutation.mutate(forecastIds);
+  }
+
   return {
     isLoading,
     isFetching,
@@ -266,6 +302,7 @@ export function useTransactions() {
     clearTransaction,
     editTransaction,
     mutliEditTransactions,
+    convertForecastTransactions,
   };
 }
 


### PR DESCRIPTION
## Problem

Forecast rows in the transaction table come from two sources, and only one of them could be made real:

| Source | Display id | Has reminder FK | Convertible before |
|---|---|---|---|
| `ReminderCacheTransaction` | `-id` (−1…−9999) | Yes | Yes, via `PUT /reminders/addtrans/{id}` |
| `ForecastCacheTransaction` | `-id - 10000` (≤ −10001) | **No** | **No** |

`ForecastCacheTransaction` rows — credit-card statement interest and payments, savings/parent-group interest — are computed from account settings rather than being reminder instances, so they carry no reminder to convert through. Selecting one offered no action at all: `rowChanged` gated on `id > -10000` and dropped them from every selection array.

## Change

`convert_forecast_transaction` copies the cache row across **as-is** — amount, dates, accounts, checkNumber and its detail tag rows — into a real `Transaction` at `pending`, then drops the cache entry so the table updates immediately. Edits happen afterwards, on the real transaction.

Notes on the implementation:

- Creation and deletion share one `transaction.atomic()`, so a failure can't leave the forecast row gone without its replacement.
- Tag amounts are passed as **magnitudes**, because `create_transactions` re-derives sign and full-toggle amounts from `transaction_type`; passing the stored signed values would double-apply.
- Deleting the cache row is safe because the generators rebuild it. The credit-card payment forecast computes `remaining_payment = cycle_payment - existing_payment_sum`, summing existing real *and* reminder transactions in the payment window — so once the transaction exists, the row returns smaller or not at all.

Exposed as `PATCH /transactions/convert-forecast` taking a list, matching the batch shape of the existing `/clear` and `/delete`. The frontend recovers the real pk from the negated display id and routes it through the existing **Clear / Add Transaction(s)** speed-dial action, so the interaction is unchanged.

## Please verify before merge

Credit-card **payments** self-reconcile as described. **Interest** is derived from balance rather than netted against existing interest transactions, so a converted interest charge may be recomputed and re-added on the next rebuild. That math is unchanged by this PR. Worth converting one CC interest row against a live stack and watching the rebuild.

## Testing

- 8 new tests in `transactions/tests/service/test_forecast_conversion.py` — field carry-across, cache row removal including details, tag round-trip with sign preserved, untagged case, unknown id raising, isolation from other cached rows, batch conversion, 404
- Full suite: **687 passed**
- `ruff check backend/` clean, `npm run lint` clean
- Endpoint confirmed registered against a running dev stack

`conftest.py`'s `patch_delete_pattern` gains the new service. That fixture patches `delete_pattern` per importing module rather than at its source, since each module binds its own reference with a from-import — a module missing from the list hits the real redis-only helper and fails under the locmem test cache.

## Note

`test_forecast_list_endpoint_includes_forecast_transactions` fails on this branch, but it **also fails on `alpha`** — verified by checking out alpha and running it. Pre-existing and untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)