### PR TITLE
fix: only require a payment amount for the custom cc strategy

### DIFF
--- a/frontend/src/components/EditAccountForm.vue
+++ b/frontend/src/components/EditAccountForm.vue
@@ -474,10 +474,14 @@
         then: schema => schema.required("Must select payment strategy."),
         otherwise: schema => schema.notRequired(),
       }),
+    // Only the custom strategy uses payment_amount -- full and minimum derive
+    // the payment themselves. Must match the field's own v-if above, or the
+    // form blocks on a validation error attached to a hidden field.
     payment_amount: yup
       .number()
       .when(["account_type_id", "calculate_payments", "payment_strategy"], {
-        is: (type, calc, strat) => type === 1 && calc === true && strat,
+        is: (type, calc, strat) =>
+          type === 1 && calc === true && strat === "C",
         then: schema => schema.required("Must enter a payment amount."),
         otherwise: schema => schema.notRequired(),
       }),


### PR DESCRIPTION
## Problem

Editing an account and enabling credit-card calculations refused to save unless a Payment Amount was entered — even for the **Full** and **Minimum** strategies, which don't use that field.

Worse, it failed silently. The save button did nothing and there was no visible reason.

## Cause

The Payment Amount input is rendered only for the custom strategy:

```
<v-col v-if="payment_strategy.value.value == 'C'">   <!-- EditAccountForm.vue:293 -->
```

But the validation schema required it whenever **any** strategy was selected:

```js
is: (type, calc, strat) => type === 1 && calc === true && strat,   // truthy
```

So with Full or Minimum, the form failed validation on a field that wasn't on screen, and vee-validate attached the error message to the hidden input — hence no feedback.

The backend agrees the field is custom-only: `update_cc_forecast_cache` reads `payment_amount` solely under the `payment_strategy == "C"` branch, and `minimum_payment_amount` under `"M"`.

## Fix

Match the schema condition to the field's own `v-if` (`strat === "C"`).

`minimum_payment_amount` is deliberately left required — that input is always visible when calculations are enabled, so requiring it is not a hidden-field trap.

## Testing

Found while manually building a test credit-card account. `npm run lint` clean; frontend-only, no backend change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)