### PR TITLE
feat: animate icon state transitions

### DIFF
--- a/frontend/src/components/AccountForecastWidget.vue
+++ b/frontend/src/components/AccountForecastWidget.vue
@@ -13,7 +13,7 @@
       <v-tooltip location="bottom" text="Highlight lowest balance after today">
         <template v-slot:activator="{ props: tipProps }">
           <v-btn
-            :icon="showMinHighlight ? 'mdi-flag' : 'mdi-flag-outline'"
+            icon
             flat
             size="small"
             :color="showMinHighlight ? 'error' : undefined"
@@ -21,7 +21,11 @@
             :disabled="isActive"
             v-bind="tipProps"
             @click="toggleMinHighlight"
-          ></v-btn>
+          >
+            <AnimatedIcon
+              :icon="showMinHighlight ? 'mdi-flag' : 'mdi-flag-outline'"
+            />
+          </v-btn>
         </template>
       </v-tooltip>
       <v-tooltip location="bottom" text="Show trend line">
@@ -109,6 +113,7 @@
 <script setup>
   import { ref, defineProps, defineEmits, computed } from "vue";
   import ApexChart from "vue3-apexcharts";
+  import AnimatedIcon from "@/components/AnimatedIcon.vue";
   import { useAccountForecasts } from "@/composables/forecastsComposable";
   import { useMainStore } from "@/stores/main";
   import { useDisplay } from "vuetify";

--- a/frontend/src/components/AccountHeaderWidget.vue
+++ b/frontend/src/components/AccountHeaderWidget.vue
@@ -99,7 +99,7 @@
                 >
                   <template v-slot:activator="{ props }">
                     <v-btn
-                      :icon="account.is_favorite ? 'mdi-star' : 'mdi-star-outline'"
+                      icon
                       :color="account.is_favorite ? 'amber' : undefined"
                       flat
                       variant="text"
@@ -108,7 +108,14 @@
                       size="small"
                       class="mx-0"
                       :disabled="!isOnline"
-                    />
+                    >
+                      <AnimatedIcon
+                        transition="scale"
+                        :icon="
+                          account.is_favorite ? 'mdi-star' : 'mdi-star-outline'
+                        "
+                      />
+                    </v-btn>
                   </template>
                 </v-tooltip>
                 <v-tooltip
@@ -118,7 +125,7 @@
                 >
                   <template v-slot:activator="{ props }">
                     <v-btn
-                      :icon="account.active ? 'mdi-delete' : 'mdi-delete-restore'"
+                      icon
                       flat
                       variant="text"
                       @click="deleteDialog = true"
@@ -126,19 +133,35 @@
                       size="small"
                       class="mx-0"
                       :disabled="!isOnline"
-                    />
+                    >
+                      <AnimatedIcon
+                        transition="scale"
+                        :icon="
+                          account.active ? 'mdi-delete' : 'mdi-delete-restore'
+                        "
+                      />
+                    </v-btn>
                   </template>
                 </v-tooltip>
-                <!-- Mobile chevron toggle -->
+                <!-- Mobile chevron toggle. Up and down are the same glyph, so
+                     this rotates one icon rather than cross-fading two. -->
                 <v-btn
                   v-if="smAndDown"
-                  :icon="actionDrawer ? 'mdi-chevron-up' : 'mdi-chevron-down'"
+                  icon
                   flat
                   variant="text"
                   size="small"
                   class="mx-0"
                   @click="actionDrawer = !actionDrawer"
-                />
+                >
+                  <v-icon
+                    icon="mdi-chevron-down"
+                    :class="[
+                      'chevron-toggle',
+                      { 'chevron-toggle--flipped': actionDrawer },
+                    ]"
+                  ></v-icon>
+                </v-btn>
                 <DeleteAccountForm
                   v-model="deleteDialog"
                   :account="account"
@@ -539,6 +562,7 @@
   import NumberFlow from "@number-flow/vue";
   import { useDisplay } from "vuetify";
   import RewardsGraphs from "./RewardsGraphs.vue";
+  import AnimatedIcon from "./AnimatedIcon.vue";
   import { useAuthStore } from "@/stores/auth";
   import { useOnlineStatus } from "@/composables/useOnlineStatus";
   const { isOnline } = useOnlineStatus();
@@ -664,6 +688,19 @@
   @media (max-width: 600px) {
     .bank-watermark {
       display: none;
+    }
+  }
+  .chevron-toggle {
+    transition: transform 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  }
+
+  .chevron-toggle--flipped {
+    transform: rotate(180deg);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .chevron-toggle {
+      transition-duration: 0.01ms;
     }
   }
 </style>

--- a/frontend/src/components/AnimatedIcon.vue
+++ b/frontend/src/components/AnimatedIcon.vue
@@ -1,0 +1,59 @@
+<template>
+  <span class="animated-icon">
+    <component :is="transitions[transition]" mode="out-in">
+      <!-- Keying on the icon name is what makes the swap a transition rather
+           than an in-place attribute change. -->
+      <v-icon :key="icon" :icon="icon" v-bind="$attrs"></v-icon>
+    </component>
+  </span>
+</template>
+<script setup>
+  import { defineProps } from "vue";
+  import { VFadeTransition, VScaleTransition } from "vuetify/components";
+
+  // Attrs land on the inner v-icon (size, color, ...) rather than the wrapper.
+  defineOptions({ inheritAttrs: false });
+
+  // Imported rather than resolved from a name string, so a typo is a build
+  // error instead of a silently missing icon.
+  const transitions = {
+    fade: VFadeTransition,
+    scale: VScaleTransition,
+  };
+
+  defineProps({
+    icon: { type: String, required: true },
+    // "fade" suits outline/filled pairs of the same glyph; "scale" suits a
+    // genuine change of shape.
+    // Values are inlined rather than derived from `transitions` above because
+    // defineProps is a compile-time macro and cannot see setup scope.
+    transition: {
+      type: String,
+      default: "fade",
+      validator: value => ["fade", "scale"].includes(value),
+    },
+  });
+</script>
+<style>
+  .animated-icon {
+    display: inline-flex;
+  }
+
+  /* Vuetify's own durations are tuned for panels, not for a button icon that
+     toggles under the cursor. out-in runs the two halves back to back, so the
+     stock timing reads as lag. Matched by suffix because the generated classes
+     are "fade-transition-*" / "scale-transition-*". */
+  .animated-icon [class*="-enter-active"],
+  .animated-icon [class*="-leave-active"] {
+    transition-duration: 0.13s;
+  }
+
+  /* createCssTransition, unlike the javascript transitions, does not honour
+     reduced motion on its own. */
+  @media (prefers-reduced-motion: reduce) {
+    .animated-icon [class*="-enter-active"],
+    .animated-icon [class*="-leave-active"] {
+      transition-duration: 0.01ms;
+    }
+  }
+</style>

--- a/frontend/src/components/TransactionSpeedDial.vue
+++ b/frontend/src/components/TransactionSpeedDial.vue
@@ -7,11 +7,18 @@
   >
     <template v-slot:activator="{ props: activatorProps }">
       <v-btn
-        :icon="!open ? 'mdi-dots-vertical' : 'mdi-close'"
+        icon
         v-bind="activatorProps"
         :variant="!open ? 'plain' : 'outlined'"
         size="small"
-      ></v-btn>
+      >
+        <!-- A genuine change of shape rather than a fill state, so this scales
+             instead of cross-fading. -->
+        <AnimatedIcon
+          transition="scale"
+          :icon="!open ? 'mdi-dots-vertical' : 'mdi-close'"
+        />
+      </v-btn>
     </template>
     <v-btn
       icon="mdi-invoice-remove"
@@ -35,6 +42,7 @@
 </template>
 <script setup>
   import { ref } from "vue";
+  import AnimatedIcon from "@/components/AnimatedIcon.vue";
 
   const open = ref(false);
 </script>

--- a/frontend/src/components/TransactionTableWidget.vue
+++ b/frontend/src/components/TransactionTableWidget.vue
@@ -10,14 +10,18 @@
         >
           <template v-slot:activator="{ props }">
             <v-btn
-              :icon="hasActiveFilters ? 'mdi-filter' : 'mdi-filter-outline'"
+              icon
               flat
               variant="plain"
               v-bind="props"
               @click="showFilters = !showFilters"
               :color="hasActiveFilters ? 'primary' : undefined"
               :disabled="isActive"
-            ></v-btn>
+            >
+              <AnimatedIcon
+                :icon="hasActiveFilters ? 'mdi-filter' : 'mdi-filter-outline'"
+              />
+            </v-btn>
           </template>
         </v-tooltip>
         <v-tooltip
@@ -683,11 +687,7 @@
                 <v-tooltip text="Edit Transaction(s)" location="left" key="3">
                   <template v-slot:activator="{ props }">
                     <v-btn
-                      :icon="
-                        selected_transactions.length > 1
-                          ? 'mdi-calendar-edit'
-                          : 'mdi-invoice-text-edit'
-                      "
+                      icon
                       :disabled="
                         (selected_transactions &&
                           selected_transactions.length === 0) ||
@@ -697,7 +697,16 @@
                       @click="displayEditForm"
                       v-bind="props"
                       key="3"
-                    ></v-btn>
+                    >
+                      <AnimatedIcon
+                        transition="scale"
+                        :icon="
+                          selected_transactions.length > 1
+                            ? 'mdi-calendar-edit'
+                            : 'mdi-invoice-text-edit'
+                        "
+                      />
+                    </v-btn>
                   </template>
                 </v-tooltip>
               </div>
@@ -746,6 +755,7 @@
   import { ref, defineProps, computed, watch } from "vue";
   import TransactionForm from "@/components/TransactionForm.vue";
   import MultipleTransactionAddForm from "@/components/MultipleTransactionAddForm.vue";
+  import AnimatedIcon from "@/components/AnimatedIcon.vue";
   import FileImportForm from "@/components/FileImportForm.vue";
   import { useTransactionsStore } from "@/stores/transactions";
   import MultipleTransactionEditForm from "@/components/MultipleTransactionEditForm.vue";

--- a/frontend/src/views/AppNavigationVue.vue
+++ b/frontend/src/views/AppNavigationVue.vue
@@ -126,13 +126,17 @@
               <template v-slot:activator="{ props: tipProps }">
                 <v-btn
                   v-bind="tipProps"
-                  :icon="pushSubscribed ? 'mdi-bell' : 'mdi-bell-outline'"
+                  icon
                   :color="pushSubscribed ? 'primary' : 'default'"
                   size="small"
                   variant="text"
                   @click.stop="togglePush"
                   :disabled="!isOnline"
-                ></v-btn>
+                >
+                  <AnimatedIcon
+                    :icon="pushSubscribed ? 'mdi-bell' : 'mdi-bell-outline'"
+                  />
+                </v-btn>
               </template>
             </v-tooltip>
           </v-card-title>
@@ -188,13 +192,17 @@
                 <template v-slot:activator="{ props: tipProps }">
                   <v-btn
                     v-bind="tipProps"
-                    :icon="pushSubscribed ? 'mdi-bell' : 'mdi-bell-outline'"
+                    icon
                     :color="pushSubscribed ? 'primary' : 'default'"
                     size="small"
                     variant="text"
                     @click.stop="togglePush"
                     :disabled="!isOnline"
-                  ></v-btn>
+                  >
+                    <AnimatedIcon
+                      :icon="pushSubscribed ? 'mdi-bell' : 'mdi-bell-outline'"
+                    />
+                  </v-btn>
                 </template>
               </v-tooltip>
             </v-card-title>
@@ -355,6 +363,7 @@
   import AccountsMenu from "@/components/AccountsMenu.vue";
   import PlanningMenu from "@/components/PlanningMenu.vue";
   import DashboardEditor from "@/components/DashboardEditor.vue";
+  import AnimatedIcon from "@/components/AnimatedIcon.vue";
   import { useMessages } from "@/composables/messagesComposable";
   import { usePushNotifications } from "@/composables/usePushNotifications";
   import { useRouter, useRoute } from "vue-router";


### PR DESCRIPTION
## Summary

Last item on the current work list. Animates the icons that change state, using Vuetify's built-in transitions per the approach decided on 2026-08-04 (morphicons and Material Symbols were evaluated and rejected then).

New `AnimatedIcon.vue` keys a `v-icon` on its icon name inside a transition. Fill-state pairs of the same glyph cross-fade; genuine changes of shape scale.

## Sites animated (9)

| Site | Swap | Transition |
|---|---|---|
| `TransactionTableWidget` | filter outline↔filled | fade |
| `TransactionTableWidget` | invoice-text-edit↔calendar-edit | scale |
| `AccountForecastWidget` | flag outline↔filled | fade |
| `AccountHeaderWidget` | star outline↔filled | scale |
| `AccountHeaderWidget` | delete↔delete-restore | scale |
| `AccountHeaderWidget` | chevron up/down | rotate |
| `AppNavigationVue` ×2 | bell outline↔filled | fade |
| `TransactionSpeedDial` | dots-vertical↔close | scale |

The mobile chevron rotates one glyph rather than cross-fading two, since up and down are the same icon.

## Structural note

The earlier survey counted 18 dynamic `:icon` bindings, but that count included sites where the icon does not actually toggle. Every genuine toggle turned out to be a **`v-btn` `icon` prop**, not a `v-icon` element, so none could simply be wrapped — each call site moves the icon into the button's default slot and passes `icon` as a boolean.

Checked against `VBtn.js` before doing so: `v-btn--icon` is applied for a boolean `icon` prop (line 175), and the default-slot path wraps content in a `VDefaultsProvider` that injects no size (line 208). So the rendered button and icon are unchanged apart from the animation.

## Deliberately not animated

- **Ten `item.raw.is_system ? 'mdi-tag' : 'mdi-tag-outline'` bindings** in dropdown item templates (`TagTable`, `BudgetForm`, `ReminderForm`, `ReportsView`, `FileImportForm`, `CalculatorRuleForm`, `TagsHeaderWidget`, `BudgetFormMobile`, `MultipleTransactionAddForm`). The icon is fixed for a given item and never toggles, so the transition would never fire — `appear` is off, so it would not even animate on dropdown open. Wrapping them would be dead code.
- **The per-row selection badge** (`TransactionTableWidget`) takes an `icon` prop on `v-badge`, which has no slot to wrap.

## Details

- Transitions are imported directly rather than resolved from a name string, so a typo is a build error instead of a silently missing icon.
- Duration is shortened to 130ms. `mode="out-in"` runs both halves sequentially, and Vuetify's stock timing reads as lag on a button under the cursor.
- `createCssTransition` does **not** honour `prefers-reduced-motion` — only the javascript transitions do (`createTransition.js:97`) — so `AnimatedIcon` handles that itself, as does the chevron rotation.

## Testing

ESLint clean on all changed files, production build succeeds, and the dev server transforms all six components. Backend untouched.

**Not verified: how the animations actually look.** Timing and transition choice are judgement calls I could not see; they want a click-through, particularly the scale on the speed-dial activator and the 130ms duration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)