### PR TITLE
fix: allow row-click selection of forecast rows and clean their description

### DIFF
--- a/backend/transactions/services/__init__.py
+++ b/backend/transactions/services/__init__.py
@@ -11,5 +11,6 @@ from transactions.services.transaction import (
 )
 from transactions.services.forecast_conversion import (
     convert_forecast_transaction as convert_forecast_transaction,
+    clean_forecast_description as clean_forecast_description,
     ForecastTransactionNotFound as ForecastTransactionNotFound,
 )

--- a/backend/transactions/services/forecast_conversion.py
+++ b/backend/transactions/services/forecast_conversion.py
@@ -1,3 +1,5 @@
+import re
+
 from django.db import transaction as db_transaction
 from django.db.models import Q
 
@@ -19,6 +21,29 @@ class ForecastTransactionNotFound(Exception):
     pass
 
 
+def clean_forecast_description(description: str) -> str:
+    """
+    Turns a projected description into one that reads as a real transaction.
+
+    The forecast generators label their rows "({name} Estimated Payment)" and
+    "({name} Estimated Interest)" -- the brackets and the word "Estimated" mark
+    the row as a projection. Once converted the transaction is real, so both
+    markers are dropped: "(Visa Estimated Payment)" becomes "Visa Payment".
+
+    Leaves anything that does not carry those markers untouched.
+    """
+
+    if not description:
+        return description
+
+    text = description.strip()
+    if text.startswith("(") and text.endswith(")"):
+        text = text[1:-1]
+    text = re.sub(r"\bestimated\b", "", text, flags=re.IGNORECASE)
+    # Collapse the gap the removed word leaves behind.
+    return " ".join(text.split())
+
+
 def convert_forecast_transaction(forecast_id: int) -> None:
     """
     Materialises a computed forecast row into a real pending Transaction.
@@ -27,8 +52,10 @@ def convert_forecast_transaction(forecast_id: int) -> None:
     (credit-card statement interest/payments, savings interest) rather than
     instances of a Reminder, so unlike ReminderCacheTransaction they carry no
     reminder FK and cannot go through add_reminder_transaction. This copies the
-    row across as-is — amount, dates, accounts and tags — and drops the cache
-    entry so the table reflects the change immediately.
+    row across — amount, dates, accounts and tags — and drops the cache entry so
+    the table reflects the change immediately. The only field not carried
+    verbatim is the description, which loses its projection markers (see
+    clean_forecast_description).
 
     The cache row is safe to delete because the generators rebuild it: the
     credit-card payment forecast subtracts existing real and reminder
@@ -75,7 +102,7 @@ def convert_forecast_transaction(forecast_id: int) -> None:
         total_amount=forecast.total_amount,
         status_id=pending_status_id,
         memo=forecast.memo,
-        description=forecast.description,
+        description=clean_forecast_description(forecast.description),
         edit_date=today,
         add_date=today,
         transaction_type_id=forecast.transaction_type_id,

--- a/backend/transactions/tests/service/test_forecast_conversion.py
+++ b/backend/transactions/tests/service/test_forecast_conversion.py
@@ -10,6 +10,7 @@ from transactions.models import (
 )
 from transactions.services import (
     ForecastTransactionNotFound,
+    clean_forecast_description,
     convert_forecast_transaction,
 )
 
@@ -51,7 +52,7 @@ def test_convert_creates_real_transaction(forecast_with_tag, test_checking_accou
     """The forecast row is carried across as-is into a real transaction."""
     convert_forecast_transaction(forecast_with_tag.id)
 
-    created = Transaction.objects.get(description="(Test Card Estimated Payment)")
+    created = Transaction.objects.get(description="Test Card Payment")
     assert created.total_amount == Decimal("-125.00")
     assert created.transaction_date == forecast_with_tag.transaction_date
     assert created.source_account_id == test_checking_account.id
@@ -80,7 +81,7 @@ def test_convert_carries_tags_across(forecast_with_tag, test_tag):
     """Detail rows are recreated against the real transaction, sign preserved."""
     convert_forecast_transaction(forecast_with_tag.id)
 
-    created = Transaction.objects.get(description="(Test Card Estimated Payment)")
+    created = Transaction.objects.get(description="Test Card Payment")
     details = TransactionDetail.objects.filter(transaction_id=created.id)
     assert details.count() == 1
     detail = details.first()
@@ -110,7 +111,7 @@ def test_convert_untagged_forecast(
 
     convert_forecast_transaction(forecast.id)
 
-    created = Transaction.objects.get(description="(Test Savings Interest)")
+    created = Transaction.objects.get(description="Test Savings Interest")
     assert created.total_amount == Decimal("-3.21")
     assert not TransactionDetail.objects.filter(transaction_id=created.id).exists()
 
@@ -143,9 +144,7 @@ def test_convert_leaves_other_forecasts_alone(
     convert_forecast_transaction(forecast_with_tag.id)
 
     assert ForecastCacheTransaction.objects.filter(id=other.id).exists()
-    assert not Transaction.objects.filter(
-        description="(Other Estimated Payment)"
-    ).exists()
+    assert not Transaction.objects.filter(description="Other Payment").exists()
 
 
 @pytest.mark.django_db
@@ -174,12 +173,8 @@ def test_convert_endpoint_converts_batch(
 
     assert response.status_code == 200
     assert response.json()["success"] is True
-    assert Transaction.objects.filter(
-        description="(Test Card Estimated Payment)"
-    ).exists()
-    assert Transaction.objects.filter(
-        description="(Second Estimated Payment)"
-    ).exists()
+    assert Transaction.objects.filter(description="Test Card Payment").exists()
+    assert Transaction.objects.filter(description="Second Payment").exists()
     assert ForecastCacheTransaction.objects.count() == 0
 
 
@@ -194,3 +189,27 @@ def test_convert_endpoint_missing_id_returns_404(
     )
 
     assert response.status_code == 404
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        # The three formats the forecast generators actually emit.
+        ("(Visa Estimated Payment)", "Visa Payment"),
+        ("(Visa Estimated Interest)", "Visa Interest"),
+        ("(Emergency Fund Estimated Interest)", "Emergency Fund Interest"),
+        # Brackets without the word, and the word without brackets.
+        ("(Test Savings Interest)", "Test Savings Interest"),
+        ("Visa Estimated Payment", "Visa Payment"),
+        # Nothing to strip is left alone.
+        ("Groceries", "Groceries"),
+        # Account names containing brackets mid-string are not mangled.
+        ("(Visa (Joint) Estimated Payment)", "Visa (Joint) Payment"),
+        # Defensive: empty and whitespace-only.
+        ("", ""),
+        ("   ", ""),
+    ],
+)
+def test_clean_forecast_description(raw, expected):
+    assert clean_forecast_description(raw) == expected

--- a/frontend/src/components/TransactionTableWidget.vue
+++ b/frontend/src/components/TransactionTableWidget.vue
@@ -267,7 +267,7 @@
           <div
             class="w-100 h-100 d-flex align-center"
             style="cursor: pointer"
-            @click="item.id > -10000 ? toggleSelect(internalItem) : null"
+            @click="toggleSelect(internalItem)"
           >
             <v-tooltip text="Image(s)" location="top">
               <template v-slot:activator="{ props }">
@@ -342,7 +342,7 @@
           <div
             class="w-100 h-100 d-flex align-center"
             style="cursor: pointer"
-            @click="item.id > -10000 ? toggleSelect(internalItem) : null"
+            @click="toggleSelect(internalItem)"
           >
             {{ formatDate(item.transaction_date, true) }}
           </div>
@@ -354,7 +354,7 @@
           <div
             class="w-100 h-100 d-flex align-center"
             style="cursor: pointer"
-            @click="item.id > -10000 ? toggleSelect(internalItem) : null"
+            @click="toggleSelect(internalItem)"
           >
             <span :class="getClassForMoney(item.pretty_total, item.status.id)">
               {{ formatCurrency(item.pretty_total) }}
@@ -368,7 +368,7 @@
           <div
             class="w-100 h-100 d-flex align-center"
             style="cursor: pointer"
-            @click="item.id > -10000 ? toggleSelect(internalItem) : null"
+            @click="toggleSelect(internalItem)"
           >
             <span
               :class="getClassForMoney(item.balance, item.status.id)"
@@ -391,7 +391,7 @@
           <div
             class="w-100 h-100 d-flex align-center"
             style="cursor: pointer"
-            @click="item.id > -10000 ? toggleSelect(internalItem) : null"
+            @click="toggleSelect(internalItem)"
           >
             <span>{{ item.description }}</span>
           </div>
@@ -403,7 +403,7 @@
           <div
             class="w-100 h-100 d-flex align-center text-primary text-subtitle-2"
             style="cursor: pointer"
-            @click="item.id > -10000 ? toggleSelect(internalItem) : null"
+            @click="toggleSelect(internalItem)"
           >
             {{ processTags(item.tags) }}
           </div>
@@ -415,14 +415,14 @@
           <div
             class="w-100 h-100 d-flex align-center text-altAccent"
             style="cursor: pointer"
-            @click="item.id > -10000 ? toggleSelect(internalItem) : null"
+            @click="toggleSelect(internalItem)"
           >
             <span>{{ item.pretty_account }}</span>
           </div>
         </template>
         <!-- Mobile View -->
         <template v-slot:[`item.mobile`]="{ item, internalItem, toggleSelect }">
-          <div @click="item.id > -10000 ? toggleSelect(internalItem) : null">
+          <div @click="toggleSelect(internalItem)">
             <v-container class="ma-0 pa-0 ga-0">
               <v-row dense class="ma-0 pa-0 ga-0">
                 <v-col class="ma-0 pa-0 ga-0" cols="3">


### PR DESCRIPTION
Two follow-ups to #186, both found in manual testing.

## 1. Forecast rows could only be selected via the badge

Eight per-cell click handlers each carried the same guard:

```
@click="item.id > -10000 ? toggleSelect(internalItem) : null"
```

That range is exactly what excludes computed forecast rows, so clicking the date, amount, description or any other cell did nothing — the row felt inert. Removing `isSelectable` in the previous fix corrected the badge but left these eight behind.

Every row type is selectable now, so the guard is gone and forecast rows behave like real and reminder rows.

## 2. Converted transactions kept their projection labelling

The generators write `({name} Estimated Payment)` and `({name} Estimated Interest)`. The brackets and the word "Estimated" both mark the row as a projection, and neither is true once it's a real transaction.

`clean_forecast_description` strips both on conversion:

| Before | After |
|---|---|
| `(Visa Estimated Payment)` | `Visa Payment` |
| `(Emergency Fund Estimated Interest)` | `Emergency Fund Interest` |
| `(Test Savings Interest)` | `Test Savings Interest` |
| `Groceries` | `Groceries` |

Only the **outer** brackets are removed, so an account name carrying its own — `(Visa (Joint) Estimated Payment)` → `Visa (Joint) Payment` — survives intact.

## Testing

- 9 new parametrised cases over `clean_forecast_description`, including the bracket-in-name case and empty/whitespace input
- Existing conversion tests updated to assert the cleaned descriptions
- **696 passed**; `ruff` and `eslint` clean

The one failing test, `test_forecast_list_endpoint_includes_forecast_transactions`, fails on `alpha` too and is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)