### PR TITLE
fix: inject today into balance accuracy tests instead of assuming it

### DIFF
--- a/backend/transactions/tests/service/test_balance_accuracy.py
+++ b/backend/transactions/tests/service/test_balance_accuracy.py
@@ -17,6 +17,7 @@ Invariants under test:
 import pytest
 from datetime import date, timedelta
 from decimal import Decimal
+from unittest.mock import patch
 
 from transactions.models import Transaction, TransactionStatus, TransactionType
 from transactions.api.dependencies.transaction_utilities import (
@@ -34,7 +35,26 @@ TWO_DAYS_AGO = TODAY - timedelta(days=2)
 TOMORROW = TODAY + timedelta(days=1)
 NEXT_WEEK = TODAY + timedelta(days=7)
 
+# get_transactions_by_account anchors to get_todays_date_timezone_adjusted() and,
+# on the forecast path, drops every row dated before it. None of the tests here
+# pass forecast=True today, so the literal TODAY above is currently harmless --
+# but that is a property of the callers, not of the module, and the same pinned
+# literal is what made test_transaction_ordering.py start failing on 2026-06-02
+# (see #190). Inject TODAY instead of assuming it, so a forecast test added here
+# later gets the date it wrote rather than the wall clock.
+PATCH_TODAY = (
+    "transactions.api.dependencies.get_transactions_by_account."
+    "get_todays_date_timezone_adjusted"
+)
+
 BASE_BALANCE = Decimal("611.10")  # opening=55.55 + archive=555.55
+
+
+@pytest.fixture(autouse=True)
+def fixed_today():
+    """Pin the date the code under test sees to this module's TODAY."""
+    with patch(PATCH_TODAY, return_value=TODAY):
+        yield
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Summary

Follow-up to #190. `test_balance_accuracy.py` carried the same pinned `TODAY = date(2026, 6, 1)` literal and derived every relative date (`YESTERDAY`, `TOMORROW`, `NEXT_WEEK`, …) from it.

Nothing fails today. `get_transactions_by_account` only consults `get_todays_date_timezone_adjusted()` inside the `if forecast:` branch, and no test in this module passes `forecast=True` — so the stale literal never meets the code that would filter it out as past.

That is a property of the current callers, not of the module. The first forecast test added here inherits the exact failure mode #190 fixed: a row written as "tomorrow" gets silently dropped as past, and the production code is blameless.

## Change

An autouse fixture patches `get_todays_date_timezone_adjusted` at its lookup site in `get_transactions_by_account`, so `TODAY` is *injected* rather than assumed. The literal stays and is now true.

This is the `test_cc_interest.py` `PATCH_TODAY` pattern that #190 explicitly named as the one to copy when a test needs a predictable today. Anchoring to the real date — what #190 did — would be wrong here: these tests want deterministic ordering around a fixed point, not a moving one.

## Testing

- `pytest transactions/tests/service/test_balance_accuracy.py` — 17 passed
- `pytest transactions/tests` — 206 passed
- `ruff check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)