### PR TITLE
fix: restrict forecast conversion to credit-card payments

### DIFF
--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -244,6 +244,11 @@ def test_income_transaction_type():
 
 
 @pytest.fixture
+def test_transfer_transaction_type():
+    return TransactionType.objects.create(transaction_type="Transfer")
+
+
+@pytest.fixture
 def test_pending_transaction_status():
     return TransactionStatus.objects.create(transaction_status="Pending")
 

--- a/backend/transactions/api/views/transaction.py
+++ b/backend/transactions/api/views/transaction.py
@@ -33,6 +33,7 @@ from transactions.services.transaction import (
 from transactions.services.forecast_conversion import (
     convert_forecast_transaction,
     ForecastTransactionNotFound,
+    ForecastTransactionNotConvertible,
 )
 from utils.dates import (
     get_todays_date_timezone_adjusted,
@@ -273,12 +274,14 @@ def delete_transaction(request, payload: TransactionList):
 @transaction_router.patch("/convert-forecast", auth=FullAccessAuth())
 def convert_forecast_transactions(request, payload: ForecastTransactionList):
     """
-    The function `convert_forecast_transactions` turns computed forecast rows
-    (credit-card interest/payments, savings interest) into real pending
-    transactions, carrying them across as-is.
+    The function `convert_forecast_transactions` turns credit-card payment
+    forecasts into real pending transactions.
 
-    Reminder-derived rows are not handled here — those already convert through
-    /reminders/addtrans/{reminder_id}, which also advances the reminder.
+    Interest projections (savings, parent-group and credit-card statement
+    interest) are rejected — they do not reconcile on rebuild and would be
+    double counted. Reminder-derived rows are not handled here either; those
+    convert through /reminders/addtrans/{reminder_id}, which also advances the
+    reminder.
 
     Args:
         request (HttpRequest): The HTTP request object.
@@ -288,7 +291,8 @@ def convert_forecast_transactions(request, payload: ForecastTransactionList):
         dict: 'success' True, and 'converted' with the ids that were converted.
 
     Raises:
-        HttpError: 404 if any id does not exist, 500 on failure.
+        HttpError: 404 if an id does not exist, 400 if a row is an interest
+        projection, 500 on failure.
     """
 
     try:
@@ -301,6 +305,9 @@ def convert_forecast_transactions(request, payload: ForecastTransactionList):
     except ForecastTransactionNotFound as e:
         api_logger.error("Forecast transaction not converted")
         raise HttpError(404, str(e))
+    except ForecastTransactionNotConvertible as e:
+        api_logger.error("Forecast transaction not convertible")
+        raise HttpError(400, str(e))
     except Exception as e:
         # Log other types of exceptions
         api_logger.error("Forecast transaction not converted")

--- a/backend/transactions/services/__init__.py
+++ b/backend/transactions/services/__init__.py
@@ -12,5 +12,7 @@ from transactions.services.transaction import (
 from transactions.services.forecast_conversion import (
     convert_forecast_transaction as convert_forecast_transaction,
     clean_forecast_description as clean_forecast_description,
+    is_convertible_forecast as is_convertible_forecast,
     ForecastTransactionNotFound as ForecastTransactionNotFound,
+    ForecastTransactionNotConvertible as ForecastTransactionNotConvertible,
 )

--- a/backend/transactions/services/forecast_conversion.py
+++ b/backend/transactions/services/forecast_conversion.py
@@ -21,6 +21,35 @@ class ForecastTransactionNotFound(Exception):
     pass
 
 
+class ForecastTransactionNotConvertible(Exception):
+    pass
+
+
+# Only credit-card payment projections may be converted. The generators emit
+# three kinds of forecast row, distinguished by transaction type:
+#
+#   income   -> savings / parent-group interest
+#   expense  -> credit-card statement interest
+#   transfer -> credit-card payment (funding account -> card)
+#
+# Interest is excluded because it does not reconcile. The payment forecast
+# subtracts existing real and reminder transactions in the payment window, so
+# converting one makes the next rebuild produce a smaller row or none at all.
+# Interest is derived from the balance instead, and is not netted against
+# interest transactions that already exist -- so a converted interest charge
+# would simply be recomputed and re-added, double counting it.
+CONVERTIBLE_TYPE_SLUG = "transfer"
+
+
+def is_convertible_forecast(forecast) -> bool:
+    """True when a ForecastCacheTransaction may be made real."""
+
+    return (
+        forecast.transaction_type is not None
+        and forecast.transaction_type.slug == CONVERTIBLE_TYPE_SLUG
+    )
+
+
 def clean_forecast_description(description: str) -> str:
     """
     Turns a projected description into one that reads as a real transaction.
@@ -46,7 +75,10 @@ def clean_forecast_description(description: str) -> str:
 
 def convert_forecast_transaction(forecast_id: int) -> None:
     """
-    Materialises a computed forecast row into a real pending Transaction.
+    Materialises a credit-card payment forecast into a real pending Transaction.
+
+    Only payment projections are convertible; interest projections raise
+    ForecastTransactionNotConvertible. See CONVERTIBLE_TYPE_SLUG for why.
 
     ForecastCacheTransactions are projections derived from account settings
     (credit-card statement interest/payments, savings interest) rather than
@@ -70,10 +102,18 @@ def convert_forecast_transaction(forecast_id: int) -> None:
     """
 
     try:
-        forecast = ForecastCacheTransaction.objects.get(id=forecast_id)
+        forecast = ForecastCacheTransaction.objects.select_related(
+            "transaction_type"
+        ).get(id=forecast_id)
     except ForecastCacheTransaction.DoesNotExist:
         raise ForecastTransactionNotFound(
             f"Forecast transaction {forecast_id} not found"
+        )
+
+    if not is_convertible_forecast(forecast):
+        raise ForecastTransactionNotConvertible(
+            f"Forecast transaction {forecast_id} is an interest projection "
+            "and cannot be converted"
         )
 
     today = get_todays_date_timezone_adjusted()

--- a/backend/transactions/tests/service/test_forecast_conversion.py
+++ b/backend/transactions/tests/service/test_forecast_conversion.py
@@ -9,6 +9,7 @@ from transactions.models import (
     TransactionDetail,
 )
 from transactions.services import (
+    ForecastTransactionNotConvertible,
     ForecastTransactionNotFound,
     clean_forecast_description,
     convert_forecast_transaction,
@@ -18,7 +19,7 @@ from transactions.services import (
 @pytest.fixture
 def forecast_with_tag(
     test_pending_transaction_status,
-    test_expense_transaction_type,
+    test_transfer_transaction_type,
     test_income_transaction_type,
     test_checking_account,
     test_tag,
@@ -33,7 +34,7 @@ def forecast_with_tag(
         status=test_pending_transaction_status,
         description="(Test Card Estimated Payment)",
         memo="projected",
-        transaction_type=test_expense_transaction_type,
+        transaction_type=test_transfer_transaction_type,
         source_account=test_checking_account,
         total_amount=Decimal("-125.00"),
     )
@@ -87,8 +88,8 @@ def test_convert_carries_tags_across(forecast_with_tag, test_tag):
     detail = details.first()
     assert detail.tag_id == test_tag.id
     assert detail.full_toggle is True
-    # create_transactions re-derives the sign from transaction_type, so an
-    # expense must not come back positive after the round trip.
+    # create_transactions re-derives the sign from transaction_type, so a
+    # non-income row must not come back positive after the round trip.
     assert detail.detail_amt == Decimal("-125.00")
 
 
@@ -96,24 +97,56 @@ def test_convert_carries_tags_across(forecast_with_tag, test_tag):
 @pytest.mark.service
 def test_convert_untagged_forecast(
     test_pending_transaction_status,
-    test_expense_transaction_type,
+    test_transfer_transaction_type,
     test_income_transaction_type,
     test_checking_account,
 ):
-    """A forecast row with no details still converts."""
+    """A payment forecast with no details still converts."""
     forecast = ForecastCacheTransaction.objects.create(
         status=test_pending_transaction_status,
-        description="(Test Savings Interest)",
-        transaction_type=test_expense_transaction_type,
+        description="(Test Card Estimated Payment)",
+        transaction_type=test_transfer_transaction_type,
         source_account=test_checking_account,
         total_amount=Decimal("-3.21"),
     )
 
     convert_forecast_transaction(forecast.id)
 
-    created = Transaction.objects.get(description="Test Savings Interest")
+    created = Transaction.objects.get(description="Test Card Payment")
     assert created.total_amount == Decimal("-3.21")
     assert not TransactionDetail.objects.filter(transaction_id=created.id).exists()
+
+
+@pytest.mark.django_db
+@pytest.mark.service
+@pytest.mark.parametrize("interest_type", ["income", "expense"])
+def test_interest_projections_are_rejected(
+    interest_type,
+    request,
+    test_pending_transaction_status,
+    test_income_transaction_type,
+    test_expense_transaction_type,
+    test_checking_account,
+):
+    """Savings (income) and credit-card statement (expense) interest cannot be
+    converted -- neither reconciles on rebuild, so both would double count."""
+    type_obj = request.getfixturevalue(f"test_{interest_type}_transaction_type")
+    forecast = ForecastCacheTransaction.objects.create(
+        status=test_pending_transaction_status,
+        description="(Test Card Estimated Interest)",
+        transaction_type=type_obj,
+        source_account=test_checking_account,
+        total_amount=Decimal("-9.99"),
+    )
+
+    with pytest.raises(ForecastTransactionNotConvertible):
+        convert_forecast_transaction(forecast.id)
+
+    # The projection survives and no transaction is written.
+    assert ForecastCacheTransaction.objects.filter(id=forecast.id).exists()
+    assert not Transaction.objects.filter(
+        description="Test Card Interest"
+    ).exists()
 
 
 @pytest.mark.django_db
@@ -129,14 +162,14 @@ def test_convert_missing_forecast_raises(db):
 def test_convert_leaves_other_forecasts_alone(
     forecast_with_tag,
     test_pending_transaction_status,
-    test_expense_transaction_type,
+    test_transfer_transaction_type,
     test_checking_account,
 ):
     """Converting one row does not disturb the rest of the cache."""
     other = ForecastCacheTransaction.objects.create(
         status=test_pending_transaction_status,
         description="(Other Estimated Payment)",
-        transaction_type=test_expense_transaction_type,
+        transaction_type=test_transfer_transaction_type,
         source_account=test_checking_account,
         total_amount=Decimal("-50.00"),
     )
@@ -154,14 +187,14 @@ def test_convert_endpoint_converts_batch(
     patch_auth_as_full_access,
     forecast_with_tag,
     test_pending_transaction_status,
-    test_expense_transaction_type,
+    test_transfer_transaction_type,
     test_checking_account,
 ):
     """The endpoint takes a list and converts every id in it."""
     second = ForecastCacheTransaction.objects.create(
         status=test_pending_transaction_status,
         description="(Second Estimated Payment)",
-        transaction_type=test_expense_transaction_type,
+        transaction_type=test_transfer_transaction_type,
         source_account=test_checking_account,
         total_amount=Decimal("-10.00"),
     )
@@ -176,6 +209,34 @@ def test_convert_endpoint_converts_batch(
     assert Transaction.objects.filter(description="Test Card Payment").exists()
     assert Transaction.objects.filter(description="Second Payment").exists()
     assert ForecastCacheTransaction.objects.count() == 0
+
+
+@pytest.mark.django_db
+@pytest.mark.api
+def test_convert_endpoint_rejects_interest_with_400(
+    api_client,
+    patch_auth_as_full_access,
+    test_pending_transaction_status,
+    test_expense_transaction_type,
+    test_checking_account,
+):
+    """An interest projection is refused at the API boundary, not silently
+    skipped, so the UI can surface why."""
+    forecast = ForecastCacheTransaction.objects.create(
+        status=test_pending_transaction_status,
+        description="(Test Card Estimated Interest)",
+        transaction_type=test_expense_transaction_type,
+        source_account=test_checking_account,
+        total_amount=Decimal("-9.99"),
+    )
+
+    response = api_client.patch(
+        "/transactions/convert-forecast",
+        json={"forecast_transactions": [forecast.id]},
+    )
+
+    assert response.status_code == 400
+    assert ForecastCacheTransaction.objects.filter(id=forecast.id).exists()
 
 
 @pytest.mark.django_db

--- a/frontend/src/components/TransactionTableWidget.vue
+++ b/frontend/src/components/TransactionTableWidget.vue
@@ -190,6 +190,34 @@
           }"
         >
           <div class="text-center">
+            <!-- Interest projections have no action available, so they render
+                 without the selection badge rather than looking clickable. -->
+            <v-btn
+              variant="plain"
+              icon
+              block
+              disabled
+              v-if="!isActionable(internalItem.raw)"
+            >
+              <v-icon
+                icon="mdi-alpha-p-circle"
+                color="textPending"
+                size="x-large"
+                v-if="internalItem.raw.status.id === 1"
+              ></v-icon>
+              <v-icon
+                icon="mdi-alpha-c-circle"
+                color="success"
+                v-if="internalItem.raw.status.id === 2"
+                size="large"
+              ></v-icon>
+              <v-icon
+                icon="mdi-alpha-r-circle"
+                color="error"
+                v-if="internalItem.raw.status.id === 3"
+                size="large"
+              ></v-icon>
+            </v-btn>
             <v-badge
               color="textPending-lighten-3"
               :icon="
@@ -200,6 +228,7 @@
               location="right top"
               :offset-x="6"
               :offset-y="10"
+              v-if="isActionable(internalItem.raw)"
             >
               <v-btn
                 @click="toggleSelect(internalItem)"
@@ -267,7 +296,7 @@
           <div
             class="w-100 h-100 d-flex align-center"
             style="cursor: pointer"
-            @click="toggleSelect(internalItem)"
+            @click="isActionable(item) ? toggleSelect(internalItem) : null"
           >
             <v-tooltip text="Image(s)" location="top">
               <template v-slot:activator="{ props }">
@@ -342,7 +371,7 @@
           <div
             class="w-100 h-100 d-flex align-center"
             style="cursor: pointer"
-            @click="toggleSelect(internalItem)"
+            @click="isActionable(item) ? toggleSelect(internalItem) : null"
           >
             {{ formatDate(item.transaction_date, true) }}
           </div>
@@ -354,7 +383,7 @@
           <div
             class="w-100 h-100 d-flex align-center"
             style="cursor: pointer"
-            @click="toggleSelect(internalItem)"
+            @click="isActionable(item) ? toggleSelect(internalItem) : null"
           >
             <span :class="getClassForMoney(item.pretty_total, item.status.id)">
               {{ formatCurrency(item.pretty_total) }}
@@ -368,7 +397,7 @@
           <div
             class="w-100 h-100 d-flex align-center"
             style="cursor: pointer"
-            @click="toggleSelect(internalItem)"
+            @click="isActionable(item) ? toggleSelect(internalItem) : null"
           >
             <span
               :class="getClassForMoney(item.balance, item.status.id)"
@@ -391,7 +420,7 @@
           <div
             class="w-100 h-100 d-flex align-center"
             style="cursor: pointer"
-            @click="toggleSelect(internalItem)"
+            @click="isActionable(item) ? toggleSelect(internalItem) : null"
           >
             <span>{{ item.description }}</span>
           </div>
@@ -403,7 +432,7 @@
           <div
             class="w-100 h-100 d-flex align-center text-primary text-subtitle-2"
             style="cursor: pointer"
-            @click="toggleSelect(internalItem)"
+            @click="isActionable(item) ? toggleSelect(internalItem) : null"
           >
             {{ processTags(item.tags) }}
           </div>
@@ -415,14 +444,14 @@
           <div
             class="w-100 h-100 d-flex align-center text-altAccent"
             style="cursor: pointer"
-            @click="toggleSelect(internalItem)"
+            @click="isActionable(item) ? toggleSelect(internalItem) : null"
           >
             <span>{{ item.pretty_account }}</span>
           </div>
         </template>
         <!-- Mobile View -->
         <template v-slot:[`item.mobile`]="{ item, internalItem, toggleSelect }">
-          <div @click="toggleSelect(internalItem)">
+          <div @click="isActionable(item) ? toggleSelect(internalItem) : null">
             <v-container class="ma-0 pa-0 ga-0">
               <v-row dense class="ma-0 pa-0 ga-0">
                 <v-col class="ma-0 pa-0 ga-0" cols="3">
@@ -972,6 +1001,20 @@
   // ForecastCacheTransaction pk the convert endpoint expects.
   const toForecastId = displayId => -displayId - 10000;
 
+  // Of the computed forecast rows, only credit-card payments (transfer type)
+  // can be converted. Interest projections -- savings/parent-group (income) and
+  // credit-card statement interest (expense) -- are excluded: they are derived
+  // from the balance rather than netted against existing interest transactions,
+  // so converting one would be recomputed and re-added on the next rebuild.
+  const isForecastRow = item => item.id <= -10000;
+  const isConvertibleForecast = item =>
+    isForecastRow(item) && item.transaction_type?.slug === "transfer";
+
+  // A row is actionable when something can be done with it: real transactions
+  // clear, reminder rows add, and cc payment forecasts convert.
+  const isActionable = item =>
+    !isForecastRow(item) || isConvertibleForecast(item);
+
   const rowChanged = newSelection => {
     selected_transactions.value = [];
     selected_reminders.value = [];
@@ -986,7 +1029,7 @@
           transaction_date: selectedrow.transaction_date,
         };
         selected_reminders.value.push(reminder_trans_obj);
-      } else if (selectedrow.id <= -10000) {
+      } else if (isConvertibleForecast(selectedrow)) {
         selected_forecasts.value.push(toForecastId(selectedrow.id));
       }
     }


### PR DESCRIPTION
Interest projections are no longer convertible — only credit-card payments are. This closes the open risk carried by #186 rather than leaving it to be verified.

## Why

The two kinds behave differently on rebuild:

- **Payments reconcile.** The generator computes `remaining_payment = cycle_payment - existing_payment_sum`, summing existing real and reminder transactions in the payment window. Convert one and the next rebuild produces a smaller row, or none.
- **Interest does not.** It's derived from the account balance and is never netted against interest transactions that already exist. A converted interest charge would simply be recomputed and re-added — double counted.

## How they're told apart

The three generators are already distinguishable by transaction type, so **no new model field or migration** was needed:

| Generator | `transaction_type` | Convertible |
|---|---|---|
| Savings / parent-group interest | `income` | No |
| Credit-card statement interest | `expense` | No |
| Credit-card payment | `transfer` | **Yes** |

## Behaviour

- Service raises `ForecastTransactionNotConvertible`; endpoint answers **400** rather than silently skipping, so a stale UI is told why.
- Front end: interest rows render without the selection badge and ignore row clicks. That's the same inertness forecast rows had before #188 — wrong then because an action existed, correct now because none does.
- Reminder rows and real transactions are unaffected.

## Scope check

I read "interest forecast transactions" as **all** interest, including credit-card statement interest, since the double-counting risk is identical for both and neither is something you'd record by hand. If you meant only savings interest and wanted CC interest to stay convertible, it's a one-line change to `CONVERTIBLE_TYPE_SLUG`.

## Testing

- Parametrised rejection test over both interest types (income and expense)
- Endpoint test asserting 400 and that the projection survives
- Existing conversion tests moved onto the transfer type, so they isolate the behaviour they name
- **699 passed**; `ruff` and `eslint` clean

The lone failure, `test_forecast_list_endpoint_includes_forecast_transactions`, fails on `alpha` too and is unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)