### PR TITLE
ci: add inert Forgejo stubs and digest-pin the floating Node base

### DIFF
--- a/.forgejo/workflows/README.md
+++ b/.forgejo/workflows/README.md
@@ -1,0 +1,21 @@
+# Forgejo workflow stubs
+
+These are the Forgejo half of the CI migration. **During Phase 2 they are inert
+on both forges** and exist so the shape can be reviewed before it is load-bearing:
+
+* **GitHub ignores this directory entirely** — it reads only `.github/workflows/`.
+* **The forge copy of this repo is a read-only pull mirror with the `actions`
+  unit disabled**, so nothing here can be triggered there either.
+
+All the real logic lives once in `lenore/lenore-ci`, pinned at `@v1` (a moving
+major tag, actions convention). These files stay ~6 lines each — that is the
+point.
+
+## 🔴 At the Phase 3 cutover, `.github/workflows/` must be DELETED in the same change
+
+Forgejo reads **both** `.github/workflows/` and `.forgejo/workflows/`. The moment
+Actions is enabled on the forge copy, leaving both in place means every workflow
+runs twice — and two `semantic-release` instances on one push is exactly the
+double-changelog / double-bump anomaly this migration exists to prevent.
+
+Enabling Actions and deleting `.github/workflows/` are one atomic step, not two.

--- a/.forgejo/workflows/announce.yml
+++ b/.forgejo/workflows/announce.yml
@@ -1,0 +1,24 @@
+name: Announce
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to announce (e.g. v1.6.1)"
+        required: true
+jobs:
+  patreon:
+    uses: lenore/lenore-ci/.forgejo/workflows/announce.yml@v1
+    with:
+      tag: ${{ github.event.release.tag_name || inputs.tag }}
+      target: patreon
+      dry_run: true
+    secrets: inherit
+  reddit:
+    uses: lenore/lenore-ci/.forgejo/workflows/announce.yml@v1
+    with:
+      tag: ${{ github.event.release.tag_name || inputs.tag }}
+      target: reddit
+      dry_run: true
+    secrets: inherit

--- a/.forgejo/workflows/build-publish.yml
+++ b/.forgejo/workflows/build-publish.yml
@@ -1,0 +1,21 @@
+name: Build & Publish
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to build and publish (e.g. v1.6.1)"
+        required: true
+jobs:
+  build-publish:
+    uses: lenore/lenore-ci/.forgejo/workflows/build-publish.yml@v1
+    with:
+      # The tag is the only source of truth. workflow_dispatch is what the old
+      # build_publish.yml lacked entirely — its sole trigger was
+      # release:[published], so re-running a failed build meant deleting and
+      # re-publishing the release.
+      tag: ${{ github.event.release.tag_name || inputs.tag }}
+      image_list: app          # LenoreFin is single-container
+      dry_run: true
+    secrets: inherit

--- a/.forgejo/workflows/docs-release.yml
+++ b/.forgejo/workflows/docs-release.yml
@@ -1,0 +1,17 @@
+name: Deploy MkDocs (Release)
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to deploy docs for (e.g. v1.6.1)"
+        required: true
+jobs:
+  docs:
+    uses: lenore/lenore-ci/.forgejo/workflows/docs.yml@v1
+    with:
+      mode: release
+      tag: ${{ github.event.release.tag_name || inputs.tag }}
+      dry_run: true
+    secrets: inherit

--- a/.forgejo/workflows/docs.yml
+++ b/.forgejo/workflows/docs.yml
@@ -1,0 +1,12 @@
+name: Deploy MkDocs (Preview)
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+jobs:
+  docs:
+    uses: lenore/lenore-ci/.forgejo/workflows/docs.yml@v1
+    with:
+      mode: preview
+      dry_run: true
+    secrets: inherit

--- a/.forgejo/workflows/pr-title-lint.yml
+++ b/.forgejo/workflows/pr-title-lint.yml
@@ -1,0 +1,8 @@
+name: Lint PR Title
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+jobs:
+  lint:
+    uses: lenore/lenore-ci/.forgejo/workflows/pr-title-lint.yml@v1
+    secrets: inherit

--- a/.forgejo/workflows/release.yml
+++ b/.forgejo/workflows/release.yml
@@ -1,0 +1,13 @@
+name: Semantic Release
+on:
+  workflow_dispatch:
+  push:
+    branches: [main, "release/v*", alpha, beta, rc]
+jobs:
+  release:
+    uses: lenore/lenore-ci/.forgejo/workflows/release.yml@v1
+    with:
+      # Phase 2 computes and compares; it never writes. Flipping this to false
+      # is the Phase 3 cutover, in the same change that deletes .github/workflows/.
+      dry_run: true
+    secrets: inherit

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,20 @@
 # STAGE 1 #
 # Vue build
 ###########
-FROM node:lts-alpine AS frontend-build
+# Digest-pinned on purpose. `node:lts-alpine` is fully floating — `lts` rolls to
+# a new major on its own schedule — so rebuilding an OLD release tag could pull
+# a different Node major and produce a materially different frontend bundle
+# under the same version tag. That defeats "re-run any step after an outage with
+# no gaps": the re-run would succeed and quietly ship different bytes.
+#
+# The Python bases below are already specific (python:3.11.4-slim-bookworm), so
+# this was the only floating base in the image.
+#
+# To bump: docker pull node:lts-alpine && docker image inspect node:lts-alpine \
+#            --format '{{index .RepoDigests 0}}'
+# and update the comment with the version you moved to.
+FROM node:lts-alpine@sha256:d32cdf619f63fe0471182d08996dd516c6275bb5fd31ae06e55a570bd9e1ad43 AS frontend-build
+# ^ node 24.19.0 (lts-alpine as of 2026-08-07)
 
 WORKDIR /app
 COPY frontend/package*.json ./


### PR DESCRIPTION
Phase 2 of the Forgejo migration. **Nothing here changes the GitHub pipeline** — GitHub stays the sole writer until Phase 3.

## `.forgejo/workflows/` — six stubs

All the real logic now lives once in `lenore/lenore-ci`, pinned at `@v1` (a moving major tag). Each stub is ~6 lines.

**Inert on both forges today:**
- GitHub reads only `.github/workflows/`.
- This repo's forge copy is a read-only pull mirror with the `actions` unit disabled.

They are here so the shape can be reviewed before it is load-bearing.

> 🔴 **At the Phase 3 cutover, enabling Actions on the forge copy and deleting `.github/workflows/` must be ONE change.** Forgejo reads *both* directories, so leaving both would run every workflow twice — and two `semantic-release` instances on one push is the double-changelog / double-bump anomaly this migration exists to prevent.

## `Dockerfile` — digest-pin `node:lts-alpine`

`lts` is fully floating and rolls to a new major on its own schedule, so rebuilding an old release tag could pull a different Node major and produce a materially different frontend bundle **under the same version tag**. The re-run would succeed and quietly ship different bytes — which defeats "re-run any step after an outage with no gaps".

Pinned to the digest `lts-alpine` resolves to today (**24.19.0**), so this is a **no-op for the next build**. The Python bases were already specific; this was the only floating one.

## Not in this PR (deliberately)

- The `.releaserc.json` plugin swap (`@semantic-release/github` → `@saithodev/semantic-release-gitea`). It would break GitHub releases immediately — that is a Phase 3 cutover change.
- Deleting `.github/workflows/`. Same reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)