### PR TITLE
fix: allow Build & Publish to be re-run manually

### DIFF
--- a/.github/workflows/build_publish.yml
+++ b/.github/workflows/build_publish.yml
@@ -3,13 +3,17 @@ name: Build & Publish
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to build and publish (e.g. v1.7.0-beta.1)"
+        required: true
 
 permissions:
   contents: read
 
 env:
-  VERSION: ${{ github.event.release.tag_name }}
-  IS_PRERELEASE: ${{ github.event.release.prerelease }}
+  VERSION: ${{ github.event.release.tag_name || inputs.tag }}
 
 jobs:
   docker:


### PR DESCRIPTION
## Why

`build_publish.yml` triggered **only** on `release: published`. During the 2026-08-06 GitHub Actions outage the release object for `v1.7.0-beta.1` was created but the event never routed, so none of the four downstream workflows ran. Three of them (`deploy-docs-release`, `announce_patreon`, `announce_reddit`) have a `workflow_dispatch` and could be recovered by hand — `build_publish` could not.

The only recovery was deleting and re-publishing the release, which re-fires the docs and announcement workflows too (duplicate Reddit/Patreon posts) and briefly destroys the release object.

**Result: `novanglus96/lenorefin:v1.7.0-beta.1` and the floating `:beta` tag do not exist.** This PR is what makes recovering them possible.

## What

- Add `workflow_dispatch` with a required `tag` input, matching the shape already used by `announce_patreon.yml`, `announce_reddit.yml` and `deploy-docs-release.yml`.
- `VERSION` falls back to `inputs.tag`; the existing `actions/checkout` step already pins `ref: ${{ env.VERSION }}`, so the dispatch path builds the tagged code.
- Remove the unused `IS_PRERELEASE` env var — the job computes `PRERELEASE` from the tag string at the "Extract major/minor versions" step, so nothing ever read it.

No behaviour change on the `release: published` path.

## Note

This gap exists in **all five** current-generation repos (`LenoreFin`, `LenoreChore`, `LenoreShop`, `LenoreSchedule`, `LenoreAD`). It is fixed here only because LenoreFin has an artifact to recover; the others are covered structurally by the `lenore-ci` reusable workflow rather than by five hand-applied patches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)