### PR TITLE
fix: anchor ordering tests to the real date instead of a literal

### DIFF
--- a/backend/transactions/tests/service/test_transaction_ordering.py
+++ b/backend/transactions/tests/service/test_transaction_ordering.py
@@ -17,10 +17,18 @@ from transactions.api.dependencies.transaction_utilities import (
 from transactions.api.dependencies.get_transactions_by_account import (
     get_transactions_by_account,
 )
+from utils.dates import get_todays_date_timezone_adjusted
 
 AUTH = {"Authorization": "Bearer test-api-key"}
 
-TODAY = date(2026, 6, 1)
+# Must track the real current date, and must use the same timezone-adjusted
+# helper the code under test uses. The forecast path keeps only rows dated on or
+# after today, so a hardcoded date silently stops exercising it the moment that
+# date passes: this was pinned to 2026-06-01 and
+# test_forecast_list_endpoint_includes_forecast_transactions began failing on
+# 2026-06-02, when "TOMORROW" became yesterday and the row was filtered out as
+# past. Anything anchored to a literal date here is a time bomb.
+TODAY = get_todays_date_timezone_adjusted()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Diagnoses and fixes the long-standing `test_forecast_list_endpoint_includes_forecast_transactions` failure. **The production code was never at fault** — which is why it survived so long unexplained.

## Cause

`test_transaction_ordering.py` pinned its clock to a literal:

```python
TODAY = date(2026, 6, 1)
TOMORROW = TODAY + timedelta(days=1)    # 2026-06-02
```

But the forecast path anchors to the real `get_todays_date_timezone_adjusted()` and keeps only rows dated **on or after today**:

```python
if transaction.transaction_date >= start_date
```

Once 2026-06-01 passed, the row the test created as "tomorrow" was in the past and got filtered out. The endpoint correctly returned nothing and the assertion failed. **It began failing on 2026-06-02** and would have kept failing forever.

That also explains the shape of the symptom I noted earlier — the response came back *entirely* empty rather than merely missing the forecast row. Every row the test created was pre-dated.

## How it was confirmed

Calling `get_transactions_by_account` directly with real dates returned the row (`id=-10001`), and driving the endpoint through `api_client` with real dates returned `total_records=1`. Both layers were healthy; only the test's clock was wrong.

## Fix

Anchor `TODAY` to the same timezone-adjusted helper the code under test uses, so the forecast filter keeps being exercised as time passes.

The literal `date(2020, 1, 1)` in `test_forecast_list_excludes_past_transactions` is deliberately left alone — that one *must* stay in the past to test what it claims.

## Result

**700 passed, 0 failed.** First fully green suite in a while; all 27 tests in the module pass, and nothing elsewhere regressed.

## Worth noting

`test_cc_interest.py` already handles this correctly — it defines `PATCH_TODAY` and patches `get_todays_date_timezone_adjusted`, so its `FIXED_TODAY` is *injected* rather than assumed. That's the pattern to copy when a test needs a predictable today.

`test_balance_accuracy.py` still carries an unpatched `TODAY = date(2026, 6, 1)`. It never exercises the forecast path, so it's harmless today and I left it alone — but a future forecast test added to that module would hit exactly this bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)